### PR TITLE
Restore support for 17134

### DIFF
--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -123,6 +123,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
       <Version>5.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.UI.Xaml.Core.Direct">
+      <Version>2.0.190315001-prerelease</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>

--- a/CharacterMap/CharacterMap/Core/TypographyBehavior.cs
+++ b/CharacterMap/CharacterMap/Core/TypographyBehavior.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Graphics.Canvas.Text;
+using Microsoft.UI.Xaml.Core.Direct;
 using Microsoft.Xaml.Interactivity;
 using System;
 using System.Collections.Generic;
@@ -7,14 +8,13 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Core.Direct;
 using Windows.UI.Xaml.Documents;
 
 namespace CharacterMap.Core
 {
     public partial class TypographyBehavior : Behavior<TextBlock>
     {
-        private XamlDirect _xamlDirect { get; set; }
+        private IXamlDirect _xamlDirect { get; set; }
 
         public TypographyFeatureInfo TypographyFeature
         {
@@ -62,7 +62,7 @@ namespace CharacterMap.Core
             TextBlock t = AssociatedObject;
 
             /* XAML Direct Helpers. Using XD is faster than setting Dependency Properties */
-            IXamlDirectObject o = _xamlDirect.GetXamlDirectObject(t);
+            object o = _xamlDirect.GetXamlDirectObject(t);
             void Set(XamlPropertyIndex index, bool value)
             {
                 _xamlDirect.SetBooleanProperty(o, index, value);

--- a/CharacterMap/CharacterMap/Core/Utils.cs
+++ b/CharacterMap/CharacterMap/Core/Utils.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Svg;
 using Microsoft.Graphics.Canvas.Text;
+using Microsoft.UI.Xaml.Core.Direct;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,7 +13,6 @@ using Windows.Storage.Pickers;
 using Windows.Storage.Provider;
 using Windows.UI.Core;
 using Windows.UI.Text;
-using Windows.UI.Xaml.Core.Direct;
 
 namespace CharacterMap.Core
 {
@@ -20,12 +20,12 @@ namespace CharacterMap.Core
     {
         public static CanvasDevice CanvasDevice { get; } = CanvasDevice.GetSharedDevice();
 
-        private static Dictionary<int, XamlDirect> _xamlDirectCache { get; } = new Dictionary<int, XamlDirect>();
+        private static Dictionary<int, IXamlDirect> _xamlDirectCache { get; } = new Dictionary<int, IXamlDirect>();
 
-        public static XamlDirect GetXamlDirectForWindow(CoreDispatcher dispatcher)
+        public static IXamlDirect GetXamlDirectForWindow(CoreDispatcher dispatcher)
         {
             int hash = dispatcher.GetHashCode();
-            if (_xamlDirectCache.TryGetValue(hash, out XamlDirect d))
+            if (_xamlDirectCache.TryGetValue(hash, out IXamlDirect d))
                 return d;
 
             d = XamlDirect.GetDefault();

--- a/CharacterMap/CharacterMap/Styles/Button.xaml
+++ b/CharacterMap/CharacterMap/Styles/Button.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
@@ -26,8 +26,7 @@
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ButtonRevealBorderBrush}" />
         <Setter Property="BorderThickness" Value="0 0 0 0" />
-        <!-- This is throwing exception for a few user -->
-        <!--<Setter Property="Padding" Value="{StaticResource ButtonPadding}" />-->
+        <Setter Property="Padding" Value="8,4,8,5" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
@@ -41,8 +40,7 @@
                 <ControlTemplate TargetType="Button">
                     <Grid
                         x:Name="RootGrid"
-                        Background="{TemplateBinding Background}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
+                        Background="{TemplateBinding Background}">
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
@@ -99,8 +97,7 @@
                                 AutomationProperties.AccessibilityView="Raw"
                                 Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
-                                ContentTransitions="{TemplateBinding ContentTransitions}"
-                                CornerRadius="{TemplateBinding CornerRadius}" />
+                                ContentTransitions="{TemplateBinding ContentTransitions}" />
 
                         </Border>
 
@@ -130,8 +127,7 @@
                         x:Name="Root"
                         MinWidth="{TemplateBinding MinWidth}"
                         MaxWidth="{TemplateBinding MaxWidth}"
-                        Background="{TemplateBinding Background}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
+                        Background="{TemplateBinding Background}">
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
@@ -221,8 +217,7 @@
                                 Grid.RowSpan="2"
                                 Grid.ColumnSpan="2"
                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding CornerRadius}" />
+                                BorderThickness="{TemplateBinding BorderThickness}" />
 
                         </Grid>
                     </Grid>

--- a/CharacterMap/CharacterMap/Styles/ComboBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/ComboBox.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:CharacterMap.Styles">

--- a/CharacterMap/CharacterMap/Styles/CommandBar.xaml
+++ b/CharacterMap/CharacterMap/Styles/CommandBar.xaml
@@ -645,7 +645,7 @@
                                                 <SplineDoubleKeyFrame
                                                     KeySpline="0.2,0 0,1"
                                                     KeyTime="0:0:0.167"
-                                                    Value="0}" />
+                                                    Value="0" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OverflowContentTransform" Storyboard.TargetProperty="Y">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0" />

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -493,7 +493,7 @@
                                     Command="{Binding CommandSavePng}"
                                     CommandParameter="{x:Bind ViewModel.BlackColor}"
                                     Style="{ThemeResource TransparentButton}"
-                                    Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay}">
+                                    Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}">
                                     <AppBarButton.Content>
                                         <TextBlock x:Uid="BlackFill" Margin="12,10" />
                                     </AppBarButton.Content>
@@ -504,7 +504,7 @@
                                     Command="{Binding CommandSavePng}"
                                     CommandParameter="{x:Bind ViewModel.WhiteColor}"
                                     Style="{ThemeResource TransparentButton}"
-                                    Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay}">
+                                    Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}">
                                     <AppBarButton.Content>
                                         <TextBlock x:Uid="WhiteFill" Margin="12,10" />
                                     </AppBarButton.Content>


### PR DESCRIPTION
Tested by building with both Min & Max version set to 17134

Includes XAML changes:
- Removing corner radius on content presenters
- Removing new buttonpadding resource

Includes Compiled binding change:
- Requires Fallback value for binding not to crash application. 

Also now uses XAML Direct from Microsoft.UI.XAML as native XD libs don't exist on 17134.

I still don't understand why compiled bindings is SDK version dependent... the generated code has no SDK dependency. Oh well.

Apologies for not catching these sooner!