### PR TITLE
Add search option flyout and settings

### DIFF
--- a/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
+++ b/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
@@ -1,19 +1,10 @@
-﻿using CharacterMap.Helpers;
-using GalaSoft.MvvmLight;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
+﻿using GalaSoft.MvvmLight;
 using Windows.ApplicationModel.Core;
 using Windows.UI;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Documents;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
 
 namespace CharacterMap.Controls
 {
@@ -43,25 +34,25 @@ namespace CharacterMap.Controls
 
     public sealed class XamlTitleBar : ContentControl
     {
-        private UISettings _settings = null;
-        private CoreApplicationViewTitleBar _titleBar = null;
-        private CoreWindow _window = null;
-        private FrameworkElement _backgroundElement = null;
+        private UISettings _settings;
+        private CoreApplicationViewTitleBar _titleBar;
+        private CoreWindow _window;
+        private FrameworkElement _backgroundElement;
 
         public XamlTitleBarTemplateSettings TemplateSettings { get; } = new XamlTitleBarTemplateSettings();
 
         public XamlTitleBar()
         {
-            this.DefaultStyleKey = typeof(XamlTitleBar);
-            this.Loaded += XamlTitleBar_Loaded;
-            this.Unloaded += XamlTitleBar_Unloaded;
+            DefaultStyleKey = typeof(XamlTitleBar);
+            Loaded += XamlTitleBar_Loaded;
+            Unloaded += XamlTitleBar_Unloaded;
         }
 
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
 
-            if (this.GetTemplateChild("BackgroundElement") is FrameworkElement e)
+            if (GetTemplateChild("BackgroundElement") is FrameworkElement e)
             {
                 _backgroundElement = e;
                 UpdateDragElement();
@@ -139,14 +130,7 @@ namespace CharacterMap.Controls
         {
             bool active = _window.ActivationMode == CoreWindowActivationMode.ActivatedInForeground;
 
-            if (active)
-            {
-                TemplateSettings.BackgroundColor = _settings.GetColorValue(UIColorType.Accent);
-            }
-            else
-            {
-                TemplateSettings.BackgroundColor = _settings.GetColorValue(UIColorType.AccentDark1);
-            }
+            TemplateSettings.BackgroundColor = _settings.GetColorValue(active ? UIColorType.Accent : UIColorType.AccentDark1);
 
             var accentColor = _settings.GetColorValue(UIColorType.Accent);
             var darkAccent = _settings.GetColorValue(UIColorType.AccentDark1);
@@ -164,19 +148,19 @@ namespace CharacterMap.Controls
                 accentColor, Colors.White,
                 Colors.Transparent, Colors.Gray);
 
-            this.RequestedTheme = !IsAccentColorDark() ? ElementTheme.Light : ElementTheme.Dark;
+            RequestedTheme = !IsAccentColorDark() ? ElementTheme.Light : ElementTheme.Dark;
         }
 
         private void UpdateMetrics(CoreApplicationViewTitleBar bar)
         {
             bool ltr = FlowDirection == FlowDirection.LeftToRight;
 
-            this.Height = bar.Height;
+            Height = bar.Height;
 
-            this.TemplateSettings.LeftColumnWidth 
+            TemplateSettings.LeftColumnWidth 
                 = new GridLength(ltr ? bar.SystemOverlayLeftInset : bar.SystemOverlayRightInset);
 
-            this.TemplateSettings.RightColumnWidth 
+            TemplateSettings.RightColumnWidth 
                 = new GridLength(ltr ? bar.SystemOverlayRightInset : bar.SystemOverlayLeftInset);
         }
 

--- a/CharacterMap/CharacterMap/Core/AppSettings.cs
+++ b/CharacterMap/CharacterMap/Core/AppSettings.cs
@@ -78,6 +78,36 @@ namespace CharacterMap.Core
             }
         }
 
+        public bool UseInstantSearch
+        {
+            get => ReadSettings(nameof(UseInstantSearch), true);
+            set
+            {
+                SaveSettings(nameof(UseInstantSearch), value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        public int InstantSearchDelay
+        {
+            get => ReadSettings(nameof(InstantSearchDelay), 500);
+            set
+            {
+                SaveSettings(nameof(InstantSearchDelay), value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        public int MaxSearchResult
+        {
+            get => ReadSettings(nameof(MaxSearchResult), 10);
+            set
+            {
+                SaveSettings(nameof(MaxSearchResult), value);
+                NotifyPropertyChanged();
+            }
+        }
+
         public ApplicationDataContainer LocalSettings { get; set; }
 
         public AppSettings()

--- a/CharacterMap/CharacterMap/Core/Converters.cs
+++ b/CharacterMap/CharacterMap/Core/Converters.cs
@@ -20,5 +20,21 @@ namespace CharacterMap.Core
         public static bool IsNotNull(object obj) => obj != null;
 
         public static char ToHex(int i) => (char)i;
+
+        public static GridLength GridLengthAorB(bool input, string a, string b) 
+            => input ? ReadFromString(a) : ReadFromString(b);
+
+        private static GridLength ReadFromString(string s)
+        {
+            if (s == Auto)
+                return new GridLength(1, GridUnitType.Auto);
+            else if (s == Star)
+                return new GridLength(1, GridUnitType.Star);
+            else
+                return new GridLength(double.Parse(s), GridUnitType.Pixel);
+        }
+
+        public const string Auto = "Auto";
+        public const string Star = "*";
     }
 }

--- a/CharacterMap/CharacterMap/Core/Utils.cs
+++ b/CharacterMap/CharacterMap/Core/Utils.cs
@@ -208,5 +208,21 @@ namespace CharacterMap.Core
             sb.Append(document.GetXml());
             return FileIO.WriteTextAsync(file, sb.ToString()).AsTask();
         }
+
+        private static bool? isOn1809OrNewer = null;
+        /// <summary>
+        /// Use to check if App is on Windows 10 October or not.
+        /// To prevent app on older system running into unsupport code (Eg. FlyoutOptions)
+        /// </summary>
+        public static bool IsSystemOnWin10v1809OrNewer
+        {
+            get
+            {
+                if (isOn1809OrNewer is null)
+                    isOn1809OrNewer = Windows.Foundation.Metadata.
+                        ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7);
+                return isOn1809OrNewer.Value;
+            }
+        }
     }
 }

--- a/CharacterMap/CharacterMap/Provider/SQLiteGlyphProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/SQLiteGlyphProvider.cs
@@ -20,7 +20,7 @@ namespace CharacterMap.Provider
         internal const string MDL2_SEARCH_TABLE = "mdl2search";
         internal const string FONTAWESOME_SEARCH_TABLE = "fontawesomesearch";
         internal const string UNICODE_SEARCH_TABLE = "unicodesearch";
-        const int SEARCH_LIMIT = 10;
+        private int SEARCH_LIMIT = new AppSettings().MaxSearchResult;
 
         private SQLiteConnection _connection { get; set; }
 

--- a/CharacterMap/CharacterMap/Services/ActivationService.cs
+++ b/CharacterMap/CharacterMap/Services/ActivationService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Activation;
-using Windows.UI;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
@@ -14,7 +13,6 @@ using CharacterMap.Helpers;
 using CommonServiceLocator;
 using Edi.UWP.Helpers;
 using GalaSoft.MvvmLight.Threading;
-using Windows.ApplicationModel.Core;
 using CharacterMap.Views;
 
 namespace CharacterMap.Services

--- a/CharacterMap/CharacterMap/Services/GlyphService.cs
+++ b/CharacterMap/CharacterMap/Services/GlyphService.cs
@@ -3,17 +3,8 @@
 using CharacterMap.Core;
 using CharacterMap.Provider;
 using SQLite;
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Windows.ApplicationModel;
-using Windows.Data.Xml.Dom;
-using Windows.Storage;
-using Windows.System;
-using Windows.UI.Xaml.Controls;
 
 namespace CharacterMap.Services
 {
@@ -47,7 +38,7 @@ namespace CharacterMap.Services
         Task<IReadOnlyList<IGlyphData>> SearchAsync(string query, FontVariant variant);
     }
 
-    public static partial class GlyphService
+    public static class GlyphService
     {
         private static IGlyphDataProvider _provider { get; set; }
 
@@ -63,10 +54,7 @@ namespace CharacterMap.Services
 
         public static Task InitializeAsync()
         {
-            if (_init == null)
-                _init = InitializeInternalAsync();
-
-            return _init;
+            return _init ?? (_init = InitializeInternalAsync());
         }
 
         private static Task InitializeInternalAsync()

--- a/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
@@ -24,6 +24,8 @@ namespace CharacterMap.ViewModels
 {
     public class FontMapViewModel : ViewModelBase
     {
+        private AppSettings Settings { get; }
+
         private Interop Interop { get; }
 
         private StorageFile _sourceFile { get; set; }
@@ -221,8 +223,8 @@ namespace CharacterMap.ViewModels
             set
             {
                 if (Set(ref _searchQuery, value))
-                    DebounceSearch(value); }
-
+                    DebounceSearch(value, Settings.InstantSearchDelay, SearchSource.AutoProperty);
+            }
         }
 
         public FontMapViewModel(IDialogService dialogService)
@@ -274,7 +276,7 @@ namespace CharacterMap.ViewModels
                 SearchResults = null;
                 DebounceSearch(SearchQuery, 100);
             }
-            catch (Exception ex)
+            catch
             {
                 /* 
                  * Hack to avoid crash.
@@ -384,8 +386,10 @@ namespace CharacterMap.ViewModels
             return c.UnicodeString;
         }
 
-        public void DebounceSearch(string query, int delayMilliseconds = 500)
+        public void DebounceSearch(string query, int delayMilliseconds = 500, SearchSource from = SearchSource.AutoProperty)
         {
+            if (from == SearchSource.AutoProperty && !Settings.UseInstantSearch)
+                return;
             _searchDebouncer.Debounce(delayMilliseconds, () => Search(query));
         }
 
@@ -474,5 +478,11 @@ namespace CharacterMap.ViewModels
                 IsLoading = false;
             }
         }
+    }
+
+    public enum SearchSource
+    {
+        AutoProperty,
+        ManualSubmit
     }
 }

--- a/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
@@ -24,7 +24,7 @@ namespace CharacterMap.ViewModels
 {
     public class FontMapViewModel : ViewModelBase
     {
-        private AppSettings Settings { get; }
+        private AppSettings Settings { get; } = new AppSettings();
 
         private Interop Interop { get; }
 

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -18,14 +18,13 @@ using CharacterMap.Services;
 
 namespace CharacterMap.ViewModels
 {
-
     public class MainViewModel : ViewModelBase
     {
         #region Properties
 
         public event EventHandler FontListCreated;
 
-        private Task _initialLoad { get; }
+        private Task InitialLoad { get; }
 
         public IDialogService DialogService { get; }
 
@@ -118,7 +117,7 @@ namespace CharacterMap.ViewModels
             CommandToggleFullScreen = new RelayCommand(ToggleFullScreenMode);
             MessengerInstance.Register<ImportMessage>(this, OnFontImportRequest);
 
-            _initialLoad = LoadAsync();
+            InitialLoad = LoadAsync();
         }
 
         private async Task LoadAsync()
@@ -179,15 +178,7 @@ namespace CharacterMap.ViewModels
                 if (!string.IsNullOrEmpty(App.AppSettings.LastSelectedFontName))
                 {
                     var lastSelectedFont = FontList.FirstOrDefault((i => i.Name == App.AppSettings.LastSelectedFontName));
-
-                    if (null != lastSelectedFont)
-                    {
-                        this.SelectedFont = lastSelectedFont;
-                    }
-                    else
-                    {
-                        SelectedFont = FontList.FirstOrDefault();
-                    }
+                    SelectedFont = lastSelectedFont ?? FontList.FirstOrDefault();
                 }
                 else
                 {
@@ -251,13 +242,13 @@ namespace CharacterMap.ViewModels
                 IsLoadingFonts = true;
                 try
                 {
-                    if (_initialLoad.IsCompleted)
+                    if (InitialLoad.IsCompleted)
                     {
                         RefreshFontList();
                     }
                     else
                     {
-                        await _initialLoad;
+                        await InitialLoad;
                         await Task.Delay(50);
                     }
 

--- a/CharacterMap/CharacterMap/ViewModels/ViewModelLocator.cs
+++ b/CharacterMap/CharacterMap/ViewModels/ViewModelLocator.cs
@@ -5,13 +5,12 @@ using CharacterMapCX;
 using CommonServiceLocator;
 using GalaSoft.MvvmLight.Ioc;
 using GalaSoft.MvvmLight.Views;
-using Microsoft.Graphics.Canvas;
 
 namespace CharacterMap.ViewModels
 {
     public class ViewModelLocator
     {
-        NavigationServiceEx _navigationService = new NavigationServiceEx();
+        private readonly NavigationServiceEx _navigationService = new NavigationServiceEx();
 
         public ViewModelLocator()
         {
@@ -33,7 +32,6 @@ namespace CharacterMap.ViewModels
         public void Register<VM, V>() where VM : class
         {
             SimpleIoc.Default.Register<VM>();
-
             _navigationService.Configure(typeof(VM).FullName, typeof(V));
         }
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -10,8 +10,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:services="using:CharacterMap.Services"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:w10v1803="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 6)"
-    xmlns:w10v1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -71,7 +69,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
-                <w10v1803:ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="{x:Bind core:Converters.GridLengthAorB(core:Utils.IsSystemOnWin10v1809OrNewer, '0', 'Auto')}" />
             </Grid.ColumnDefinitions>
             <TextBlock
                 x:Name="FontTitleBlock"
@@ -128,8 +126,8 @@
                     <SymbolIcon Symbol="Find" Visibility="{x:Bind core:Converters.FalseToVis(Settings.UseInstantSearch), Mode=OneWay}"/>
                 </AutoSuggestBox.QueryIcon>
                 <AutoSuggestBox.ContextFlyout>
-                    <Flyout x:Name="SearchOptionFlyout" Placement="BottomEdgeAlignedLeft" w10v1809:ShowMode="Transient" >
-                        <StackPanel>
+                    <Flyout>
+                        <StackPanel Width="260">
                             <ToggleSwitch IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" 
                                           Margin="0 4"
                                           OnContent="Enabled instant search"
@@ -174,18 +172,18 @@
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
 
-            <w10v1803:Button
+            <AppBarButton
+                x:Name="SearchOptionButton"
+                x:Load="{x:Bind core:Converters.False(core:Utils.IsSystemOnWin10v1809OrNewer)}"
+                Visibility="{x:Bind core:Converters.FalseToVis(core:Utils.IsSystemOnWin10v1809OrNewer)}"
                 Grid.Column="3"
-                Height="45"
-                Padding="12 0"
-                HorizontalAlignment="Right"
-                RequestedTheme="Dark"
-                Style="{ThemeResource TransparentButton}">
+                Width="45"
+                Height="45">
                 <Grid>
                     <FontIcon Glyph="&#xE11A;" />
                     <FontIcon Glyph="&#xE115;" HorizontalAlignment="Right" VerticalAlignment="Top" FontSize="7" Margin="0 3 3 0" />
                 </Grid>
-                <AutoSuggestBox.ContextFlyout>
+                <AppBarButton.ContextFlyout>
                     <Flyout Placement="Bottom">
                         <StackPanel>
                             <ToggleSwitch IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" 
@@ -208,8 +206,8 @@
                                     Value="{x:Bind Settings.MaxSearchResult, Mode=TwoWay}"/>
                         </StackPanel>
                     </Flyout>
-                </AutoSuggestBox.ContextFlyout>
-            </w10v1803:Button>
+                </AppBarButton.ContextFlyout>
+            </AppBarButton>
         </Grid>
 
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -116,10 +116,38 @@
                 ItemsSource="{x:Bind ViewModel.SearchResults, Mode=OneWay}"
                 PlaceholderText="#SearchBox"
                 PreviewKeyDown="SearchBox_PreviewKeyDown"
+                QuerySubmitted="SearchBox_QuerySubmitted"
                 SuggestionChosen="SearchBox_SuggestionChosen"
                 Text="{Binding SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 TextMemberPath="Description"
                 UpdateTextOnSelect="False">
+                <AutoSuggestBox.QueryIcon>
+                    <SymbolIcon Symbol="Find" Visibility="{x:Bind core:Converters.FalseToVis(Settings.UseInstantSearch), Mode=OneWay}"/>
+                </AutoSuggestBox.QueryIcon>
+                <AutoSuggestBox.ContextFlyout>
+                    <Flyout x:Name="SearchOptionFlyout">
+                        <StackPanel>
+                            <ToggleSwitch IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" 
+                                          Margin="0 4"
+                                          OnContent="Enabled instant search"
+                                          OffContent="Disabled instant search">
+                            </ToggleSwitch>
+                            <Slider Header="Delay before search (ms)" 
+                                    Minimum="250" 
+                                    Margin="0 4"
+                                    Maximum="3000"
+                                    TickFrequency="50"
+                                    Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}"
+                                    Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"/>
+                            <Slider Header="Maximum preview search result" 
+                                    Minimum="5" 
+                                    Margin="0 4"
+                                    Maximum="100" 
+                                    TickFrequency="1"
+                                    Value="{x:Bind Settings.MaxSearchResult, Mode=TwoWay}"/>                            
+                        </StackPanel>
+                    </Flyout>
+                </AutoSuggestBox.ContextFlyout>
                 <AutoSuggestBox.ItemTemplate>
                     <DataTemplate x:DataType="services:IGlyphData">
                         <Grid>

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -10,6 +10,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:services="using:CharacterMap.Services"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:w10v1803="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 6)"
+    xmlns:w10v1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -69,6 +71,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
+                <win10v1803:ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <TextBlock
                 x:Name="FontTitleBlock"
@@ -125,7 +128,7 @@
                     <SymbolIcon Symbol="Find" Visibility="{x:Bind core:Converters.FalseToVis(Settings.UseInstantSearch), Mode=OneWay}"/>
                 </AutoSuggestBox.QueryIcon>
                 <AutoSuggestBox.ContextFlyout>
-                    <Flyout x:Name="SearchOptionFlyout">
+                    <Flyout x:Name="SearchOptionFlyout" Placement="BottomEdgeAlignedLeft" w10v1809:ShowMode="Transient" >
                         <StackPanel>
                             <ToggleSwitch IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" 
                                           Margin="0 4"
@@ -170,6 +173,43 @@
                     </DataTemplate>
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
+
+            <win10v1803:Button
+                Grid.Column="3"
+                Height="45"
+                Padding="12 0"
+                HorizontalAlignment="Right"
+                RequestedTheme="Dark"
+                Style="{ThemeResource TransparentButton}">
+                <Grid>
+                    <FontIcon Glyph="&#xE11A;" />
+                    <FontIcon Glyph="&#xE115;" HorizontalAlignment="Right" VerticalAlignment="Top" FontSize="7" Margin="0 3 3 0" />
+                </Grid>
+                <AutoSuggestBox.ContextFlyout>
+                    <Flyout Placement="Bottom">
+                        <StackPanel>
+                            <ToggleSwitch IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" 
+                                          Margin="0 4"
+                                          OnContent="Enabled instant search"
+                                          OffContent="Disabled instant search">
+                            </ToggleSwitch>
+                            <Slider Header="Delay before search (ms)" 
+                                    Minimum="250" 
+                                    Margin="0 4"
+                                    Maximum="3000"
+                                    TickFrequency="50"
+                                    Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}"
+                                    Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"/>
+                            <Slider Header="Maximum preview search result" 
+                                    Minimum="5" 
+                                    Margin="0 4"
+                                    Maximum="100" 
+                                    TickFrequency="1"
+                                    Value="{x:Bind Settings.MaxSearchResult, Mode=TwoWay}"/>
+                        </StackPanel>
+                    </Flyout>
+                </AutoSuggestBox.ContextFlyout>
+            </win10v1803:Button>
         </Grid>
 
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -71,7 +71,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
-                <win10v1803:ColumnDefinition Width="Auto" />
+                <w10v1803:ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <TextBlock
                 x:Name="FontTitleBlock"
@@ -174,7 +174,7 @@
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
 
-            <win10v1803:Button
+            <w10v1803:Button
                 Grid.Column="3"
                 Height="45"
                 Padding="12 0"
@@ -209,7 +209,7 @@
                         </StackPanel>
                     </Flyout>
                 </AutoSuggestBox.ContextFlyout>
-            </win10v1803:Button>
+            </w10v1803:Button>
         </Grid>
 
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -1,29 +1,17 @@
 ﻿using CharacterMap.Core;
-using CharacterMap.Helpers;
 using CharacterMap.Services;
 using CharacterMap.ViewModels;
 using CommonServiceLocator;
 using GalaSoft.MvvmLight.Views;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
-using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.System;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 
 namespace CharacterMap.Views
 {
@@ -35,8 +23,8 @@ namespace CharacterMap.Views
 
         public InstalledFont Font
         {
-            get { return (InstalledFont)GetValue(FontProperty); }
-            set { SetValue(FontProperty, value); }
+            get => (InstalledFont)GetValue(FontProperty);
+            set => SetValue(FontProperty, value);
         }
 
         public static readonly DependencyProperty FontProperty =
@@ -52,8 +40,8 @@ namespace CharacterMap.Views
 
         public bool IsStandalone
         {
-            get { return (bool)GetValue(IsStandaloneProperty); }
-            set { SetValue(IsStandaloneProperty, value); }
+            get => (bool)GetValue(IsStandaloneProperty);
+            set => SetValue(IsStandaloneProperty, value);
         }
 
         public static readonly DependencyProperty IsStandaloneProperty =
@@ -65,8 +53,8 @@ namespace CharacterMap.Views
 
         public FontMapViewModel ViewModel
         {
-            get { return (FontMapViewModel)GetValue(ViewModelProperty); }
-            private set { SetValue(ViewModelProperty, value); }
+            get => (FontMapViewModel)GetValue(ViewModelProperty);
+            private set => SetValue(ViewModelProperty, value);
         }
 
         public static readonly DependencyProperty ViewModelProperty =
@@ -115,12 +103,9 @@ namespace CharacterMap.Views
         private void UpdateStates()
         {
             // Ideally should have been achieved with VisualState setters, buuuuut didn't work for some reason
-            if (ViewModel.SelectedFont == null)
-                VisualStateManager.GoToState(this, NoFontState.Name, true);
-            else
-                VisualStateManager.GoToState(this, HasFontState.Name, true);
+            VisualStateManager.GoToState(this, ViewModel.SelectedFont == null ? NoFontState.Name : HasFontState.Name,
+                true);
         }
-
 
         /* Public surface-area methods */
 
@@ -224,7 +209,6 @@ namespace CharacterMap.Views
             }
             else
             {
-                if (Core.Utils.IsSystemOnWin10v1809OrNewer)
                 if (Utils.IsSystemOnWin10v1809OrNewer)
                 {
                     if (!searchBox.ContextFlyout.IsOpen && string.IsNullOrWhiteSpace(ViewModel.SearchQuery))
@@ -285,13 +269,7 @@ namespace CharacterMap.Views
         {
             void CreateView()
             {
-                FontMapView map = new FontMapView
-                {
-                    IsStandalone = true,
-                };
-
-                map.ViewModel.SelectedFont = font;
-
+                FontMapView map = new FontMapView { IsStandalone = true, ViewModel = { SelectedFont = font } };
                 Window.Current.Content = map;
                 Window.Current.Activate();
             }

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -221,11 +221,8 @@ namespace CharacterMap.Views
                 searchBox.IsSuggestionListOpen = true;
             else
             {
-                searchBox.ContextFlyout.ShowAt(searchBox, new FlyoutShowOptions()
-                {
-                    Placement = FlyoutPlacementMode.BottomEdgeAlignedLeft,
-                    ShowMode = FlyoutShowMode.Transient
-                });
+                if (!SearchOptionFlyout.IsOpen && ViewModel.SearchQuery == null)
+                    searchBox.ContextFlyout.ShowAt(searchBox);
                 ViewModel.DebounceSearch(ViewModel.SearchQuery, Settings.InstantSearchDelay);
             }
         }

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -220,7 +220,14 @@ namespace CharacterMap.Views
             if (ViewModel.SearchResults != null && ViewModel.SearchResults.Count > 0)
                 searchBox.IsSuggestionListOpen = true;
             else
-                ViewModel.DebounceSearch(ViewModel.SearchQuery);
+            {
+                searchBox.ContextFlyout.ShowAt(searchBox, new FlyoutShowOptions()
+                {
+                    Placement = FlyoutPlacementMode.BottomEdgeAlignedLeft,
+                    ShowMode = FlyoutShowMode.Transient
+                });
+                ViewModel.DebounceSearch(ViewModel.SearchQuery, Settings.InstantSearchDelay);
+            }
         }
 
         internal void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
@@ -241,8 +248,13 @@ namespace CharacterMap.Views
             if (e.Key == VirtualKey.Enter)
                 e.Handled = true;
         }
-    }
 
+        private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            SearchBox.IsSuggestionListOpen = true;
+            ViewModel.DebounceSearch(ViewModel.SearchQuery, Settings.InstantSearchDelay, SearchSource.ManualSubmit);
+        }
+    }
 
     public partial class FontMapView
     {

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -221,10 +221,23 @@ namespace CharacterMap.Views
                 searchBox.IsSuggestionListOpen = true;
             else
             {
-                if (!SearchOptionFlyout.IsOpen && ViewModel.SearchQuery == null)
-                    searchBox.ContextFlyout.ShowAt(searchBox);
+                if (Core.Utils.IsSystemOnWin10v1809OrNewer)
+                {
+                    if (!searchBox.ContextFlyout.IsOpen && ViewModel.SearchQuery == null)
+                        searchBox.ContextFlyout.ShowAt(searchBox, new FlyoutShowOptions()
+                        {
+                            Placement = FlyoutPlacementMode.BottomEdgeAlignedLeft,
+                            ShowMode = FlyoutShowMode.Transient
+                        });
+                }
                 ViewModel.DebounceSearch(ViewModel.SearchQuery, Settings.InstantSearchDelay);
             }
+        }
+
+        internal void OnSearchBoxSubmittedQuery(AutoSuggestBox searchBox)
+        {
+            searchBox.IsSuggestionListOpen = true;
+            ViewModel.DebounceSearch(ViewModel.SearchQuery, Settings.InstantSearchDelay, SearchSource.ManualSubmit);
         }
 
         internal void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
@@ -248,8 +261,7 @@ namespace CharacterMap.Views
 
         private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
-            SearchBox.IsSuggestionListOpen = true;
-            ViewModel.DebounceSearch(ViewModel.SearchQuery, Settings.InstantSearchDelay, SearchSource.ManualSubmit);
+            OnSearchBoxSubmittedQuery(SearchBox);
         }
     }
 

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -110,6 +110,7 @@
                 <ColumnDefinition Width="256" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="{x:Bind core:Converters.GridLengthAorB(core:Utils.IsSystemOnWin10v1809OrNewer, '0', 'Auto')}" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
@@ -188,9 +189,37 @@
                 ItemsSource="{x:Bind FontMap.ViewModel.SearchResults, Mode=OneWay}"
                 PlaceholderText="#SearchBox"
                 SuggestionChosen="SearchBox_SuggestionChosen"
+                QuerySubmitted="SearchBox_QuerySubmitted"
                 Text="{Binding ElementName=FontMap, Path=ViewModel.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 TextMemberPath="Description"
                 UpdateTextOnSelect="False">
+                <AutoSuggestBox.QueryIcon>
+                    <SymbolIcon Symbol="Find" Visibility="{x:Bind core:Converters.FalseToVis(Settings.UseInstantSearch), Mode=OneWay}"/>
+                </AutoSuggestBox.QueryIcon>
+                <AutoSuggestBox.ContextFlyout>
+                    <Flyout>
+                        <StackPanel Width="260">
+                            <ToggleSwitch IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" 
+                                          Margin="0 4"
+                                          OnContent="Enabled instant search"
+                                          OffContent="Disabled instant search">
+                            </ToggleSwitch>
+                            <Slider Header="Delay before search (ms)" 
+                                    Minimum="250" 
+                                    Margin="0 4"
+                                    Maximum="3000"
+                                    TickFrequency="50"
+                                    Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}"
+                                    Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"/>
+                            <Slider Header="Maximum preview search result" 
+                                    Minimum="5" 
+                                    Margin="0 4"
+                                    Maximum="100" 
+                                    TickFrequency="1"
+                                    Value="{x:Bind Settings.MaxSearchResult, Mode=TwoWay}"/>
+                        </StackPanel>
+                    </Flyout>
+                </AutoSuggestBox.ContextFlyout>
                 <AutoSuggestBox.ItemTemplate>
                     <DataTemplate x:DataType="services:IGlyphData">
                         <Grid>
@@ -213,13 +242,47 @@
                     </DataTemplate>
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
-            <!--<TextBox
-
-                Style="{StaticResource SearchTextBox}"
-                />-->
+            
+            <AppBarButton
+                x:Name="SearchOptionButton"
+                x:Load="{x:Bind core:Converters.False(core:Utils.IsSystemOnWin10v1809OrNewer)}"
+                Visibility="{x:Bind core:Converters.FalseToVis(core:Utils.IsSystemOnWin10v1809OrNewer)}"
+                Grid.Column="3"
+                Width="45"
+                Height="45">
+                <Grid>
+                    <FontIcon Glyph="&#xE11A;" />
+                    <FontIcon Glyph="&#xE115;" HorizontalAlignment="Right" VerticalAlignment="Top" FontSize="7" Margin="0 3 3 0" />
+                </Grid>
+                <AppBarButton.ContextFlyout>
+                    <Flyout Placement="Bottom">
+                        <StackPanel>
+                            <ToggleSwitch IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" 
+                                          Margin="0 4"
+                                          OnContent="Enabled instant search"
+                                          OffContent="Disabled instant search">
+                            </ToggleSwitch>
+                            <Slider Header="Delay before search (ms)" 
+                                    Minimum="250" 
+                                    Margin="0 4"
+                                    Maximum="3000"
+                                    TickFrequency="50"
+                                    Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}"
+                                    Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"/>
+                            <Slider Header="Maximum preview search result" 
+                                    Minimum="5" 
+                                    Margin="0 4"
+                                    Maximum="100" 
+                                    TickFrequency="1"
+                                    Value="{x:Bind Settings.MaxSearchResult, Mode=TwoWay}"/>
+                        </StackPanel>
+                    </Flyout>
+                </AppBarButton.ContextFlyout>
+            </AppBarButton>
+            
             <AppBarButton
                 x:Name="BtnSettings"
-                Grid.Column="3"
+                Grid.Column="4"
                 Width="45"
                 Height="45"
                 Click="BtnSettings_OnClick">

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -7,7 +7,6 @@ using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 using Windows.UI.Core;
-using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
@@ -15,13 +14,7 @@ using Windows.UI.Xaml.Navigation;
 using CharacterMap.Annotations;
 using CharacterMap.Core;
 using CharacterMap.ViewModels;
-using System.Diagnostics;
 using CharacterMap.Helpers;
-using Windows.UI.Xaml.Media;
-using GalaSoft.MvvmLight.Messaging;
-using Windows.Storage;
-using System.Collections.Generic;
-using CharacterMap.Services;
 using Windows.Storage.Pickers;
 
 namespace CharacterMap.Views
@@ -36,20 +29,20 @@ namespace CharacterMap.Views
 
         public MainPage()
         {
-            this.InitializeComponent();
+            InitializeComponent();
             Settings = (AppSettings)App.Current.Resources[nameof(AppSettings)];
 
-            this.ViewModel = this.DataContext as MainViewModel;
-            this.NavigationCacheMode = NavigationCacheMode.Enabled;
+            ViewModel = DataContext as MainViewModel;
+            NavigationCacheMode = NavigationCacheMode.Enabled;
 
-            this.Loaded += MainPage_Loaded;
-            this.Unloaded += MainPage_Unloaded;
+            Loaded += MainPage_Loaded;
+            Unloaded += MainPage_Unloaded;
         }
 
         private void MainPage_Loaded(object sender, RoutedEventArgs e)
         {
-            this.ViewModel.FontListCreated -= ViewModel_FontListCreated;
-            this.ViewModel.FontListCreated += ViewModel_FontListCreated;
+            ViewModel.FontListCreated -= ViewModel_FontListCreated;
+            ViewModel.FontListCreated += ViewModel_FontListCreated;
         }
 
         private void ViewModel_FontListCreated(object sender, EventArgs e)
@@ -64,7 +57,7 @@ namespace CharacterMap.Views
 
         private void MainPage_Unloaded(object sender, RoutedEventArgs e)
         {
-            this.ViewModel.FontListCreated -= ViewModel_FontListCreated;
+            ViewModel.FontListCreated -= ViewModel_FontListCreated;
         }
 
 
@@ -152,10 +145,9 @@ namespace CharacterMap.Views
             e.Handled = true;
             if (sender is Grid grid
                 && grid.DataContext is InstalledFont font
-                && font.HasImportedFiles
-                && grid.ContextFlyout != null)
+                && font.HasImportedFiles)
             {
-                grid.ContextFlyout.ShowAt(grid);
+                grid.ContextFlyout?.ShowAt(grid);
             }
         }
 

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -257,5 +257,10 @@ namespace CharacterMap.Views
             if (e.Key == VirtualKey.Enter)
                 e.Handled = true;
         }
+
+        private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            FontMap.OnSearchBoxSubmittedQuery(SearchBox);
+        }
     }
 }


### PR DESCRIPTION
The search option flyout: The idea of it came from the "Photo" app search bar.
The option will show when you click it. And it goes away when you start typing or click elsewhere.

Search settings:
Use instant search: This should address issue #27 
Instant search delay: As JohnnyWestlake said "May it be worth having an option to extend this for slower typists?" So, I added it.
Max search result: IMO 10 is alright. But I'm sure there could be someone who wanted 100 results at a time. Who knows :/