### PR TITLE
User collections

### DIFF
--- a/0_artifacts/StoreListing.en.md
+++ b/0_artifacts/StoreListing.en.md
@@ -10,4 +10,5 @@ A modern, native UWP replacement for the Win32 Character Map and Windows Font Vi
 - Copy XAML code for Characters for FontIcon, SymbolIcon and text properties
 - Export Characters as PNG and SVG files
 - Search for unicode characters and Segoe MDL2 Assets
+- Create and manage custom font collections
 - Use as your default font file application to preview font files

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -185,6 +185,9 @@
     <Compile Include="Core\FontVariant.cs" />
     <Compile Include="Core\ImportMessage.cs" />
     <Compile Include="Core\InstalledFont.cs" />
+    <Compile Include="Core\PanoseFamily.cs" />
+    <Compile Include="Core\PanoseParser.cs" />
+    <Compile Include="Core\SerifStyle.cs" />
     <Compile Include="Core\SVGPathReciever.cs" />
     <Compile Include="Core\TypographyAnalyzer.cs" />
     <Compile Include="Core\TypographyBehavior.cs" />

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -173,14 +173,19 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\CreateCollectionDialog.xaml.cs">
+      <DependentUpon>CreateCollectionDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Converters\CharGridSelectedItemToTextConverter.cs" />
     <Compile Include="Converters\SmartTextColorBasedOnAccentTypeConverter.cs" />
     <Compile Include="Converters\ZoomBackgroundConverter.cs" />
     <Compile Include="Core\AlphaKeyGroup.cs" />
     <Compile Include="Core\AppSettings.cs" />
     <Compile Include="Core\Character.cs" />
+    <Compile Include="Core\CollectionsUpdatedMessage.cs" />
     <Compile Include="Core\Converters.cs" />
     <Compile Include="Core\ExportManager.cs" />
+    <Compile Include="Helpers\FlyoutHelper.cs" />
     <Compile Include="Core\FontFinder.cs" />
     <Compile Include="Core\FontVariant.cs" />
     <Compile Include="Core\ImportMessage.cs" />
@@ -196,6 +201,7 @@
     <Compile Include="Helpers\Debouncer.cs" />
     <Compile Include="Helpers\Json.cs" />
     <Compile Include="Helpers\Localization.cs" />
+    <Compile Include="Helpers\ResourceHelper.cs" />
     <Compile Include="Helpers\SettingsStorageExtensions.cs" />
     <Compile Include="Helpers\Singleton.cs" />
     <Compile Include="Core\Utils.cs" />
@@ -303,6 +309,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="Controls\CreateCollectionDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Styles\Button.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Provider\SQLiteGlyphProvider.cs" />
     <Compile Include="Provider\SQLiteGlyphProvider.Debug.cs" />
     <Compile Include="Services\ActivationService.cs" />
+    <Compile Include="Services\UserCollectionsService.cs" />
     <Compile Include="Services\GlyphService.cs" />
     <Compile Include="Services\NavigationServiceEx.cs" />
     <Compile Include="Services\ToastNotificationsService.cs" />

--- a/CharacterMap/CharacterMap/Controls/CreateCollectionDialog.xaml
+++ b/CharacterMap/CharacterMap/Controls/CreateCollectionDialog.xaml
@@ -1,0 +1,19 @@
+﻿<ContentDialog
+    x:Class="CharacterMap.Controls.CreateCollectionDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    x:Uid="DigCreateCollection"
+    IsPrimaryButtonEnabled="{x:Bind TemplateSettings.IsCollectionTitleValid, Mode=OneWay}"
+    PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
+    SecondaryButtonClick="{x:Bind Hide}"
+    mc:Ignorable="d">
+
+    <TextBox
+        x:Uid="CreateCollectionEntryBox"
+        Margin="-14,0"
+        DataContext="{x:Bind TemplateSettings}"
+        Text="{Binding CollectionTitle, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+</ContentDialog>

--- a/CharacterMap/CharacterMap/Controls/CreateCollectionDialog.xaml.cs
+++ b/CharacterMap/CharacterMap/Controls/CreateCollectionDialog.xaml.cs
@@ -1,0 +1,63 @@
+﻿using CharacterMap.Core;
+using CharacterMap.Services;
+using CommonServiceLocator;
+using GalaSoft.MvvmLight;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace CharacterMap.Controls
+{
+    public class CreateCollectionDialogTemplateSettings : ViewModelBase
+    {
+        private string _collectionTitle;
+        public string CollectionTitle
+        {
+            get => _collectionTitle;
+            set { if (Set(ref _collectionTitle, value)) OnCollectionTitleChanged(); }
+        }
+
+        private bool _isCollectionTitleValid;
+        public bool IsCollectionTitleValid
+        {
+            get => _isCollectionTitleValid;
+            private set => Set(ref _isCollectionTitleValid, value);
+        }
+
+        private void OnCollectionTitleChanged()
+        {
+            IsCollectionTitleValid = !string.IsNullOrWhiteSpace(CollectionTitle);
+        }
+    }
+
+    public sealed partial class CreateCollectionDialog : ContentDialog
+    {
+        public CreateCollectionDialogTemplateSettings TemplateSettings { get; }
+
+        public CreateCollectionDialog()
+        {
+            TemplateSettings = new CreateCollectionDialogTemplateSettings();
+            this.InitializeComponent();
+        }
+
+        private async void ContentDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            var d = args.GetDeferral();
+            var collections = ServiceLocator.Current.GetInstance<UserCollectionsService>();
+            var collection = await collections.CreateCollectionAsync(TemplateSettings.CollectionTitle);
+            await collections.AddToCollectionAsync(this.DataContext as InstalledFont, collection);
+            d.Complete();
+        }
+    }
+}

--- a/CharacterMap/CharacterMap/Core/AppSettings.cs
+++ b/CharacterMap/CharacterMap/Core/AppSettings.cs
@@ -78,6 +78,16 @@ namespace CharacterMap.Core
             }
         }
 
+        public bool UseFontForPreview
+        {
+            get => ReadSettings(nameof(UseFontForPreview), false);
+            set
+            {
+                SaveSettings(nameof(UseFontForPreview), value);
+                NotifyPropertyChanged();
+            }
+        }
+
         public bool UseInstantSearch
         {
             get => ReadSettings(nameof(UseInstantSearch), true);

--- a/CharacterMap/CharacterMap/Core/CollectionsUpdatedMessage.cs
+++ b/CharacterMap/CharacterMap/Core/CollectionsUpdatedMessage.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CharacterMap.Core
+{
+    public class CollectionsUpdatedMessage
+    {
+    }
+}

--- a/CharacterMap/CharacterMap/Core/Converters.cs
+++ b/CharacterMap/CharacterMap/Core/Converters.cs
@@ -1,9 +1,12 @@
-﻿using System;
+﻿using CharacterMap.Services;
+using CommonServiceLocator;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 
 namespace CharacterMap.Core
 {
@@ -36,5 +39,24 @@ namespace CharacterMap.Core
 
         public const string Auto = "Auto";
         public const string Star = "*";
+
+        private static AppSettings _settings;
+        private static UserCollectionsService _userCollections;
+
+        public static FontFamily GetPreviewFontSource(FontVariant variant)
+        {
+            if (_settings == null)
+            {
+                _settings = (AppSettings)App.Current.Resources[nameof(AppSettings)];
+                _userCollections = ServiceLocator.Current.GetInstance<UserCollectionsService>();
+            }
+
+            if (_settings.UseFontForPreview
+                && !variant.FontFace.IsSymbolFont
+                && !_userCollections.SymbolCollection.Fonts.Contains(variant.FamilyName))
+                return new FontFamily(variant.Source);
+
+            return FontFamily.XamlAutoFontFamily;
+        }
     }
 }

--- a/CharacterMap/CharacterMap/Core/FontFinder.cs
+++ b/CharacterMap/CharacterMap/Core/FontFinder.cs
@@ -395,5 +395,7 @@ namespace CharacterMap.Core
         }
 
         public static bool IsMDL2(FontVariant variant) => variant.FamilyName.Contains("MDL2 Assets");
+
+        
     }
 }

--- a/CharacterMap/CharacterMap/Core/FontFinder.cs
+++ b/CharacterMap/CharacterMap/Core/FontFinder.cs
@@ -396,6 +396,5 @@ namespace CharacterMap.Core
 
         public static bool IsMDL2(FontVariant variant) => variant.FamilyName.Contains("MDL2 Assets");
 
-        
     }
 }

--- a/CharacterMap/CharacterMap/Core/FontVariant.cs
+++ b/CharacterMap/CharacterMap/Core/FontVariant.cs
@@ -59,8 +59,6 @@ namespace CharacterMap.Core
 
         public Panose Panose { get; }
 
-        public bool IsSansSerif { get; }
-
         /// <summary>
         /// File-system path for DWrite / Xaml to construct a font for use in this application
         /// </summary>
@@ -100,7 +98,6 @@ namespace CharacterMap.Core
             UnicodeRanges = face.UnicodeRanges.Select(r => (r.First, r.Last)).ToArray();
             PreferredName = name;
             Panose = PanoseParser.Parse(face);
-            IsSansSerif = PanoseParser.IsSansSerif(Panose.Style);
         }
 
         public IReadOnlyList<Character> GetCharacters()

--- a/CharacterMap/CharacterMap/Core/FontVariant.cs
+++ b/CharacterMap/CharacterMap/Core/FontVariant.cs
@@ -57,6 +57,10 @@ namespace CharacterMap.Core
 
         public (uint,uint)[] UnicodeRanges { get; }
 
+        public Panose Panose { get; }
+
+        public bool IsSansSerif { get; }
+
         /// <summary>
         /// File-system path for DWrite / Xaml to construct a font for use in this application
         /// </summary>
@@ -95,6 +99,8 @@ namespace CharacterMap.Core
 
             UnicodeRanges = face.UnicodeRanges.Select(r => (r.First, r.Last)).ToArray();
             PreferredName = name;
+            Panose = PanoseParser.Parse(face);
+            IsSansSerif = PanoseParser.IsSansSerif(Panose.Style);
         }
 
         public IReadOnlyList<Character> GetCharacters()

--- a/CharacterMap/CharacterMap/Core/PanoseFamily.cs
+++ b/CharacterMap/CharacterMap/Core/PanoseFamily.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CharacterMap.Core
+{
+    public enum PanoseFamily
+    {
+        /// <summary>
+        /// Any typeface classification.
+        /// </summary>
+        Any = 0,
+        /// <summary>
+        /// No fit typeface classification.
+        /// </summary>
+        NoFit = 1,
+        /// <summary>
+        /// Text display typeface classification.
+        /// </summary>
+        TextDisplay = 2,
+        /// <summary>
+        /// Script (or hand written) typeface classification.
+        /// </summary>
+        Script = 3,
+        /// <summary>
+        /// Decorative typeface classification.
+        /// </summary>
+        Decorative = 4,
+        /// <summary>
+        /// Symbol typeface classification.
+        /// </summary>
+        Symbol = 5,
+        /// <summary>
+        /// Pictorial (or symbol) typeface classification.
+        /// </summary>
+        Pictorial = 6
+    }
+}

--- a/CharacterMap/CharacterMap/Core/PanoseParser.cs
+++ b/CharacterMap/CharacterMap/Core/PanoseParser.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Graphics.Canvas.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CharacterMap.Core
+{
+    public class Panose
+    {
+        public SerifStyle Style { get; }
+        public PanoseFamily Family { get; }
+
+        public Panose(PanoseFamily family, SerifStyle style)
+        {
+            Family = family;
+            Style = style;
+        }
+    }
+
+    public static class PanoseParser
+    {
+        public static Panose Parse(CanvasFontFace fontFace)
+        {
+            byte[] panose = fontFace.Panose;
+
+            PanoseFamily family = (PanoseFamily)panose[0];
+            SerifStyle style = SerifStyle.Any;
+
+            if (family == PanoseFamily.TextDisplay)
+            {
+                style = (SerifStyle)panose[1];
+            }
+
+            return new Panose(family, style);
+        }
+
+        public static bool IsSansSerif(SerifStyle style)
+        {
+            return
+                style == SerifStyle.NormalSans ||
+                style == SerifStyle.ObtuseSans ||
+                style == SerifStyle.PerpendicularSans ||
+                style == SerifStyle.PerpSans;
+        }
+    }
+}

--- a/CharacterMap/CharacterMap/Core/PanoseParser.cs
+++ b/CharacterMap/CharacterMap/Core/PanoseParser.cs
@@ -9,6 +9,7 @@ namespace CharacterMap.Core
 {
     public class Panose
     {
+        public bool IsSansSerifStyle { get; }
         public SerifStyle Style { get; }
         public PanoseFamily Family { get; }
 
@@ -16,6 +17,7 @@ namespace CharacterMap.Core
         {
             Family = family;
             Style = style;
+            IsSansSerifStyle = PanoseParser.IsSansSerif(Style);
         }
     }
 
@@ -25,13 +27,22 @@ namespace CharacterMap.Core
         {
             byte[] panose = fontFace.Panose;
 
+            // The contents of the Panose byte array depends on the value of the first byte. 
+            // See https://docs.microsoft.com/en-us/windows/win32/api/dwrite_1/ns-dwrite_1-dwrite_panose 
+            // for how the Family value changes the meaning of the following 9 bytes.
             PanoseFamily family = (PanoseFamily)panose[0];
-            SerifStyle style = SerifStyle.Any;
 
+            // Only fonts in TextDisplay family will identify their serif style
+            SerifStyle style = SerifStyle.Any;
             if (family == PanoseFamily.TextDisplay)
             {
                 style = (SerifStyle)panose[1];
             }
+
+            // Warning - not all fonts store correct values for Panose information. 
+            // If expanding PanoseParser in the future to read all values, direct casting
+            // enums may lead to errors - safer parsing may be needed to take into account
+            // faulty panose classifications.
 
             return new Panose(family, style);
         }

--- a/CharacterMap/CharacterMap/Core/SerifStyle.cs
+++ b/CharacterMap/CharacterMap/Core/SerifStyle.cs
@@ -17,21 +17,21 @@ namespace CharacterMap.Core
         /// </summary>
         NoFit = 1,
         /// <summary>
-        /// No fit appearance of the serif text.
+        /// Cove appearance of the serif text.
         /// </summary>
         Cove = 2,
         /// <summary>
-        /// No fit appearance of the serif text.
+        /// Obtuse Cove appearance of the serif text.
         /// </summary>
         ObtuseCove = 3,
         /// <summary>
-        /// No fit appearance of the serif text.
+        /// Square cove appearance of the serif text.
         /// </summary>
         SquareCove = 4,
         /// <summary>
-        /// No fit appearance of the serif text.
+        /// Obtuse square cove appearance of the serif text.
         /// </summary>
-        ObtuseSquareCore = 5,
+        ObtuseSquareCove = 5,
         /// <summary>
         /// Square appearance of the serif text.
         /// </summary>

--- a/CharacterMap/CharacterMap/Core/SerifStyle.cs
+++ b/CharacterMap/CharacterMap/Core/SerifStyle.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CharacterMap.Core
+{
+    public enum SerifStyle
+    {
+        /// <summary>
+        /// Any appearance of the serif text.
+        /// </summary>
+        Any = 0,
+        /// <summary>
+        /// No fit appearance of the serif text.
+        /// </summary>
+        NoFit = 1,
+        /// <summary>
+        /// No fit appearance of the serif text.
+        /// </summary>
+        Cove = 2,
+        /// <summary>
+        /// No fit appearance of the serif text.
+        /// </summary>
+        ObtuseCove = 3,
+        /// <summary>
+        /// No fit appearance of the serif text.
+        /// </summary>
+        SquareCove = 4,
+        /// <summary>
+        /// No fit appearance of the serif text.
+        /// </summary>
+        ObtuseSquareCore = 5,
+        /// <summary>
+        /// Square appearance of the serif text.
+        /// </summary>
+        Square = 6,
+        /// <summary>
+        /// Thin appearance of the serif text.
+        /// </summary>
+        Thin = 7,
+        /// <summary>
+        /// Oval appearance of the serif text.
+        /// </summary>
+        Oval = 8,
+        /// <summary>
+        /// Exaggerated appearance of the serif text.
+        /// </summary>
+        Exaggerated = 9,
+        /// <summary>
+        /// Triangle appearance of the serif text.
+        /// </summary>
+        Triangle = 10,
+        /// <summary>
+        /// Normal sans appearance of the serif text.
+        /// </summary>
+        NormalSans = 11,
+        /// <summary>
+        /// Obtuse sans appearance of the serif text.
+        /// </summary>
+        ObtuseSans = 12,
+        /// <summary>
+        /// Perpendicular sans appearance of the serif text.
+        /// </summary>
+        PerpendicularSans = 13,
+        /// <summary>
+        ///Flared appearance of the serif text.
+        /// </summary>
+        Flared = 14,
+        /// <summary>
+        /// Rounded appearance of the serif text.
+        /// </summary>
+        Rounded = 15,
+        /// <summary>
+        /// Script appearance of the serif text.
+        /// </summary>
+        Script = 16,
+        /// <summary>
+        /// Perpendicular sans appearance of the serif text.
+        /// </summary>
+        PerpSans = 17,
+        /// <summary>
+        /// Oval appearance of the serif text.
+        /// </summary>
+        Bone = 18
+    }
+}

--- a/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
@@ -1,0 +1,203 @@
+﻿using CharacterMap.Controls;
+using CharacterMap.Core;
+using CharacterMap.Helpers;
+using CharacterMap.Services;
+using CharacterMap.ViewModels;
+using CharacterMap.Views;
+using CommonServiceLocator;
+using GalaSoft.MvvmLight.Messaging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace CharacterMap.Helpers
+{
+    public static class FlyoutHelper
+    {
+        private static UserCollectionsService _collections { get; } = ServiceLocator.Current.GetInstance<UserCollectionsService>();
+
+        public static void CreateMenu(
+            MenuFlyout menu,
+            InstalledFont font,
+            bool standalone,
+            CreateCollectionDialog createDialog)
+        {
+            MainViewModel main = null;
+            if (ResourceHelper.TryGet("Locator", out ViewModelLocator l))
+                main = l.Main;
+
+            void OpenInNewWindow(object s, RoutedEventArgs args)
+            {
+                if (s is FrameworkElement f && f.Tag is InstalledFont fnt)
+                _ = FontMapView.CreateNewViewForFontAsync(fnt);
+            }
+
+            async void AddToSymbolFonts_Click(object sender, RoutedEventArgs e)
+            {
+                if (sender is FrameworkElement f && f.DataContext is InstalledFont fnt)
+                {
+                    await _collections.AddToCollectionAsync(
+                                   fnt, _collections.SymbolCollection);
+
+                    Messenger.Default.Send(new CollectionsUpdatedMessage());
+                }
+            }
+
+            void CreateCollection_Click(object sender, RoutedEventArgs e)
+            {
+                createDialog.TemplateSettings.CollectionTitle = null;
+                createDialog.DataContext = (sender as FrameworkElement)?.DataContext;
+                _ = createDialog.ShowAsync();
+            }
+
+            async void RemoveFrom_Click(object sender, RoutedEventArgs e)
+            {
+                if (sender is FrameworkElement f && f.DataContext is InstalledFont fnt)
+                {
+                    UserFontCollection collection = (main.SelectedCollection == null && main.FontListFilter == 1)
+                        ? _collections.SymbolCollection
+                        : main.SelectedCollection;
+
+                    await _collections.RemoveFromCollectionAsync(fnt, collection);
+                    Messenger.Default.Send(new CollectionsUpdatedMessage());
+
+                }
+            }
+
+            void RemoveMenuFlyoutItem_Click(object sender, RoutedEventArgs e)
+            {
+                if (sender is MenuFlyoutItem item && item.Tag is InstalledFont fnt)
+                {
+                    _ = MainPage.MainDispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                    {
+                        main.TryRemoveFont(font);
+                    });
+                }
+            }
+
+            menu.Items.Clear();
+            MenuFlyoutSubItem coll = null;
+
+            {  // HORRIBLE Hacks, because MenuFlyoutSubItem never updates it's UI tree after the first
+               // render, meaning we can't dynamically update items. Instead we need to make an entirely
+               // new one.
+
+                // Add "Open in New Window" button
+                if (!standalone)
+                {
+                    var newWindow = new MenuFlyoutItem
+                    {
+                        Text = Localization.Get("OpenInNewWindow/Text"),
+                        Icon = new SymbolIcon { Symbol = Symbol.NewWindow },
+                        Tag = font
+                    };
+                    newWindow.Click += OpenInNewWindow;
+                    menu.Items.Add(newWindow);
+                }
+                
+                // Add "Delete Font" button
+                if (!standalone)
+                {
+                    if (font.HasImportedFiles)
+                    {
+                        var removeFont = new MenuFlyoutItem
+                        {
+                            Text = Localization.Get("RemoveFontFlyout/Text"),
+                            Icon = new SymbolIcon { Symbol = Symbol.Delete },
+                            Tag = font
+                        };
+                        removeFont.Click += RemoveMenuFlyoutItem_Click;
+                        menu.Items.Add(removeFont);
+                    }
+                }
+                
+
+                // Add "Add to Collection" button
+                MenuFlyoutSubItem newColl = new MenuFlyoutSubItem
+                {
+                    Text = Localization.Get("AddToCollectionFlyout/Text"),
+                    Icon = new SymbolIcon { Symbol = Symbol.AllApps }
+                };
+
+                // Create "New Collection" Item
+                var newCollection = new MenuFlyoutItem
+                {
+                    Text = Localization.Get("NewCollectionItem/Text"),
+                    Icon = new SymbolIcon
+                    {
+                        Symbol = Symbol.Add
+                    }
+                };
+                newCollection.Click += CreateCollection_Click;
+                newColl.Items.Add(newCollection);
+
+                // Create "Symbol Font" item
+                if (!font.IsSymbolFont)
+                {
+                    newColl.Items.Add(new MenuFlyoutSeparator());
+
+                    var symb = new MenuFlyoutItem
+                    {
+                        Text = Localization.Get("OptionSymbolFonts/Text"),
+                        IsEnabled = !_collections.SymbolCollection.Fonts.Contains(font.Name)
+                    };
+                    symb.Click += AddToSymbolFonts_Click;
+                    newColl.Items.Add(symb);
+                }
+
+                coll = newColl;
+                menu.Items.Add(coll);
+            }
+
+            // Only show the "Remove from Collection" menu item if:
+            //  -- we are not in a standalone window
+            //  AND
+            //  -- we are in a custom collection
+            //  OR 
+            //  -- we are in the Symbol Font collection, and this is a font that 
+            //     the user has manually tagged as a symbol font
+            if (!standalone)
+            {
+                if (main.SelectedCollection != null ||
+                    (main.FontListFilter == 1 && !font.FontFace.IsSymbolFont))
+                {
+                    var removeItem = new MenuFlyoutItem
+                    {
+                        Text = Localization.Get("RemoveFromCollectionItem/Text"),
+                        Icon = new SymbolIcon { Symbol = Symbol.Remove },
+                        Tag = font
+                    };
+                    removeItem.Click += RemoveFrom_Click;
+                    menu.Items.Add(removeItem);
+                }
+            }
+            
+
+            // Add items for each user Collection
+            if (_collections.Items.Count > 0)
+            {
+                coll.Items.Add(new MenuFlyoutSeparator());
+
+                foreach (var item in _collections.Items)
+                {
+                    var m = new MenuFlyoutItem { DataContext = item, Text = item.Name, IsEnabled = !item.Fonts.Contains(font.Name) };
+                    if (m.IsEnabled)
+                    {
+                        m.Click += async (s, a) =>
+                        {
+                            await _collections.AddToCollectionAsync(
+                                font, (UserFontCollection)(((FrameworkElement)s).DataContext));
+                        };
+                    }
+                    coll.Items.Add(m);
+                }
+            }
+        }
+
+    }
+}

--- a/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
@@ -75,7 +75,7 @@ namespace CharacterMap.Helpers
                 {
                     _ = MainPage.MainDispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                     {
-                        main.TryRemoveFont(font);
+                        main.TryRemoveFont(fnt);
                     });
                 }
             }

--- a/CharacterMap/CharacterMap/Helpers/Json.cs
+++ b/CharacterMap/CharacterMap/Helpers/Json.cs
@@ -1,18 +1,55 @@
+using System;
+using System.IO;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Windows.Storage;
 
 namespace CharacterMap.Helpers
 {
     public static class Json
     {
-        public static async Task<T> ToObjectAsync<T>(string value)
+        public static Task<T> ReadAsync<T>(StorageFile file)
         {
-            return await Task.Run(() => JsonConvert.DeserializeObject<T>(value));
+            return Task.Run(async () =>
+            {
+                T result = default;
+                var d = JsonSerializer.CreateDefault();
+                using (var s = await file.OpenAsync(FileAccessMode.Read).AsTask().ConfigureAwait(false))
+                using (var stream = s.AsStreamForRead())
+                using (var reader = new StreamReader(stream))
+                {
+                    result = (T)d.Deserialize(reader, typeof(T));
+                }
+
+                return result;
+            });
         }
 
-        public static async Task<string> StringifyAsync(object value)
+        public static Task WriteAsync<T>(StorageFile file, T obj)
         {
-            return await Task.Run(() => JsonConvert.SerializeObject(value));
+            return Task.Run(async () =>
+            {
+                T result = default;
+                var d = JsonSerializer.CreateDefault();
+                using (var s = await file.OpenAsync(FileAccessMode.ReadWrite).AsTask().ConfigureAwait(false))
+                using (var stream = s.AsStreamForWrite())
+                using (var writer = new StreamWriter(stream))
+                {
+                    d.Serialize(writer, obj);
+                }
+
+                return result;
+            });
+        }
+
+        public static Task<T> ToObjectAsync<T>(string value)
+        {
+            return Task.Run(() => JsonConvert.DeserializeObject<T>(value));
+        }
+
+        public static Task<string> StringifyAsync(object value)
+        {
+            return Task.Run(() => JsonConvert.SerializeObject(value));
         }
     }
 }

--- a/CharacterMap/CharacterMap/Helpers/Json.cs
+++ b/CharacterMap/CharacterMap/Helpers/Json.cs
@@ -8,17 +8,18 @@ namespace CharacterMap.Helpers
 {
     public static class Json
     {
+        public static JsonSerializer DefaultSerializer { get; } = JsonSerializer.CreateDefault();
+
         public static Task<T> ReadAsync<T>(StorageFile file)
         {
             return Task.Run(async () =>
             {
                 T result = default;
-                var d = JsonSerializer.CreateDefault();
                 using (var s = await file.OpenAsync(FileAccessMode.Read).AsTask().ConfigureAwait(false))
                 using (var stream = s.AsStreamForRead())
                 using (var reader = new StreamReader(stream))
                 {
-                    result = (T)d.Deserialize(reader, typeof(T));
+                    result = (T)DefaultSerializer.Deserialize(reader, typeof(T));
                 }
 
                 return result;
@@ -30,12 +31,12 @@ namespace CharacterMap.Helpers
             return Task.Run(async () =>
             {
                 T result = default;
-                var d = JsonSerializer.CreateDefault();
                 using (var s = await file.OpenAsync(FileAccessMode.ReadWrite).AsTask().ConfigureAwait(false))
                 using (var stream = s.AsStreamForWrite())
                 using (var writer = new StreamWriter(stream))
                 {
-                    d.Serialize(writer, obj);
+                    stream.SetLength(0);
+                    DefaultSerializer.Serialize(writer, obj);
                 }
 
                 return result;

--- a/CharacterMap/CharacterMap/Helpers/ResourceHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/ResourceHelper.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+
+namespace CharacterMap.Helpers
+{
+    public static class ResourceHelper
+    {
+        public static bool TryGet<T>(string resourceKey, out T value)
+        {
+            if (TryGetInternal(Application.Current.Resources, resourceKey, out value))
+                return true;
+
+            value = default;
+            return false;
+        }
+
+        static bool TryGetInternal<T>(ResourceDictionary dictionary, string key, out T v)
+        {
+            if (dictionary.TryGetValue(key, out object r) && r is T c)
+            {
+                v = c;
+                return true;
+            }
+
+            foreach (var dic in dictionary.MergedDictionaries)
+            {
+                if (TryGetInternal(dic, key, out v))
+                    return true;
+            }
+
+            v = default;
+            return false;
+        }
+    }
+
+}

--- a/CharacterMap/CharacterMap/Services/UserCollectionsService.cs
+++ b/CharacterMap/CharacterMap/Services/UserCollectionsService.cs
@@ -1,0 +1,108 @@
+﻿using CharacterMap.Core;
+using CharacterMap.Helpers;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Storage;
+
+namespace CharacterMap.Services
+{
+    public class UserFontCollection
+    {
+        [JsonIgnore]
+        public StorageFile File { get; set; }
+        public string Name { get; set; }
+        public HashSet<string> Fonts { get; set; } = new HashSet<string>();
+    }
+
+    public class UserCollectionsService
+    {
+        public UserFontCollection SymbolCollection { get; private set; }
+        public ObservableCollection<UserFontCollection> Items { get; } = new ObservableCollection<UserFontCollection>();
+
+        public async Task LoadCollectionsAsync()
+        {
+            List<UserFontCollection> collections = new List<UserFontCollection>();
+
+            await Task.Run(async () =>
+            {
+                var folder = await GetCollectionsFolderAsync().AsTask().ConfigureAwait(false);
+                var files = await folder.GetFilesAsync().AsTask().ConfigureAwait(false);
+
+                foreach (var file in files)
+                {
+                    UserFontCollection collection = await Json.ReadAsync<UserFontCollection>(file).ConfigureAwait(false);
+                    collection.File = file;
+                    if (file.DisplayName != "Symbol")
+                    {
+                        collections.Add(collection);
+                    }
+                    else
+                    {
+                        SymbolCollection = collection;
+                    }
+                }
+                if (SymbolCollection == null)
+                {
+                    SymbolCollection = await CreateCollectionAsync("Symbol", "Symbol");
+                }
+            });
+            
+            foreach (var item in collections)
+                Items.Add(item);
+        }
+
+        public bool DoesCollectionExist(string name)
+        {
+            return TryGetCollection(name) != null;
+        }
+
+        public UserFontCollection TryGetCollection(string name)
+        {
+            return Items.FirstOrDefault(i => string.CompareOrdinal(i.Name, name) > 0);
+        }
+
+        public async Task<UserFontCollection> CreateCollectionAsync(string name, string fileName = null)
+        {
+            var folder = await GetCollectionsFolderAsync();
+            var file = await folder.CreateFileAsync($"{fileName ?? Guid.NewGuid().ToString()}.json");
+            var collection = new UserFontCollection { Name = name, File = file };
+            await SaveCollectionAsync(collection);
+            Items.Add(collection);
+            return collection;
+        }
+
+        public async Task DeleteCollectionAsync(UserFontCollection collection)
+        {
+            await collection.File.DeleteAsync();
+            Items.Remove(collection);
+        }
+
+        public Task SaveCollectionAsync(UserFontCollection collection)
+        {
+            return Json.WriteAsync(collection.File, collection);
+        }
+
+        public Task AddToCollectionAsync(InstalledFont font, UserFontCollection collection)
+        {
+            if (!collection.Fonts.Contains(font.Name))
+            {
+                collection.Fonts.Add(font.Name);
+                return SaveCollectionAsync(collection);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private IAsyncOperation<StorageFolder> GetCollectionsFolderAsync()
+        {
+            return ApplicationData.Current.LocalCacheFolder.CreateFolderAsync("Collections", CreationCollisionOption.OpenIfExists);
+        }
+    }
+}

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -214,7 +214,7 @@
     <value>PNG Resolution (pixel)</value>
   </data>
   <data name="RemoveFontFlyout.Text" xml:space="preserve">
-    <value>Remove Font Family</value>
+    <value>Delete Font Family</value>
   </data>
   <data name="RestartButton.Content" xml:space="preserve">
     <value>Restart</value>
@@ -386,5 +386,17 @@
   </data>
   <data name="RemoveFromCollectionItem.Text" xml:space="preserve">
     <value>Remove from Collection</value>
+  </data>
+  <data name="AddToCollectionFlyout.Text" xml:space="preserve">
+    <value>Add to Collection</value>
+  </data>
+  <data name="InstantSearchToggle.OffContent" xml:space="preserve">
+    <value>Instant search disabled</value>
+  </data>
+  <data name="InstantSearchToggle.OnContent" xml:space="preserve">
+    <value>Instant search enabled</value>
+  </data>
+  <data name="SearchResultsSlider.Header" xml:space="preserve">
+    <value>Maximum search results</value>
   </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -315,4 +315,49 @@
   <data name="OpenFontPickerConfirm" xml:space="preserve">
     <value>Open</value>
   </data>
+  <data name="CreateCollectionEntryBox.Header" xml:space="preserve">
+    <value>Collection Name</value>
+  </data>
+  <data name="DigCreateCollection.PrimaryButtonText" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="DigCreateCollection.Title" xml:space="preserve">
+    <value>Create Collection</value>
+  </data>
+  <data name="DeleteCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Delete Collection</value>
+  </data>
+  <data name="DigCreateCollection.SecondaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="DigDeleteCollection.PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DigDeleteCollection.SecondaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="DigDeleteCollection.Title" xml:space="preserve">
+    <value>Are you sure you want to delete this collection?</value>
+  </data>
+  <data name="DigRenameCollection.PrimaryButtonText" xml:space="preserve">
+    <value>Rename</value>
+  </data>
+  <data name="DigRenameCollection.SecondaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="DigRenameCollection.Title" xml:space="preserve">
+    <value>Rename Collection</value>
+  </data>
+  <data name="OptionAllFonts.Text" xml:space="preserve">
+    <value>All Fonts</value>
+  </data>
+  <data name="OptionImportedFonts.Text" xml:space="preserve">
+    <value>Imported Fonts</value>
+  </data>
+  <data name="OptionSymbolFonts.Text" xml:space="preserve">
+    <value>Symbol Fonts</value>
+  </data>
+  <data name="RenameCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Rename Collection</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddToCollectionHint.Text" xml:space="preserve">
-    <value>Add to Collection</value>
+    <value>Add to Library</value>
   </data>
   <data name="AppName" xml:space="preserve">
     <value>Character Map</value>
@@ -298,7 +298,7 @@
     <value>Something went wrong. Please try again later.</value>
   </data>
   <data name="ImportFontHelpBlock.Text" xml:space="preserve">
-    <value>Drag fonts into the app to copy them to your collection.</value>
+    <value>Drag fonts into the app to copy them to your library.</value>
   </data>
   <data name="FontPropXaml.Text" xml:space="preserve">
     <value>XAML FontFamily Source</value>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -360,6 +360,15 @@
   <data name="RenameCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Rename Collection</value>
   </data>
+  <data name="FontListDisplayHeader.Text" xml:space="preserve">
+    <value>Fonts List Display</value>
+  </data>
+  <data name="FontListDisplayToggle.OffContent" xml:space="preserve">
+    <value>Show Font names using System default font</value>
+  </data>
+  <data name="FontListDisplayToggle.OnContent" xml:space="preserve">
+    <value>Show Font names using actual font</value>
+  </data>
   <data name="OptionMonospacedFonts.Text" xml:space="preserve">
     <value>Monospaced Fonts</value>
   </data>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -360,4 +360,13 @@
   <data name="RenameCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Rename Collection</value>
   </data>
+  <data name="OptionMonospacedFonts.Text" xml:space="preserve">
+    <value>Monospaced Fonts</value>
+  </data>
+  <data name="OptionSansSerifFonts.Text" xml:space="preserve">
+    <value>Sans Serif Fonts</value>
+  </data>
+  <data name="OptionSerifFonts.Text" xml:space="preserve">
+    <value>Serif Fonts</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -369,6 +369,9 @@
   <data name="FontListDisplayToggle.OnContent" xml:space="preserve">
     <value>Show Font names using actual font</value>
   </data>
+  <data name="FontPropCount.Text" xml:space="preserve">
+    <value>Glyph Count</value>
+  </data>
   <data name="OptionMonospacedFonts.Text" xml:space="preserve">
     <value>Monospaced Fonts</value>
   </data>
@@ -377,5 +380,11 @@
   </data>
   <data name="OptionSerifFonts.Text" xml:space="preserve">
     <value>Serif Fonts</value>
+  </data>
+  <data name="NewCollectionItem.Text" xml:space="preserve">
+    <value>New Collection</value>
+  </data>
+  <data name="RemoveFromCollectionItem.Text" xml:space="preserve">
+    <value>Remove from Collection</value>
   </data>
 </root>

--- a/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
@@ -1,6 +1,7 @@
 using CharacterMap.Core;
 using CharacterMap.Helpers;
 using CharacterMap.Services;
+using CharacterMap.Views;
 using CharacterMapCX;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Command;
@@ -467,6 +468,14 @@ namespace CharacterMap.ViewModels
             finally
             {
                 IsLoading = false;
+            }
+        }
+
+        public void OpenSelectedFontInWindow(object sender, RoutedEventArgs e)
+        {
+            if (SelectedFont is InstalledFont font)
+            {
+                _ = FontMapView.CreateNewViewForFontAsync(font);
             }
         }
     }

--- a/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
@@ -24,7 +24,7 @@ namespace CharacterMap.ViewModels
     {
         private Interop Interop { get; }
 
-        private StorageFile SourceFile { get; set; }
+        public StorageFile SourceFile { get; set; }
 
         private Debouncer SearchDebouncer { get; }
 

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -198,6 +198,21 @@ namespace CharacterMap.ViewModels
                         fontList = fontList.Where(f => f.HasImportedFiles);
                         FilterTitle = Localization.Get("OptionImportedFonts/Text");
                     }
+                    else if (FontListFilter == 3)
+                    {
+                        fontList = fontList.Where(f => f.DefaultVariant.FontFace.IsMonospaced);
+                        FilterTitle = Localization.Get("OptionMonospacedFonts/Text");
+                    }
+                    else if (FontListFilter == 4)
+                    {
+                        fontList = fontList.Where(f => !f.DefaultVariant.IsSansSerif);
+                        FilterTitle = Localization.Get("OptionSerifFonts/Text");
+                    }
+                    else if (FontListFilter == 5)
+                    {
+                        fontList = fontList.Where(f => f.DefaultVariant.IsSansSerif);
+                        FilterTitle = Localization.Get("OptionSansSerifFonts/Text");
+                    }
                     else
                         FilterTitle = Localization.Get("OptionAllFonts/Text");
                 }

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -25,7 +25,7 @@ namespace CharacterMap.ViewModels
 
         public event EventHandler FontListCreated;
 
-        private Task InitialLoad { get; }
+        public Task InitialLoad { get; }
 
         public IDialogService DialogService { get; }
 
@@ -205,12 +205,12 @@ namespace CharacterMap.ViewModels
                     }
                     else if (FontListFilter == 4)
                     {
-                        fontList = fontList.Where(f => !f.DefaultVariant.IsSansSerif);
+                        fontList = fontList.Where(f => !f.DefaultVariant.Panose.IsSansSerifStyle);
                         FilterTitle = Localization.Get("OptionSerifFonts/Text");
                     }
                     else if (FontListFilter == 5)
                     {
-                        fontList = fontList.Where(f => f.DefaultVariant.IsSansSerif);
+                        fontList = fontList.Where(f => f.DefaultVariant.Panose.IsSansSerifStyle);
                         FilterTitle = Localization.Get("OptionSansSerifFonts/Text");
                     }
                     else
@@ -285,6 +285,10 @@ namespace CharacterMap.ViewModels
             await Task.Delay(150);
 
             bool result = await FontFinder.RemoveFontAsync(font);
+            if (result)
+            {
+                _ = FontCollections.RemoveFromAllCollectionsAsync(font);
+            }
             RefreshFontList(SelectedCollection);
 
             IsLoadingFonts = false;

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -289,6 +289,7 @@ namespace CharacterMap.ViewModels
             {
                 _ = FontCollections.RemoveFromAllCollectionsAsync(font);
             }
+
             RefreshFontList(SelectedCollection);
 
             IsLoadingFonts = false;

--- a/CharacterMap/CharacterMap/ViewModels/ViewModelLocator.cs
+++ b/CharacterMap/CharacterMap/ViewModels/ViewModelLocator.cs
@@ -23,6 +23,7 @@ namespace CharacterMap.ViewModels
                 SimpleIoc.Default.Register(() => new Interop(Utils.CanvasDevice));
 
                 SimpleIoc.Default.Register<MainViewModel>();
+                SimpleIoc.Default.Register<UserCollectionsService>();
                 Register<MainViewModel, MainPage>();
             }
         }

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -37,9 +37,9 @@
 
         <Grid
             x:Name="TitleGrid"
+            x:Load="{x:Bind IsStandalone}"
             Grid.Row="1"
             Height="45"
-            x:Load="{x:Bind IsStandalone}"
             Background="{ThemeResource SystemControlBackgroundAccentBrush}"
             RequestedTheme="{Binding IsDarkAccent, Converter={StaticResource SmartTextColorBasedOnAccentTypeConverter}, Mode=OneWay}">
             <Grid.ColumnDefinitions>
@@ -74,7 +74,6 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
-
                     <FontIcon Glyph="&#xE109;" />
                     <TextBlock
                         x:Uid="AddToCollectionHint"
@@ -106,10 +105,9 @@
                     <Flyout>
                         <StackPanel Width="260">
                             <ToggleSwitch
+                                x:Uid="InstantSearchToggle"
                                 Margin="0,4"
-                                IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}"
-                                OffContent="Disabled instant search"
-                                OnContent="Enabled instant search" />
+                                IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" />
                             <Slider
                                 Margin="0,4"
                                 Header="Delay before search (ms)"
@@ -119,8 +117,8 @@
                                 Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"
                                 Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}" />
                             <Slider
+                                x:Uid="SearchResultsSlider"
                                 Margin="0,4"
-                                Header="Maximum preview search result"
                                 Maximum="100"
                                 Minimum="5"
                                 TickFrequency="1"
@@ -153,10 +151,10 @@
 
             <AppBarButton
                 x:Name="SearchOptionButton"
+                x:Load="{x:Bind core:Converters.False(core:Utils.IsSystemOnWin10v1809OrNewer)}"
                 Grid.Column="3"
                 Width="45"
                 Height="45"
-                x:Load="{x:Bind core:Converters.False(core:Utils.IsSystemOnWin10v1809OrNewer)}"
                 Visibility="{x:Bind core:Converters.FalseToVis(core:Utils.IsSystemOnWin10v1809OrNewer)}">
                 <Grid>
                     <FontIcon Glyph="&#xE11A;" />
@@ -430,8 +428,8 @@
                                                 <ToggleSwitch
                                                     x:Name="ColorGlyphToggle"
                                                     x:Uid="ColorGlyphToggle"
-                                                    VerticalAlignment="Bottom"
                                                     x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
+                                                    VerticalAlignment="Bottom"
                                                     IsOn="{Binding ShowColorGlyphs, Mode=TwoWay}" />
                                                 <TextBlock
                                                     x:Uid="TypographyVariantsHeader"
@@ -454,21 +452,17 @@
                     </StackPanel>
 
                     <Button
+                        x:Name="MoreOptionsButton"
+                        x:Load="{x:Bind core:Converters.False(ViewModel.IsExternalFile)}"
                         Grid.Column="1"
                         Width="44"
                         Height="44"
                         Margin="0,0,0,-8"
                         VerticalAlignment="Bottom"
-                        Style="{ThemeResource TransparentButton}"
-                        Visibility="{x:Bind core:Converters.FalseToVis(IsStandalone)}">
+                        DataContext="{x:Bind ViewModel.SelectedFont, Mode=OneWay}"
+                        Style="{ThemeResource TransparentButton}">
                         <Button.Flyout>
-                            <MenuFlyout Placement="Bottom">
-                                <MenuFlyoutItem x:Uid="OpenInNewWindow" Click="{x:Bind ViewModel.OpenSelectedFontInWindow}">
-                                    <MenuFlyoutItem.Icon>
-                                        <FontIcon Margin="0,0,-2,0" Glyph="&#xE2B4;" />
-                                    </MenuFlyoutItem.Icon>
-                                </MenuFlyoutItem>
-                            </MenuFlyout>
+                            <MenuFlyout Opening="MenuFlyout_Opening" Placement="Bottom" />
                         </Button.Flyout>
                         <FontIcon
                             Margin="0,0,-2,0"
@@ -874,11 +868,11 @@
 
         <Grid
             x:Name="StatusBar"
+            x:Load="{x:Bind IsStandalone}"
             Grid.Row="3"
             Grid.Column="0"
             Grid.ColumnSpan="2"
             Height="26"
-            x:Load="{x:Bind IsStandalone}"
             Background="{ThemeResource SystemControlBackgroundAccentBrush}"
             RequestedTheme="{Binding IsDarkAccent, Converter={StaticResource SmartTextColorBasedOnAccentTypeConverter}, Mode=OneWay}">
             <Grid.ColumnDefinitions>
@@ -897,6 +891,14 @@
                 Margin="12,0"
                 Text="{x:Bind ViewModel.GetCharDescription(ViewModel.SelectedChar), Mode=OneWay}" />
         </Grid>
+
+        <controls:CreateCollectionDialog
+            x:Name="DlgCreateCollection"
+            Grid.Row="0"
+            Grid.RowSpan="10"
+            Grid.Column="0"
+            Grid.ColumnSpan="10"
+            d:IsHidden="True" />
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LoadingStates">

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -11,8 +11,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:services="using:CharacterMap.Services"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    d:DesignHeight="300"
-    d:DesignWidth="400"
+    d:DesignHeight="800"
+    d:DesignWidth="1280"
     mc:Ignorable="d">
 
     <Grid DataContext="{x:Bind ViewModel}">
@@ -26,7 +26,7 @@
 
         <controls:XamlTitleBar x:Name="TitleBar" x:Load="{x:Bind IsStandalone}">
             <TextBlock
-                Margin="12 0 0 0"
+                Margin="12,0,0,0"
                 VerticalAlignment="Center"
                 FontSize="12"
                 IsHitTestVisible="False">
@@ -51,7 +51,7 @@
             <TextBlock
                 x:Name="FontTitleBlock"
                 Grid.Column="0"
-                Margin="12 0"
+                Margin="12,0"
                 VerticalAlignment="Center"
                 FontSize="22"
                 FontWeight="SemiLight"
@@ -62,7 +62,7 @@
             <Button
                 Grid.Column="1"
                 Height="45"
-                Padding="12 0"
+                Padding="12,0"
                 HorizontalAlignment="Right"
                 Click="{x:Bind ViewModel.ImportFile}"
                 IsEnabled="{Binding ImportButtonEnabled}"
@@ -88,7 +88,7 @@
                 x:Uid="SearchBox"
                 Grid.Column="2"
                 Width="290"
-                Margin="6 0 6 0"
+                Margin="6,0,6,0"
                 VerticalAlignment="Center"
                 GotFocus="SearchBox_GotFocus"
                 ItemsSource="{x:Bind ViewModel.SearchResults, Mode=OneWay}"
@@ -106,12 +106,12 @@
                     <Flyout>
                         <StackPanel Width="260">
                             <ToggleSwitch
-                                Margin="0 4"
+                                Margin="0,4"
                                 IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}"
                                 OffContent="Disabled instant search"
                                 OnContent="Enabled instant search" />
                             <Slider
-                                Margin="0 4"
+                                Margin="0,4"
                                 Header="Delay before search (ms)"
                                 Maximum="3000"
                                 Minimum="250"
@@ -119,7 +119,7 @@
                                 Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"
                                 Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}" />
                             <Slider
-                                Margin="0 4"
+                                Margin="0,4"
                                 Header="Maximum preview search result"
                                 Maximum="100"
                                 Minimum="5"
@@ -136,7 +136,7 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <FontIcon
-                                Margin="4 0 0 0"
+                                Margin="4,0,0,0"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontFamily="{Binding ElementName=SearchBox, Path=DataContext.FontFamily}"
@@ -161,7 +161,7 @@
                 <Grid>
                     <FontIcon Glyph="&#xE11A;" />
                     <FontIcon
-                        Margin="0 3 3 0"
+                        Margin="0,3,3,0"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
                         FontSize="7"
@@ -171,12 +171,12 @@
                     <Flyout Placement="Bottom">
                         <StackPanel>
                             <ToggleSwitch
-                                Margin="0 4"
+                                Margin="0,4"
                                 IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}"
                                 OffContent="Disabled instant search"
                                 OnContent="Enabled instant search" />
                             <Slider
-                                Margin="0 4"
+                                Margin="0,4"
                                 Header="Delay before search (ms)"
                                 Maximum="3000"
                                 Minimum="250"
@@ -184,7 +184,7 @@
                                 Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"
                                 Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}" />
                             <Slider
-                                Margin="0 4"
+                                Margin="0,4"
                                 Header="Maximum preview search result"
                                 Maximum="100"
                                 Minimum="5"
@@ -228,215 +228,248 @@
                     <ColumnDefinition Width="330" />
                 </Grid.ColumnDefinitions>
 
-                <StackPanel
-                    x:Name="OptionsPanel"
+                <Grid
                     Margin="12"
                     VerticalAlignment="Top"
-                    Orientation="Horizontal"
-                    Spacing="24">
-                    <ComboBox
-                        x:Name="WeightSelector"
-                        x:Uid="WeightSelector"
-                        MinWidth="160"
-                        IsEnabled="{Binding SelectedFont.HasVariants}"
-                        ItemsSource="{Binding SelectedFont.Variants}"
-                        SelectedItem="{Binding SelectedVariant, Mode=TwoWay}" />
+                    ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
 
-                    <Button
-                        x:Name="FontPropertiesButton"
-                        x:Uid="FontPropertiesButton"
-                        Width="44"
-                        Height="44"
-                        Margin="0 0 0 -8"
-                        VerticalAlignment="Bottom"
-                        Style="{ThemeResource TransparentButton}">
-                        <FontIcon
-                            Margin="0 0 -2 0"
-                            Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
-                            Glyph="&#xE946;" />
-                        <Button.Flyout>
-                            <Flyout>
-                                <StackPanel
-                                    MinWidth="300"
-                                    MaxWidth="400"
-                                    Padding="12"
-                                    Spacing="12">
-                                    <Panel.Resources>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Opacity" Value="0.5" />
-                                            <Setter Property="TextWrapping" Value="Wrap" />
-                                            <Setter Property="VerticalAlignment" Value="Top" />
-                                        </Style>
-                                        <Style x:Key="Value" TargetType="TextBlock">
-                                            <Setter Property="Opacity" Value="1" />
-                                            <Setter Property="Grid.Column" Value="1" />
-                                            <Setter Property="TextWrapping" Value="Wrap" />
-                                            <Setter Property="VerticalAlignment" Value="Top" />
-                                        </Style>
-                                    </Panel.Resources>
-                                    <TextBlock x:Uid="FontPropTitle" FontWeight="Bold" />
-                                    <Grid RowSpacing="8">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition />
-                                            <ColumnDefinition />
-                                        </Grid.ColumnDefinitions>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                        </Grid.RowDefinitions>
+                    <StackPanel
+                        x:Name="OptionsPanel"
+                        Orientation="Horizontal"
+                        Spacing="24">
+                        <ComboBox
+                            x:Name="WeightSelector"
+                            x:Uid="WeightSelector"
+                            MinWidth="160"
+                            IsEnabled="{Binding SelectedFont.HasVariants}"
+                            ItemsSource="{Binding SelectedFont.Variants}"
+                            SelectedItem="{Binding SelectedVariant, Mode=TwoWay}" />
+
+                        <Button
+                            x:Name="FontPropertiesButton"
+                            x:Uid="FontPropertiesButton"
+                            Width="44"
+                            Height="44"
+                            Margin="0,0,0,-8"
+                            VerticalAlignment="Bottom"
+                            Style="{ThemeResource TransparentButton}">
+                            <FontIcon
+                                Margin="0,0,-2,0"
+                                Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                                Glyph="&#xE946;" />
+                            <Button.Flyout>
+                                <Flyout>
+                                    <StackPanel
+                                        MinWidth="300"
+                                        MaxWidth="400"
+                                        Padding="12"
+                                        Spacing="12">
+                                        <Panel.Resources>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Opacity" Value="0.5" />
+                                                <Setter Property="TextWrapping" Value="Wrap" />
+                                                <Setter Property="VerticalAlignment" Value="Top" />
+                                            </Style>
+                                            <Style x:Key="Value" TargetType="TextBlock">
+                                                <Setter Property="Opacity" Value="1" />
+                                                <Setter Property="Grid.Column" Value="1" />
+                                                <Setter Property="TextWrapping" Value="Wrap" />
+                                                <Setter Property="VerticalAlignment" Value="Top" />
+                                            </Style>
+                                        </Panel.Resources>
+                                        <TextBlock x:Uid="FontPropTitle" FontWeight="Bold" />
+                                        <Grid RowSpacing="8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition />
+                                                <ColumnDefinition />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
 
 
-                                        <TextBlock x:Uid="FontPropFamily" Grid.Row="0" />
-                                        <TextBlock
-                                            Grid.Row="0"
-                                            Style="{StaticResource Value}"
-                                            Text="{Binding SelectedFont.Name}" />
+                                            <TextBlock x:Uid="FontPropFamily" Grid.Row="0" />
+                                            <TextBlock
+                                                Grid.Row="0"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedFont.Name}" />
 
-                                        <TextBlock x:Uid="FontPropFace" Grid.Row="1" />
-                                        <TextBlock
-                                            Grid.Row="1"
-                                            Style="{StaticResource Value}"
-                                            Text="{Binding SelectedVariant.PreferredName}" />
+                                            <TextBlock x:Uid="FontPropFace" Grid.Row="1" />
+                                            <TextBlock
+                                                Grid.Row="1"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.PreferredName}" />
 
-                                        <TextBlock x:Uid="FontPropType" Grid.Row="2" />
-                                        <TextBlock
-                                            Grid.Row="2"
-                                            Style="{StaticResource Value}"
-                                            Text="{Binding SelectedVariant.FontFace.FileFormatType}" />
+                                            <TextBlock x:Uid="FontPropType" Grid.Row="2" />
+                                            <TextBlock
+                                                Grid.Row="2"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.FileFormatType}" />
 
-                                        <TextBlock x:Uid="FontPropSymbol" Grid.Row="3" />
-                                        <TextBlock
-                                            Grid.Row="3"
-                                            Style="{StaticResource Value}"
-                                            Text="{Binding SelectedVariant.FontFace.IsSymbolFont}" />
+                                            <TextBlock x:Uid="FontPropSymbol" Grid.Row="3" />
+                                            <TextBlock
+                                                Grid.Row="3"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.IsSymbolFont}" />
 
-                                        <TextBlock x:Uid="FontPropMonospaced" Grid.Row="4" />
-                                        <TextBlock
-                                            Grid.Row="4"
-                                            Style="{StaticResource Value}"
-                                            Text="{Binding SelectedVariant.FontFace.IsMonospaced}" />
+                                            <TextBlock x:Uid="FontPropMonospaced" Grid.Row="4" />
+                                            <TextBlock
+                                                Grid.Row="4"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.IsMonospaced}" />
 
-                                        <TextBlock x:Uid="FontPropStyle" Grid.Row="5" />
-                                        <TextBlock
-                                            Grid.Row="5"
-                                            Style="{StaticResource Value}"
-                                            Text="{Binding SelectedVariant.FontFace.Style}" />
+                                            <TextBlock x:Uid="FontPropStyle" Grid.Row="5" />
+                                            <TextBlock
+                                                Grid.Row="5"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.Style}" />
 
-                                        <TextBlock x:Uid="FontPropStretch" Grid.Row="6" />
-                                        <TextBlock
-                                            Grid.Row="6"
-                                            Style="{StaticResource Value}"
-                                            Text="{Binding SelectedVariant.FontFace.Stretch}" />
+                                            <TextBlock x:Uid="FontPropStretch" Grid.Row="6" />
+                                            <TextBlock
+                                                Grid.Row="6"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.Stretch}" />
 
-                                        <TextBlock x:Uid="FontPropWeight" Grid.Row="7" />
-                                        <TextBlock
-                                            Grid.Row="7"
-                                            Style="{StaticResource Value}"
-                                            Text="{x:Bind ViewModel.SelectedVariant.FontFace.Weight.Weight.ToString(), Mode=OneWay}" />
+                                            <TextBlock x:Uid="FontPropWeight" Grid.Row="7" />
+                                            <TextBlock
+                                                Grid.Row="7"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind ViewModel.SelectedVariant.FontFace.Weight.Weight.ToString(), Mode=OneWay}" />
 
-                                        <TextBlock
-                                            x:Uid="FontPropXaml"
-                                            Grid.Row="8"
-                                            Margin="0 4 0 0"
-                                            Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
-                                        <TextBlock
-                                            Grid.Row="9"
-                                            Grid.Column="0"
-                                            Grid.ColumnSpan="2"
-                                            Margin="0 -4 0 0"
-                                            IsTextSelectionEnabled="True"
-                                            Style="{StaticResource Value}"
-                                            Text="{x:Bind ViewModel.XamlPath, Mode=OneWay}"
-                                            Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
-                                    </Grid>
+                                            <TextBlock
+                                                x:Uid="FontPropXaml"
+                                                Grid.Row="8"
+                                                Margin="0,4,0,0"
+                                                Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
+                                            <TextBlock
+                                                Grid.Row="9"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="2"
+                                                Margin="0,-4,0,0"
+                                                IsTextSelectionEnabled="True"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind ViewModel.XamlPath, Mode=OneWay}"
+                                                Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
+                                        </Grid>
 
-                                    <ItemsControl ItemsSource="{Binding SelectedVariant.FontInformation}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel Spacing="12" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <StackPanel Spacing="4">
-                                                    <TextBlock Opacity="0.5" Text="{Binding Key}" />
-                                                    <TextBlock
-                                                        IsTextSelectionEnabled="True"
-                                                        Style="{StaticResource Value}"
-                                                        Text="{Binding Value}" />
-                                                </StackPanel>
+                                        <ItemsControl ItemsSource="{Binding SelectedVariant.FontInformation}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <StackPanel Spacing="12" />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <StackPanel Spacing="4">
+                                                        <TextBlock Opacity="0.5" Text="{Binding Key}" />
+                                                        <TextBlock
+                                                            IsTextSelectionEnabled="True"
+                                                            Style="{StaticResource Value}"
+                                                            Text="{Binding Value}" />
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+
+                                    </StackPanel>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
+
+                        <Button
+                            x:Uid="FontOptionsButton"
+                            Width="44"
+                            Height="44"
+                            Margin="0,0,0,-8"
+                            VerticalAlignment="Bottom"
+                            IsEnabled="{Binding HasFontOptions}"
+                            Style="{ThemeResource TransparentButton}">
+                            <FontIcon
+                                Margin="0,0,-2,0"
+                                Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                                Glyph="&#xE890;" />
+                            <Button.Flyout>
+                                <Flyout Placement="Bottom">
+                                    <ListView
+                                        Width="300"
+                                        Padding="0"
+                                        ItemsSource="{x:Bind ViewModel.SelectedVariant.XamlTypographyFeatures, Mode=OneWay}"
+                                        SelectedItem="{Binding SelectedTypography, Mode=TwoWay}"
+                                        SelectionMode="Single"
+                                        ShowsScrollingPlaceholders="False"
+                                        SingleSelectionFollowsFocus="True">
+                                        <ListView.Header>
+                                            <StackPanel Margin="12,4" Spacing="12">
+                                                <TextBlock
+                                                    x:Name="ColorHeader"
+                                                    x:Uid="FontDisplayHeader"
+                                                    x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
+                                                    FontWeight="Bold"
+                                                    Opacity="0.5" />
+                                                <ToggleSwitch
+                                                    x:Name="ColorGlyphToggle"
+                                                    x:Uid="ColorGlyphToggle"
+                                                    VerticalAlignment="Bottom"
+                                                    x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
+                                                    IsOn="{Binding ShowColorGlyphs, Mode=TwoWay}" />
+                                                <TextBlock
+                                                    x:Uid="TypographyVariantsHeader"
+                                                    Margin="0,12,0,0"
+                                                    FontWeight="Bold"
+                                                    Opacity="0.5"
+                                                    Visibility="{x:Bind ViewModel.SelectedVariant.HasXamlTypographyFeatures, Mode=OneWay}" />
+                                            </StackPanel>
+                                        </ListView.Header>
+                                        <ListView.ItemTemplate>
+                                            <DataTemplate x:DataType="core:TypographyFeatureInfo">
+                                                <TextBlock Text="{x:Bind DisplayName}" />
                                             </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
+                                        </ListView.ItemTemplate>
+                                    </ListView>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
 
-                                </StackPanel>
-                            </Flyout>
-                        </Button.Flyout>
-                    </Button>
+                    </StackPanel>
 
                     <Button
-                        x:Uid="FontOptionsButton"
+                        Grid.Column="1"
                         Width="44"
                         Height="44"
-                        Margin="0 0 0 -8"
+                        Margin="0,0,0,-8"
                         VerticalAlignment="Bottom"
-                        IsEnabled="{Binding HasFontOptions}"
-                        Style="{ThemeResource TransparentButton}">
-                        <FontIcon
-                            Margin="0 0 -2 0"
-                            Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
-                            Glyph="&#xE890;" />
+                        Style="{ThemeResource TransparentButton}"
+                        Visibility="{x:Bind core:Converters.FalseToVis(IsStandalone)}">
                         <Button.Flyout>
-                            <Flyout Placement="Bottom">
-                                <ListView
-                                    Width="300"
-                                    Padding="0"
-                                    ItemsSource="{x:Bind ViewModel.SelectedVariant.XamlTypographyFeatures, Mode=OneWay}"
-                                    SelectedItem="{Binding SelectedTypography, Mode=TwoWay}"
-                                    SelectionMode="Single"
-                                    ShowsScrollingPlaceholders="False"
-                                    SingleSelectionFollowsFocus="True">
-                                    <ListView.Header>
-                                        <StackPanel Margin="12 4" Spacing="12">
-                                            <TextBlock
-                                                x:Name="ColorHeader"
-                                                x:Uid="FontDisplayHeader"
-                                                x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
-                                                FontWeight="Bold"
-                                                Opacity="0.5" />
-                                            <ToggleSwitch
-                                                x:Name="ColorGlyphToggle"
-                                                x:Uid="ColorGlyphToggle"
-                                                VerticalAlignment="Bottom"
-                                                x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
-                                                IsOn="{Binding ShowColorGlyphs, Mode=TwoWay}" />
-                                            <TextBlock
-                                                x:Uid="TypographyVariantsHeader"
-                                                Margin="0 12 0 0"
-                                                FontWeight="Bold"
-                                                Opacity="0.5"
-                                                Visibility="{x:Bind ViewModel.SelectedVariant.HasXamlTypographyFeatures, Mode=OneWay}" />
-                                        </StackPanel>
-                                    </ListView.Header>
-                                    <ListView.ItemTemplate>
-                                        <DataTemplate x:DataType="core:TypographyFeatureInfo">
-                                            <TextBlock Text="{x:Bind DisplayName}" />
-                                        </DataTemplate>
-                                    </ListView.ItemTemplate>
-                                </ListView>
-                            </Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem x:Uid="OpenInNewWindow" Click="{x:Bind ViewModel.OpenSelectedFontInWindow}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Margin="0,0,-2,0" Glyph="&#xE2B4;" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                            </MenuFlyout>
                         </Button.Flyout>
+                        <FontIcon
+                            Margin="0,0,-2,0"
+                            Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                            Glyph="&#xE10C;" />
                     </Button>
 
-                </StackPanel>
+                </Grid>
+
 
                 <GridView
                     x:Name="CharGrid"

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -298,6 +298,7 @@
                                                 <RowDefinition Height="Auto" />
                                                 <RowDefinition Height="Auto" />
                                                 <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
                                             </Grid.RowDefinitions>
 
 
@@ -313,49 +314,55 @@
                                                 Style="{StaticResource Value}"
                                                 Text="{Binding SelectedVariant.PreferredName}" />
 
-                                            <TextBlock x:Uid="FontPropType" Grid.Row="2" />
+                                            <TextBlock x:Uid="FontPropCount" Grid.Row="2" />
                                             <TextBlock
                                                 Grid.Row="2"
                                                 Style="{StaticResource Value}"
-                                                Text="{Binding SelectedVariant.FontFace.FileFormatType}" />
+                                                Text="{x:Bind ViewModel.SelectedVariant.FontFace.GlyphCount, Mode=OneWay}" />
 
-                                            <TextBlock x:Uid="FontPropSymbol" Grid.Row="3" />
+                                            <TextBlock x:Uid="FontPropType" Grid.Row="3" />
                                             <TextBlock
                                                 Grid.Row="3"
                                                 Style="{StaticResource Value}"
-                                                Text="{Binding SelectedVariant.FontFace.IsSymbolFont}" />
+                                                Text="{Binding SelectedVariant.FontFace.FileFormatType}" />
 
-                                            <TextBlock x:Uid="FontPropMonospaced" Grid.Row="4" />
+                                            <TextBlock x:Uid="FontPropSymbol" Grid.Row="4" />
                                             <TextBlock
                                                 Grid.Row="4"
                                                 Style="{StaticResource Value}"
-                                                Text="{Binding SelectedVariant.FontFace.IsMonospaced}" />
+                                                Text="{Binding SelectedVariant.FontFace.IsSymbolFont}" />
 
-                                            <TextBlock x:Uid="FontPropStyle" Grid.Row="5" />
+                                            <TextBlock x:Uid="FontPropMonospaced" Grid.Row="5" />
                                             <TextBlock
                                                 Grid.Row="5"
                                                 Style="{StaticResource Value}"
-                                                Text="{Binding SelectedVariant.FontFace.Style}" />
+                                                Text="{Binding SelectedVariant.FontFace.IsMonospaced}" />
 
-                                            <TextBlock x:Uid="FontPropStretch" Grid.Row="6" />
+                                            <TextBlock x:Uid="FontPropStyle" Grid.Row="6" />
                                             <TextBlock
                                                 Grid.Row="6"
                                                 Style="{StaticResource Value}"
-                                                Text="{Binding SelectedVariant.FontFace.Stretch}" />
+                                                Text="{Binding SelectedVariant.FontFace.Style}" />
 
-                                            <TextBlock x:Uid="FontPropWeight" Grid.Row="7" />
+                                            <TextBlock x:Uid="FontPropStretch" Grid.Row="7" />
                                             <TextBlock
                                                 Grid.Row="7"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.Stretch}" />
+
+                                            <TextBlock x:Uid="FontPropWeight" Grid.Row="8" />
+                                            <TextBlock
+                                                Grid.Row="8"
                                                 Style="{StaticResource Value}"
                                                 Text="{x:Bind ViewModel.SelectedVariant.FontFace.Weight.Weight.ToString(), Mode=OneWay}" />
 
                                             <TextBlock
                                                 x:Uid="FontPropXaml"
-                                                Grid.Row="8"
+                                                Grid.Row="9"
                                                 Margin="0,4,0,0"
                                                 Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
                                             <TextBlock
-                                                Grid.Row="9"
+                                                Grid.Row="10"
                                                 Grid.Column="0"
                                                 Grid.ColumnSpan="2"
                                                 Margin="0,-4,0,0"
@@ -363,6 +370,7 @@
                                                 Style="{StaticResource Value}"
                                                 Text="{x:Bind ViewModel.XamlPath, Mode=OneWay}"
                                                 Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
+
                                         </Grid>
 
                                         <ItemsControl ItemsSource="{Binding SelectedVariant.FontInformation}">

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -6,6 +6,7 @@ using GalaSoft.MvvmLight.Views;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
 using Windows.System;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
@@ -265,11 +266,13 @@ namespace CharacterMap.Views
 
     public partial class FontMapView
     {
-        public static async Task CreateNewViewForFontAsync(InstalledFont font)
+        public static async Task CreateNewViewForFontAsync(InstalledFont font, StorageFile sourceFile = null)
         {
             void CreateView()
             {
-                FontMapView map = new FontMapView { IsStandalone = true, ViewModel = { SelectedFont = font } };
+                FontMapView map = new FontMapView { 
+                    IsStandalone = true, 
+                    ViewModel = { SelectedFont = font, IsExternalFile = sourceFile != null, SourceFile = sourceFile } }; 
                 Window.Current.Content = map;
                 Window.Current.Activate();
             }

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using CharacterMap.Core;
+using CharacterMap.Helpers;
 using CharacterMap.Services;
 using CharacterMap.ViewModels;
 using CommonServiceLocator;
@@ -261,6 +262,18 @@ namespace CharacterMap.Views
         private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
             OnSearchBoxSubmittedQuery(SearchBox);
+        }
+
+        private void MenuFlyout_Opening(object sender, object e)
+        {
+            if (sender is MenuFlyout menu && ViewModel.SelectedFont is InstalledFont font)
+            {
+                FlyoutHelper.CreateMenu(
+                    menu,
+                    font,
+                    IsStandalone,
+                    DlgCreateCollection);
+            }
         }
     }
 

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -457,6 +457,8 @@
                                     <TextBlock
                                         Padding="5"
                                         VerticalAlignment="Center"
+                                        FontFamily="{x:Bind core:Converters.GetPreviewFontSource(DefaultVariant)}"
+                                        FontSize="16"
                                         Text="{x:Bind Name}"
                                         TextTrimming="CharacterEllipsis"
                                         TextWrapping="NoWrap" />
@@ -592,6 +594,9 @@
                         x:Name="BtnRestart"
                         x:Uid="RestartButton"
                         Click="BtnRestart_OnClick" />
+
+                    <TextBlock x:Uid="FontListDisplayHeader" Margin="0,40,0,4" />
+                    <ToggleSwitch x:Uid="FontListDisplayToggle" IsOn="{x:Bind Settings.UseFontForPreview, Mode=TwoWay}" />
 
                     <!--  Reenable after sorting out export UI issues  -->
                     <!--<TextBlock Margin="0 40 0 4" Text="Dev Utilities" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -87,6 +87,7 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <DropDownButton
+                    x:Name="FontListFilter"
                     Height="45"
                     Margin="0,0,0,0"
                     Padding="12,6"
@@ -109,6 +110,19 @@
                                 Tag="1"
                                 Text="Symbol Fonts" />
                             <MenuFlyoutItem
+                                x:Uid="OptionMonospacedFonts"
+                                Click="Filter_Click"
+                                Tag="3" />
+                            <MenuFlyoutItem
+                                x:Uid="OptionSerifFonts"
+                                Click="Filter_Click"
+                                Tag="4" />
+                            <MenuFlyoutItem
+                                x:Uid="OptionSansSerifFonts"
+                                Click="Filter_Click"
+                                Tag="5" />
+                            <MenuFlyoutSeparator />
+                            <MenuFlyoutItem
                                 x:Uid="OptionImportedFonts"
                                 Click="Filter_Click"
                                 Tag="2"
@@ -124,7 +138,8 @@
                     Width="45"
                     Height="45"
                     VerticalAlignment="Bottom"
-                    Click="{x:Bind PickFonts}">
+                    Click="{x:Bind PickFonts}"
+                    Visibility="Collapsed">
                     <FontIcon
                         FontSize="16"
                         Glyph="&#xE109;"

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -86,19 +86,37 @@
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <ComboBox
-                    x:Name="FontListFilter"
+                <DropDownButton
                     Height="45"
                     Margin="0,0,0,0"
+                    Padding="12,6"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
-                    FontSize="16"
-                    SelectedIndex="{Binding FontListFilter, Mode=TwoWay}">
-                    <ComboBoxItem x:Uid="FilterAllFonts" />
-                    <ComboBoxItem x:Uid="FilterSymbolFonts" />
-                    <ComboBoxItem x:Uid="FilterImportedFonts" />
-                    <!--<ComboBoxItem Content="Favorites" />-->
-                </ComboBox>
+                    HorizontalContentAlignment="Left"
+                    Background="Transparent"
+                    Content="{x:Bind ViewModel.FilterTitle, Mode=OneWay}"
+                    FontSize="16">
+                    <DropDownButton.Flyout>
+                        <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
+                            <MenuFlyoutItem
+                                x:Uid="OptionAllFonts"
+                                Click="Filter_Click"
+                                Tag="0"
+                                Text="All Fonts" />
+                            <MenuFlyoutItem
+                                x:Uid="OptionSymbolFonts"
+                                Click="Filter_Click"
+                                Tag="1"
+                                Text="Symbol Fonts" />
+                            <MenuFlyoutItem
+                                x:Uid="OptionImportedFonts"
+                                Click="Filter_Click"
+                                Tag="2"
+                                Text="Imported Fonts" />
+                        </MenuFlyout>
+                    </DropDownButton.Flyout>
+                </DropDownButton>
+
                 <AppBarButton
                     x:Name="ImportFontsButton"
                     x:Uid="ImportFontsButton"
@@ -166,12 +184,12 @@
                     <Flyout>
                         <StackPanel Width="260">
                             <ToggleSwitch
-                                Margin="0 4"
+                                Margin="0,4"
                                 IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}"
                                 OffContent="Disabled instant search"
                                 OnContent="Enabled instant search" />
                             <Slider
-                                Margin="0 4"
+                                Margin="0,4"
                                 Header="Delay before search (ms)"
                                 Maximum="3000"
                                 Minimum="250"
@@ -179,7 +197,7 @@
                                 Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"
                                 Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}" />
                             <Slider
-                                Margin="0 4"
+                                Margin="0,4"
                                 Header="Maximum preview search result"
                                 Maximum="100"
                                 Minimum="5"
@@ -196,7 +214,7 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <FontIcon
-                                Margin="4 0 0 0"
+                                Margin="4,0,0,0"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontFamily="{Binding ElementName=FontMap, Path=ViewModel.FontFamily}"
@@ -221,7 +239,7 @@
                 <Grid>
                     <FontIcon Glyph="&#xE11A;" />
                     <FontIcon
-                        Margin="0 3 3 0"
+                        Margin="0,3,3,0"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
                         FontSize="7"
@@ -231,12 +249,12 @@
                     <Flyout Placement="Bottom">
                         <StackPanel>
                             <ToggleSwitch
-                                Margin="0 4"
+                                Margin="0,4"
                                 IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}"
                                 OffContent="Disabled instant search"
                                 OnContent="Enabled instant search" />
                             <Slider
-                                Margin="0 4"
+                                Margin="0,4"
                                 Header="Delay before search (ms)"
                                 Maximum="3000"
                                 Minimum="250"
@@ -244,7 +262,7 @@
                                 Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"
                                 Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}" />
                             <Slider
-                                Margin="0 4"
+                                Margin="0,4"
                                 Header="Maximum preview search result"
                                 Maximum="100"
                                 Minimum="5"
@@ -276,9 +294,43 @@
             Grid.Column="0"
             Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
 
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <Border x:Name="CollectionControlRow" x:Load="{x:Bind core:Converters.IsNotNull(ViewModel.SelectedCollection), Mode=OneWay, TargetNullValue=False, FallbackValue=False}">
+                <Border.Background>
+                    <SolidColorBrush Opacity="0.4" Color="{ThemeResource SystemAccentColor}" />
+                </Border.Background>
+                <StackPanel
+                    Padding="0,0"
+                    HorizontalAlignment="Center"
+                    Orientation="Horizontal"
+                    Spacing="12">
+
+                    <AppBarButton
+                        x:Uid="RenameCollectionButton"
+                        Height="48"
+                        Click="RenameFontCollection_Click"
+                        Icon="Rename"
+                        ToolTipService.Placement="Bottom" />
+                    <AppBarButton
+                        x:Uid="DeleteCollectionButton"
+                        Height="48"
+                        Click="DeleteCollection_Click"
+                        Icon="Delete"
+                        ToolTipService.Placement="Bottom" />
+                </StackPanel>
+
+            </Border>
+
+
+
             <TextBlock
                 x:Name="ImportFontHelpBlock"
                 x:Uid="ImportFontHelpBlock"
+                Grid.Row="1"
                 Margin="12"
                 FontSize="13"
                 Opacity="0.7"
@@ -286,7 +338,7 @@
                 Text=""
                 Visibility="Collapsed" />
 
-            <SemanticZoom x:Name="FontsSemanticZoom">
+            <SemanticZoom x:Name="FontsSemanticZoom" Grid.Row="1">
                 <SemanticZoom.ZoomedInView>
                     <ListView
                         x:Name="LstFontFamily"
@@ -338,7 +390,7 @@
                             <DataTemplate x:DataType="core:InstalledFont">
                                 <Grid Background="Transparent" ColumnSpacing="12">
                                     <Grid.ContextFlyout>
-                                        <MenuFlyout>
+                                        <MenuFlyout Opening="FontContextFlyout_Opening">
                                             <MenuFlyoutItem x:Uid="OpenInNewWindow" Click="OpenInWindowFlyoutItem_Click">
                                                 <MenuFlyoutItem.Icon>
                                                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE2B4;" />
@@ -354,6 +406,30 @@
                                                     <SymbolIcon Symbol="Delete" />
                                                 </MenuFlyoutItem.Icon>
                                             </MenuFlyoutItem>
+                                            <!--<MenuFlyoutItem
+                                                x:Name="RemoveFromCollectionItem"
+                                                x:Uid="RemoveFromCollectionItem"
+                                                Tag="{x:Bind}">
+                                                <MenuFlyoutItem.Icon>
+                                                    <SymbolIcon Symbol="Remove" />
+                                                </MenuFlyoutItem.Icon>
+                                            </MenuFlyoutItem>-->
+                                            <MenuFlyoutSubItem Text="Add to Collection">
+                                                <MenuFlyoutSubItem.Icon>
+                                                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE71D;" />
+                                                </MenuFlyoutSubItem.Icon>
+                                                <MenuFlyoutItem Click="CreateFontCollection_Click" Text="New Collection">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <SymbolIcon Symbol="Add" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutSeparator />
+                                                <MenuFlyoutItem
+                                                    x:Name="SymbolFontItem"
+                                                    Click="AddToSymbolFonts_Click"
+                                                    Text="Symbol Fonts" />
+                                                <MenuFlyoutSeparator />
+                                            </MenuFlyoutSubItem>
                                         </MenuFlyout>
                                     </Grid.ContextFlyout>
                                     <Grid.ColumnDefinitions>
@@ -522,6 +598,57 @@
 
             </ScrollViewer>
         </ContentDialog>
+
+        <ContentDialog
+            x:Name="DigCreateCollection"
+            x:Uid="DigCreateCollection"
+            Grid.Row="0"
+            Grid.RowSpan="3"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            d:IsHidden="True"
+            IsPrimaryButtonEnabled="{x:Bind ViewModel.IsCollectionTitleValid, Mode=OneWay}"
+            PrimaryButtonClick="DigCreateCollection_PrimaryButtonClick"
+            SecondaryButtonClick="{x:Bind DigCreateCollection.Hide}">
+            <TextBox
+                x:Uid="CreateCollectionEntryBox"
+                Margin="-14,0"
+                DataContext="{x:Bind ViewModel}"
+                Header="Collection Name"
+                Text="{Binding CollectionTitle, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        </ContentDialog>
+        <ContentDialog
+            x:Name="DigRenameCollection"
+            x:Uid="DigRenameCollection"
+            Grid.Row="0"
+            Grid.RowSpan="3"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            d:IsHidden="True"
+            IsPrimaryButtonEnabled="{x:Bind ViewModel.IsCollectionTitleValid, Mode=OneWay}"
+            IsSecondaryButtonEnabled="True"
+            PrimaryButtonClick="DigRenameCollection_PrimaryButtonClick"
+            SecondaryButtonClick="{x:Bind DigRenameCollection.Hide}">
+            <TextBox
+                x:Uid="CreateCollectionEntryBox"
+                Margin="-14,0"
+                DataContext="{x:Bind ViewModel}"
+                Header="Collection Name"
+                Text="{Binding CollectionTitle, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        </ContentDialog>
+        <ContentDialog
+            x:Name="DigDeleteCollection"
+            x:Uid="DigDeleteCollection"
+            Grid.Row="0"
+            Grid.RowSpan="3"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            d:IsHidden="True"
+            IsPrimaryButtonEnabled="True"
+            IsSecondaryButtonEnabled="True"
+            PrimaryButtonClick="DigDeleteCollection_PrimaryButtonClick"
+            SecondaryButtonClick="{x:Bind DigDeleteCollection.Hide}" />
+
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LoadingStates">

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -102,13 +102,11 @@
                             <MenuFlyoutItem
                                 x:Uid="OptionAllFonts"
                                 Click="Filter_Click"
-                                Tag="0"
-                                Text="All Fonts" />
+                                Tag="0" />
                             <MenuFlyoutItem
                                 x:Uid="OptionSymbolFonts"
                                 Click="Filter_Click"
-                                Tag="1"
-                                Text="Symbol Fonts" />
+                                Tag="1" />
                             <MenuFlyoutItem
                                 x:Uid="OptionMonospacedFonts"
                                 Click="Filter_Click"
@@ -125,8 +123,7 @@
                             <MenuFlyoutItem
                                 x:Uid="OptionImportedFonts"
                                 Click="Filter_Click"
-                                Tag="2"
-                                Text="Imported Fonts" />
+                                Tag="2" />
                         </MenuFlyout>
                     </DropDownButton.Flyout>
                 </DropDownButton>
@@ -199,10 +196,9 @@
                     <Flyout>
                         <StackPanel Width="260">
                             <ToggleSwitch
+                                x:Uid="InstantSearchToggle"
                                 Margin="0,4"
-                                IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}"
-                                OffContent="Disabled instant search"
-                                OnContent="Enabled instant search" />
+                                IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" />
                             <Slider
                                 Margin="0,4"
                                 Header="Delay before search (ms)"
@@ -212,8 +208,8 @@
                                 Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"
                                 Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}" />
                             <Slider
+                                x:Uid="SearchResultsSlider"
                                 Margin="0,4"
-                                Header="Maximum preview search result"
                                 Maximum="100"
                                 Minimum="5"
                                 TickFrequency="1"
@@ -264,10 +260,9 @@
                     <Flyout Placement="Bottom">
                         <StackPanel>
                             <ToggleSwitch
+                                x:Uid="InstantSearchToggle"
                                 Margin="0,4"
-                                IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}"
-                                OffContent="Disabled instant search"
-                                OnContent="Enabled instant search" />
+                                IsOn="{x:Bind Settings.UseInstantSearch, Mode=TwoWay}" />
                             <Slider
                                 Margin="0,4"
                                 Header="Delay before search (ms)"
@@ -277,8 +272,8 @@
                                 Visibility="{x:Bind core:Converters.TrueToVis(Settings.UseInstantSearch), Mode=OneWay}"
                                 Value="{x:Bind Settings.InstantSearchDelay, Mode=TwoWay}" />
                             <Slider
+                                x:Uid="SearchResultsSlider"
                                 Margin="0,4"
-                                Header="Maximum preview search result"
                                 Maximum="100"
                                 Minimum="5"
                                 TickFrequency="1"
@@ -405,35 +400,8 @@
                             <DataTemplate x:DataType="core:InstalledFont">
                                 <Grid Background="Transparent" ColumnSpacing="12">
                                     <Grid.ContextFlyout>
-                                        <MenuFlyout Opening="FontContextFlyout_Opening">
-                                            <MenuFlyoutItem x:Uid="OpenInNewWindow" Click="OpenInWindowFlyoutItem_Click">
-                                                <MenuFlyoutItem.Icon>
-                                                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE2B4;" />
-                                                </MenuFlyoutItem.Icon>
-                                            </MenuFlyoutItem>
-                                            <MenuFlyoutItem
-                                                x:Name="RemoveFontItem"
-                                                x:Uid="RemoveFontFlyout"
-                                                x:Load="{x:Bind HasImportedFiles}"
-                                                Click="RemoveMenuFlyoutItem_Click"
-                                                Tag="{x:Bind}">
-                                                <MenuFlyoutItem.Icon>
-                                                    <SymbolIcon Symbol="Delete" />
-                                                </MenuFlyoutItem.Icon>
-                                            </MenuFlyoutItem>
-                                            <MenuFlyoutSubItem Text="Add to Collection" />
-                                            <MenuFlyoutItem
-                                                x:Name="RemoveFromCollectionItem"
-                                                x:Uid="RemoveFromCollectionItem"
-                                                Click="RemoveFromCollectionItem_Click"
-                                                Tag="{x:Bind}"
-                                                Text="Remove from Collection"
-                                                Visibility="Collapsed">
-                                                <MenuFlyoutItem.Icon>
-                                                    <SymbolIcon Symbol="Remove" />
-                                                </MenuFlyoutItem.Icon>
-                                            </MenuFlyoutItem>
-                                        </MenuFlyout>
+                                        <!--  Menu content created dynamically  -->
+                                        <MenuFlyout Opening="FontContextFlyout_Opening" />
                                     </Grid.ContextFlyout>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
@@ -610,24 +578,14 @@
             </ScrollViewer>
         </ContentDialog>
 
-        <ContentDialog
+        <controls:CreateCollectionDialog
             x:Name="DigCreateCollection"
-            x:Uid="DigCreateCollection"
             Grid.Row="0"
             Grid.RowSpan="3"
             Grid.Column="0"
             Grid.ColumnSpan="2"
-            d:IsHidden="True"
-            IsPrimaryButtonEnabled="{x:Bind ViewModel.IsCollectionTitleValid, Mode=OneWay}"
-            PrimaryButtonClick="DigCreateCollection_PrimaryButtonClick"
-            SecondaryButtonClick="{x:Bind DigCreateCollection.Hide}">
-            <TextBox
-                x:Uid="CreateCollectionEntryBox"
-                Margin="-14,0"
-                DataContext="{x:Bind ViewModel}"
-                Header="Collection Name"
-                Text="{Binding CollectionTitle, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        </ContentDialog>
+            d:IsHidden="True" />
+
         <ContentDialog
             x:Name="DigRenameCollection"
             x:Uid="DigRenameCollection"
@@ -646,6 +604,7 @@
                 DataContext="{x:Bind ViewModel}"
                 Text="{Binding CollectionTitle, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         </ContentDialog>
+
         <ContentDialog
             x:Name="DigDeleteCollection"
             x:Uid="DigDeleteCollection"

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -421,22 +421,7 @@
                                                     <SymbolIcon Symbol="Delete" />
                                                 </MenuFlyoutItem.Icon>
                                             </MenuFlyoutItem>
-                                            <MenuFlyoutSubItem Text="Add to Collection">
-                                                <MenuFlyoutSubItem.Icon>
-                                                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE71D;" />
-                                                </MenuFlyoutSubItem.Icon>
-                                                <MenuFlyoutItem Click="CreateFontCollection_Click" Text="New Collection">
-                                                    <MenuFlyoutItem.Icon>
-                                                        <SymbolIcon Symbol="Add" />
-                                                    </MenuFlyoutItem.Icon>
-                                                </MenuFlyoutItem>
-                                                <MenuFlyoutSeparator />
-                                                <MenuFlyoutItem
-                                                    x:Name="SymbolFontItem"
-                                                    Click="AddToSymbolFonts_Click"
-                                                    Text="Symbol Fonts" />
-                                                <MenuFlyoutSeparator />
-                                            </MenuFlyoutSubItem>
+                                            <MenuFlyoutSubItem Text="Add to Collection" />
                                             <MenuFlyoutItem
                                                 x:Name="RemoveFromCollectionItem"
                                                 x:Uid="RemoveFromCollectionItem"
@@ -596,7 +581,10 @@
                         Click="BtnRestart_OnClick" />
 
                     <TextBlock x:Uid="FontListDisplayHeader" Margin="0,40,0,4" />
-                    <ToggleSwitch x:Uid="FontListDisplayToggle" IsOn="{x:Bind Settings.UseFontForPreview, Mode=TwoWay}" />
+                    <ToggleSwitch
+                        x:Uid="FontListDisplayToggle"
+                        IsOn="{x:Bind Settings.UseFontForPreview, Mode=TwoWay}"
+                        Toggled="FontListDisplayToggleSwitch_Toggled" />
 
                     <!--  Reenable after sorting out export UI issues  -->
                     <!--<TextBlock Margin="0 40 0 4" Text="Dev Utilities" />
@@ -656,7 +644,6 @@
                 x:Uid="CreateCollectionEntryBox"
                 Margin="-14,0"
                 DataContext="{x:Bind ViewModel}"
-                Header="Collection Name"
                 Text="{Binding CollectionTitle, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         </ContentDialog>
         <ContentDialog
@@ -684,7 +671,8 @@
                         <Setter Target="FontMap.Opacity" Value="0" />
                         <Setter Target="FontMap.IsHitTestVisible" Value="False" />
                         <Setter Target="FontTitleBlock.Visibility" Value="Collapsed" />
-                        <Setter Target="FontListFilter.IsEnabled" Value="False" />
+                        <Setter Target="FontListFilter.IsHitTestVisible" Value="False" />
+                        <Setter Target="FontListFilter.Opacity" Value="0.4" />
                         <Setter Target="SearchBox.IsEnabled" Value="False" />
                         <Setter Target="ImportFontsButton.IsEnabled" Value="False" />
                         <Setter Target="OpenFontButton.IsEnabled" Value="False" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -406,14 +406,6 @@
                                                     <SymbolIcon Symbol="Delete" />
                                                 </MenuFlyoutItem.Icon>
                                             </MenuFlyoutItem>
-                                            <!--<MenuFlyoutItem
-                                                x:Name="RemoveFromCollectionItem"
-                                                x:Uid="RemoveFromCollectionItem"
-                                                Tag="{x:Bind}">
-                                                <MenuFlyoutItem.Icon>
-                                                    <SymbolIcon Symbol="Remove" />
-                                                </MenuFlyoutItem.Icon>
-                                            </MenuFlyoutItem>-->
                                             <MenuFlyoutSubItem Text="Add to Collection">
                                                 <MenuFlyoutSubItem.Icon>
                                                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE71D;" />
@@ -430,6 +422,17 @@
                                                     Text="Symbol Fonts" />
                                                 <MenuFlyoutSeparator />
                                             </MenuFlyoutSubItem>
+                                            <MenuFlyoutItem
+                                                x:Name="RemoveFromCollectionItem"
+                                                x:Uid="RemoveFromCollectionItem"
+                                                Click="RemoveFromCollectionItem_Click"
+                                                Tag="{x:Bind}"
+                                                Text="Remove from Collection"
+                                                Visibility="Collapsed">
+                                                <MenuFlyoutItem.Icon>
+                                                    <SymbolIcon Symbol="Remove" />
+                                                </MenuFlyoutItem.Icon>
+                                            </MenuFlyoutItem>
                                         </MenuFlyout>
                                     </Grid.ContextFlyout>
                                     <Grid.ColumnDefinitions>

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -31,6 +31,8 @@ namespace CharacterMap.Views
 
         public static CoreDispatcher MainDispatcher { get; private set; }
 
+        private Debouncer _fontListDebouncer { get; } = new Debouncer();
+
         public MainPage()
         {
             InitializeComponent();
@@ -413,7 +415,10 @@ namespace CharacterMap.Views
         {
             if (ViewModel.InitialLoad.IsCompleted)
             {
-                ViewModel.RefreshFontList(ViewModel.SelectedCollection);
+                _fontListDebouncer.Debounce(16, () =>
+                {
+                    ViewModel.RefreshFontList(ViewModel.SelectedCollection);
+                });
             }
         }
     }

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -260,9 +260,14 @@ namespace CharacterMap.Views
         {
             if (sender is MenuFlyout menu)
             {
-                while (menu.Items.Count > 3)
-                    menu.Items.RemoveAt(3);
+                // Reset to default menu
+                while (menu.Items.Count > 7)
+                    menu.Items.RemoveAt(7);
 
+                // force menu width to match the source button
+                menu.Items.OfType<MenuFlyoutSeparator>().Last().Width = FontListFilter.ActualWidth;
+
+                // add users collections 
                 if (ViewModel.FontCollections.Items.Count > 0)
                 {
                     menu.Items.Add(new MenuFlyoutSeparator());


### PR DESCRIPTION
Additions: 
- New setting to allow the preview of font titles in font list using the actual font (except for fonts marked as Symbol fonts). Defaults to OFF / current behaviour.
- Ability to create custom collections of fonts
- Ability to mark any font as a symbol font
- Several system-defined collections (Monospace, Serif, Sans Serif)
- Included glyph count in font information popup

Covers #15 

![snap1](https://user-images.githubusercontent.com/2319473/74462871-d38d6800-4e88-11ea-9397-dcfcabc0598a.png)
![snap2](https://user-images.githubusercontent.com/2319473/74462886-d7b98580-4e88-11ea-9012-a4c5433cbbb2.png)
![snap3](https://user-images.githubusercontent.com/2319473/74462933-eef87300-4e88-11ea-9d87-20d4d0bbd977.png)
