### PR TITLE
Improve support for fonts with technically invalid character ranges

### DIFF
--- a/CharacterMap/CharacterMap/Core/FontVariant.cs
+++ b/CharacterMap/CharacterMap/Core/FontVariant.cs
@@ -104,7 +104,6 @@ namespace CharacterMap.Core
             if (Characters.Count == 0)
             {
                 var characters = new List<Character>();
-
                 foreach (var range in FontFace.UnicodeRanges)
                 {
                     CharacterHash += range.First;
@@ -114,7 +113,7 @@ namespace CharacterMap.Core
                     {
                         characters.Add(new Character
                         {
-                            Char = char.ConvertFromUtf32((int)i),
+                            Char = new string((char)i, 1),
                             UnicodeIndex = (int)i
                         });
                     }

--- a/CharacterMap/CharacterMap/Core/PanoseParser.cs
+++ b/CharacterMap/CharacterMap/Core/PanoseParser.cs
@@ -10,6 +10,7 @@ namespace CharacterMap.Core
     public class Panose
     {
         public bool IsSansSerifStyle { get; }
+        public bool IsSerifStyle { get; }
         public SerifStyle Style { get; }
         public PanoseFamily Family { get; }
 
@@ -18,6 +19,13 @@ namespace CharacterMap.Core
             Family = family;
             Style = style;
             IsSansSerifStyle = PanoseParser.IsSansSerif(Style);
+            IsSerifStyle = 
+                Style != SerifStyle.Any 
+                && Style != SerifStyle.NoFit
+                && Family != PanoseFamily.NoFit
+                && Family != PanoseFamily.Script
+                && Family != PanoseFamily.Decorative
+                && !IsSansSerifStyle;
         }
     }
 
@@ -49,11 +57,7 @@ namespace CharacterMap.Core
 
         public static bool IsSansSerif(SerifStyle style)
         {
-            return
-                style == SerifStyle.NormalSans ||
-                style == SerifStyle.ObtuseSans ||
-                style == SerifStyle.PerpendicularSans ||
-                style == SerifStyle.PerpSans;
+            return style >= SerifStyle.NormalSans;
         }
     }
 }

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -205,7 +205,7 @@ namespace CharacterMap.ViewModels
                     }
                     else if (FontListFilter == 4)
                     {
-                        fontList = fontList.Where(f => !f.DefaultVariant.Panose.IsSansSerifStyle);
+                        fontList = fontList.Where(f => f.DefaultVariant.Panose.IsSerifStyle);
                         FilterTitle = Localization.Get("OptionSerifFonts/Text");
                     }
                     else if (FontListFilter == 5)

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -300,7 +300,12 @@ namespace CharacterMap.Views
                         m.Click += (s, a) =>
                         {
                             if (m.DataContext is UserFontCollection u)
+                            {
+                                if (!FontsSemanticZoom.IsZoomedInViewActive)
+                                    FontsSemanticZoom.IsZoomedInViewActive = true;
+
                                 ViewModel.SelectedCollection = u;
+                            }
                         };
                         menu.Items.Add(m);
                     }
@@ -366,6 +371,9 @@ namespace CharacterMap.Views
         {
             if (sender is FrameworkElement f)
             {
+                if (!FontsSemanticZoom.IsZoomedInViewActive)
+                    FontsSemanticZoom.IsZoomedInViewActive = true;
+
                 var filter = Convert.ToInt32(f.Tag.ToString(), 10);
                 if (filter == ViewModel.FontListFilter)
                     ViewModel.RefreshFontList();


### PR DESCRIPTION
A test of this issue is with the LastResort font from here: https://unicode.org/policies/lastresortfont_eula.html

This is a font that by design includes glyphs for technically invalid unicode characters that will still render and display properly - these characters are included for debugging purposes to help developers visualise text rendering issues.

However `char.ConvertFromUtf32` is designed to throw an exception when finding these "invalid" characters. But we want to show them as:
 - they are characters in the font
 - we currently just throw an exception and prevent the entire font loading if we hit one of these

By directly creating the string rather than using the conversion we avoid the check and correctly show the glyphs in app - the glyph itself is a symbol for invalid unicode character!
