### PR TITLE
Workaround issue in Win2D when loading fonts.

### DIFF
--- a/CharacterMap/CharacterMap.CX/Interop.cpp
+++ b/CharacterMap/CharacterMap.CX/Interop.cpp
@@ -26,6 +26,16 @@ Interop::Interop(CanvasDevice^ device)
 		&m_d2dContext);
 }
 
+CanvasFontSet^ Interop::GetSystemFonts(bool includeDownloadableFonts)
+{
+	ComPtr<IDWriteFontCollection1> fontCollection;
+	ComPtr<IDWriteFontSet> fontSet;
+	ThrowIfFailed(m_dwriteFactory->GetSystemFontCollection(includeDownloadableFonts, &fontCollection, true));
+	fontCollection->GetFontSet(&fontSet);
+	fontCollection = nullptr;
+	return GetOrCreate<CanvasFontSet>(fontSet.Get());
+}
+
 CanvasTextLayoutAnalysis^ Interop::AnalyzeFontLayout(CanvasTextLayout^ layout)
 {
 	ComPtr<IDWriteTextLayout3> context = GetWrappedResource<IDWriteTextLayout4>(layout);

--- a/CharacterMap/CharacterMap.CX/Interop.h
+++ b/CharacterMap/CharacterMap.CX/Interop.h
@@ -21,6 +21,7 @@ namespace CharacterMapCX
 		CanvasTextLayoutAnalysis^ AnalyzeFontLayout(CanvasTextLayout^ layout);
 		CanvasTextLayoutAnalysis^ AnalyzeCharacterLayout(CanvasTextLayout^ layout);
 		bool HasValidFonts(Uri^ uri);
+		CanvasFontSet^ GetSystemFonts(bool includeDownloadableFonts);
 
 	private:
 		Microsoft::WRL::ComPtr<IDWriteFactory4> m_dwriteFactory;

--- a/CharacterMap/CharacterMap/Core/FontFinder.cs
+++ b/CharacterMap/CharacterMap/Core/FontFinder.cs
@@ -54,7 +54,9 @@ namespace CharacterMap.Core
         public static async Task<CanvasFontSet> InitialiseAsync()
         {
             await _initSemaphore.WaitAsync().ConfigureAwait(false);
-            var systemFonts = CanvasFontSet.GetSystemFontSet();
+
+            Interop interop = SimpleIoc.Default.GetInstance<Interop>();
+            CanvasFontSet systemFonts = interop.GetSystemFonts(true);
 
             try
             {


### PR DESCRIPTION
Relating to the issue I posted on the Win2D GitHub:
https://github.com/microsoft/Win2D/issues/759

The default way of loading font sets will throw an exception currently if an Office app with recently-loaded cloud fonts is running. 

This works around it by directly loading the fonts ourselves in D2D then casting the result to the Win2D equivalent. (This also affect a number of other character maps / font viewers on the store)