### PR TITLE
Rename RequestedTheme setting to avoid conflict with legacy setting

### DIFF
--- a/CharacterMap/CharacterMap/Core/AppSettings.cs
+++ b/CharacterMap/CharacterMap/Core/AppSettings.cs
@@ -88,7 +88,7 @@ namespace CharacterMap.Core
             set => BroadcastSet(value);
         }
 
-        public ElementTheme RequestedTheme
+        public ElementTheme UserRequestedTheme
         {
             get => (ElementTheme)Get((int)ElementTheme.Default);
             set => BroadcastSet((int)value);
@@ -144,8 +144,8 @@ namespace CharacterMap.Core
 
         private T Get<T>(T defaultValue, [CallerMemberName]string key = null)
         {
-            if (LocalSettings.Values.TryGetValue(key, out object value))
-                return (T)value;
+            if (LocalSettings.Values.TryGetValue(key, out object value) && value is T val)
+                return val;
 
             if (defaultValue != null)
                 return defaultValue;

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -84,7 +84,7 @@ namespace CharacterMap.Views
 
         public FontMapView()
         {
-            RequestedTheme = ResourceHelper.AppSettings.RequestedTheme;
+            RequestedTheme = ResourceHelper.AppSettings.UserRequestedTheme;
 
             InitializeComponent();
             Loading += FontMapView_Loading;
@@ -204,8 +204,8 @@ namespace CharacterMap.Views
                     case nameof(AppSettings.GridSize):
                         UpdateDisplay();
                         break;
-                    case nameof(AppSettings.RequestedTheme):
-                        this.RequestedTheme = ViewModel.Settings.RequestedTheme;
+                    case nameof(AppSettings.UserRequestedTheme):
+                        this.RequestedTheme = ViewModel.Settings.UserRequestedTheme;
                         OnPropertyChanged(nameof(ThemeLock));
                         break;
                     case nameof(AppSettings.UseInstantSearch):

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -48,7 +48,7 @@ namespace CharacterMap.Views
 
         public MainPage()
         {
-            RequestedTheme = ResourceHelper.AppSettings.RequestedTheme;
+            RequestedTheme = ResourceHelper.AppSettings.UserRequestedTheme;
 
             InitializeComponent();
 
@@ -70,7 +70,7 @@ namespace CharacterMap.Views
             {
                 _ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    Messenger.Default.Send(new AppSettingsChangedMessage(nameof(AppSettings.RequestedTheme)));
+                    Messenger.Default.Send(new AppSettingsChangedMessage(nameof(AppSettings.UserRequestedTheme)));
                 });
             };
         }
@@ -112,8 +112,8 @@ namespace CharacterMap.Views
                 case nameof(AppSettings.UseFontForPreview):
                     OnFontPreviewUpdated();
                     break;
-                case nameof(AppSettings.RequestedTheme):
-                    this.RequestedTheme = ViewModel.Settings.RequestedTheme;
+                case nameof(AppSettings.UserRequestedTheme):
+                    this.RequestedTheme = ViewModel.Settings.UserRequestedTheme;
                     OnPropertyChanged(nameof(ThemeLock));
                     break;
             }

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -82,7 +82,7 @@ namespace CharacterMap.Views
 
         void OnAppSettingsUpdated(AppSettingsChangedMessage msg)
         {
-            if (msg.PropertyName == nameof(Settings.RequestedTheme))
+            if (msg.PropertyName == nameof(Settings.UserRequestedTheme))
                 OnPropertyChanged(nameof(Settings));
         }
 
@@ -125,7 +125,7 @@ namespace CharacterMap.Views
 
             // Set the settings that can't be set with bindings
 
-            switch (Settings.RequestedTheme)
+            switch (Settings.UserRequestedTheme)
             {
                 case ElementTheme.Default:
                     ThemeSystem.IsChecked = true;
@@ -165,17 +165,17 @@ namespace CharacterMap.Views
 
         private void ThemeLight_Checked(object sender, RoutedEventArgs e)
         {
-            Settings.RequestedTheme = ElementTheme.Light;
+            Settings.UserRequestedTheme = ElementTheme.Light;
         }
 
         private void ThemeDark_Checked(object sender, RoutedEventArgs e)
         {
-            Settings.RequestedTheme = ElementTheme.Dark;
+            Settings.UserRequestedTheme = ElementTheme.Dark;
         }
 
         private void ThemeSystem_Checked(object sender, RoutedEventArgs e)
         {
-            Settings.RequestedTheme = ElementTheme.Default;
+            Settings.UserRequestedTheme = ElementTheme.Default;
         }
 
         private void RadioButtons_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
In what I hope is the fix for #76 , looking back over older commits it seems the legacy `ThemeSelectorService` (removed 19 November 2017) used to save its theme setting also to a key called `RequestedTheme`, but as a string rather than an int. 

To avoid clashing with anyone who has had the app installed since theme, renaming the new `RequestedTheme` property to `UserRequestedTheme` should avoid that.