### PR TITLE
Fix #80: Null reference exception

### DIFF
--- a/CharacterMap/CharacterMap/Controls/UnhandledExceptionDialog.xaml.cs
+++ b/CharacterMap/CharacterMap/Controls/UnhandledExceptionDialog.xaml.cs
@@ -43,6 +43,11 @@ namespace CharacterMap.Controls
         private void HyperlinkButton_Click(object sender, RoutedEventArgs e)
         {
             StringBuilder sb = new StringBuilder();
+            sb.AppendLine($"<!-- If possible, please describe what you were doing before the issue occurred -->");
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("<!-- Please do not edit below this line -->");
             sb.AppendLine($"```\n{ExceptionBlock.Text}\n```");
             sb.AppendLine();
             sb.AppendLine($"**OS Version**: {SystemInformation.OperatingSystemVersion}");

--- a/CharacterMap/CharacterMap/Core/AppSettings.cs
+++ b/CharacterMap/CharacterMap/Core/AppSettings.cs
@@ -126,7 +126,7 @@ namespace CharacterMap.Core
 
         private bool Set(object value, [CallerMemberName]string key = null)
         {
-            if (LocalSettings.Values.TryGetValue(key, out object t) && t.Equals(value))
+            if (LocalSettings.Values.TryGetValue(key, out object t) && t != null && t.Equals(value))
                 return false;
 
             LocalSettings.Values[key] = value;

--- a/CharacterMap/CharacterMap/Services/UserCollectionsService.cs
+++ b/CharacterMap/CharacterMap/Services/UserCollectionsService.cs
@@ -49,7 +49,7 @@ namespace CharacterMap.Services
 
         public bool IsSymbolFont(InstalledFont font)
         {
-            return font.IsSymbolFont || SymbolCollection.Fonts.Contains(font.Name);
+            return font != null && (font.IsSymbolFont || SymbolCollection.Fonts.Contains(font.Name));
         }
 
         public async Task LoadCollectionsAsync()

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -37,14 +37,13 @@ namespace CharacterMap.Views
 
         private Random _random { get; } = new Random();
 
-        private UISettings _uiSettings { get; }
-
         public AppSettings Settings { get; }
         public UserCollectionsService FontCollections { get; }
 
         public SettingsView()
         {
-            Settings = ResourceHelper.Get<AppSettings>(nameof(AppSettings));
+            Settings = ResourceHelper.AppSettings;
+
             FontCollections = SimpleIoc.Default.GetInstance<UserCollectionsService>();
             Messenger.Default.Register<AppSettingsChangedMessage>(this, OnAppSettingsUpdated);
 
@@ -94,6 +93,9 @@ namespace CharacterMap.Views
 #pragma warning disable CS0618 // ChangeView doesn't work well when not properly visible
             ContentScroller.ScrollToVerticalOffset(0);
 #pragma warning restore CS0618 
+
+            // Note: it is legal for both "variant" and "font" to be *null*
+            //       when calling, so test both cases.
 
             bool isSymbol = FontCollections.IsSymbolFont(font);
 


### PR DESCRIPTION
Fix for #80 


Re: #79 , where doesn't seem to be any possible reason for this. Settings property can't be null, and all the bindings at that point use settings. Without any additional details about how it occurred I'm going to have to leave it open.