### PR TITLE
Bugfixes

### DIFF
--- a/CharacterMap/CharacterMap/Core/SVGPathReciever.cs
+++ b/CharacterMap/CharacterMap/Core/SVGPathReciever.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Graphics.Canvas.Geometry;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Text;
@@ -19,29 +20,29 @@ namespace CharacterMap.Core
 
         public void BeginFigure(Vector2 startPoint, CanvasFigureFill figureFill)
         {
-            _builder.AppendFormat("M {0} {1} ", startPoint.X, startPoint.Y);
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "M {0} {1} ", startPoint.X, startPoint.Y);
         }
 
         public void AddArc(Vector2 endPoint, float radiusX, float radiusY, float rotationAngle, CanvasSweepDirection sweepDirection, CanvasArcSize arcSize)
         {
-            _builder.AppendFormat("A {0} {1} {2} {3} {4} {5} {6} ", 
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "A {0} {1} {2} {3} {4} {5} {6} ", 
                 radiusX, radiusY, rotationAngle, (int)arcSize, (int)sweepDirection, endPoint.X, endPoint.Y);
         }
 
         public void AddCubicBezier(Vector2 controlPoint1, Vector2 controlPoint2, Vector2 endPoint)
         {
-            _builder.AppendFormat("C {0} {1} {2} {3} {4} {5} ", 
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "C {0} {1} {2} {3} {4} {5} ", 
                 controlPoint1.X, controlPoint1.Y, controlPoint2.X, controlPoint2.Y, endPoint.X, endPoint.Y);
         }
 
         public void AddLine(Vector2 endPoint)
         {
-            _builder.AppendFormat("L {0} {1} ", endPoint.X, endPoint.Y);
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "L {0} {1} ", endPoint.X, endPoint.Y);
         }
 
         public void AddQuadraticBezier(Vector2 controlPoint, Vector2 endPoint)
         {
-            _builder.AppendFormat("Q {0} {1} {2} {3} ", controlPoint.X, controlPoint.Y, endPoint.X, endPoint.Y);
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "Q {0} {1} {2} {3} ", controlPoint.X, controlPoint.Y, endPoint.X, endPoint.Y);
         }
 
         public void SetFilledRegionDetermination(CanvasFilledRegionDetermination filledRegionDetermination)
@@ -49,7 +50,7 @@ namespace CharacterMap.Core
             if (_builder.Length == 0)
                 return;
 
-            _builder.AppendFormat("F {0} ", (int)filledRegionDetermination);
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "F {0} ", (int)filledRegionDetermination);
         }
 
         public void SetSegmentOptions(CanvasFigureSegmentOptions figureSegmentOptions)

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -8,6 +8,7 @@
     xmlns:helpers="using:CharacterMap.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    SizeChanged="UserControl_SizeChanged"
     d:DesignHeight="800"
     d:DesignWidth="1280"
     mc:Ignorable="d">
@@ -472,6 +473,7 @@
 
                 <!--  Column Grid Splitter  -->
                 <toolkit:GridSplitter
+                    x:Name="Splitter"
                     Grid.RowSpan="2"
                     Grid.Column="1"
                     Width="8"
@@ -494,9 +496,9 @@
                 <!--  Preview Grid  -->
                 <Grid
                     x:Name="PreviewGrid"
+                    SizeChanged="PreviewGrid_SizeChanged"
                     Grid.RowSpan="2"
-                    Grid.Column="2"
-                    SizeChanged="PreviewGrid_SizeChanged">
+                    Grid.Column="2">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
                         <RowDefinition Height="Auto" />

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -307,6 +307,7 @@ namespace CharacterMap.Views
                 {
                     RequestedOperation = DataPackageOperation.Copy,
                 };
+
                 dp.SetText(character.Char);
 
                 if (!ViewModel.SelectedVariant.IsImported)
@@ -314,27 +315,18 @@ namespace CharacterMap.Views
                     // We can allow users to also copy the glyph with the font meta-data included,
                     // so when they paste into a supported program like Microsoft Word or 
                     // Adobe Photoshop the correct font is automatically applied to the paste.
-                    // To do so we need to create a RichTextFormat document, and we use the 
-                    // RichEditBox as a proxy to do this (otherwise the syntax is arcane).
-                    // This won't include any Typographic variations unfortunately.
-                    RichEditBox r = new RichEditBox();
-                    ITextCharacterFormat format = r.TextDocument.GetDefaultCharacterFormat();
-                    format.Size = 12;
-                    format.ForegroundColor = Windows.UI.Colors.Black;
-                    format.Name = ViewModel.FontFamily.Source;
+                    // This can't include any Typographic variations unfortunately.
+
+                    var rtf = $@"{{\rtf1\fbidis\ansi\ansicpg1252\deff0\nouicompat\deflang2057{{\fonttbl{{\f0\fnil {ViewModel.FontFamily.Source};}}}} " +
+                               $@"{{\colortbl;\red0\green0\blue0; }}\viewkind4\uc1\pard\ltrpar\tx720\cf1\f0\fs24\u{character.UnicodeIndex}?}}";
+                    dp.SetRtf(rtf);
 
                     var longName = ViewModel.FontFamily.Source;
                     if (ViewModel.SelectedVariant.FontInformation.FirstOrDefault(i => i.Key == "Full Name") is var p)
                     {
-                        if (p.Value != format.Name)
+                        if (p.Value != longName)
                             longName = $"{ViewModel.FontFamily.Source}, {p.Value}";
                     }
-
-                    r.TextDocument.SetDefaultCharacterFormat(format);
-                    r.TextDocument.SetText(TextSetOptions.None, character.Char);
-                    r.TextDocument.GetText(TextGetOptions.FormatRtf, out string doc);
-
-                    dp.SetRtf(doc);
                     dp.SetHtmlFormat($"<p style=\"font-family:'{longName}'; \">{character.Char}</p>");
                 }
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -76,6 +76,8 @@ namespace CharacterMap.Views
 
         private bool _isCtrlKeyPressed = false;
 
+        private Debouncer _sizeDebouncer { get; } = new Debouncer();
+
         private XamlDirect _xamlDirect { get; }
 
         private UISettings _uiSettings = null;
@@ -380,6 +382,26 @@ namespace CharacterMap.Views
             BorderFadeInStoryboard.Begin();
         }
 
+        private void UserControl_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            // Make sure the PreviewColumn fits properly.
+
+            if (e.NewSize.Width > e.PreviousSize.Width)
+                return;
+
+            _sizeDebouncer.Debounce(64, () =>
+            {
+                if (!this.IsLoaded)
+                    return;
+
+                var size = CharGrid.ActualWidth + Splitter.ActualWidth + PreviewGrid.ActualWidth;
+                if (this.ActualWidth < size)
+                {
+                    PreviewColumn.Width = new GridLength((int)(this.ActualWidth - CharGrid.ActualWidth - Splitter.ActualWidth));
+                }
+            });
+        }
+
         private void PreviewGrid_SizeChanged(object sender, SizeChangedEventArgs e)
         {
             var newSize = e.NewSize.Width - 2;
@@ -572,6 +594,7 @@ namespace CharacterMap.Views
         {
             Composition.SetThemeShadow(sender, 20, ShadowTarget);
         }
+
     }
 
 

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -42,6 +42,7 @@
             <AcrylicBrush
                 win1903:TintLuminosityOpacity="0.2"
                 BackgroundSource="Backdrop"
+                FallbackColor="{ThemeResource SystemAltHighColor}"
                 TintColor="{ThemeResource SystemChromeGrayColor}"
                 TintOpacity="0.5" />
         </Grid.Background>
@@ -150,6 +151,8 @@
                         Margin="0 12 0 0"
                         Padding="4 4 0 0"
                         HorizontalAlignment="Left"
+                        BorderThickness="1"
+                        BorderBrush="{ThemeResource PivotNavButtonBackgroundThemeBrush}"
                         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
                         Orientation="Horizontal">
                         <GridViewItem>


### PR DESCRIPTION
- Potentially fix #84 by manually creating the RTF doc. This has alleviated it for the fonts I've seen cause the issued (like `Berthold Akzidenz Grotesk BE Super`) and still pastes as RTF in apps like Word with correct font. Seems to be something strange in the validation code of ITextFormat.Name, but couldn't say what.
- Fix unreported issue with SVG & XAML paths being invalid in languages that use numeric decimal specifiers that aren't `.`
- When having a full size window with a massively sized preview column, making the window smaller wouldn't decreased the size of the preview column, forcing the preview off screen. This is now handled.
- #87 - Provide fallback brush for SettingsView