### PR TITLE
UI polishing

### DIFF
--- a/CharacterMap/CharacterMap.CX/CharacterMap.CX.vcxproj
+++ b/CharacterMap/CharacterMap.CX/CharacterMap.CX.vcxproj
@@ -275,6 +275,7 @@
     <ClInclude Include="DWriteFontSource.h" />
     <ClInclude Include="DWriteProperties.h" />
     <ClInclude Include="GlyphImageFormat.h" />
+    <ClInclude Include="PathData.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Interop.h" />
     <ClInclude Include="SVGGeometrySink.h" />

--- a/CharacterMap/CharacterMap.CX/CharacterMap.CX.vcxproj.filters
+++ b/CharacterMap/CharacterMap.CX/CharacterMap.CX.vcxproj.filters
@@ -24,6 +24,7 @@
     <ClInclude Include="SVGGeometrySink.h" />
     <ClInclude Include="DWriteFontFace.h" />
     <ClInclude Include="DWriteFontSet.h" />
+    <ClInclude Include="PathData.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/CharacterMap/CharacterMap.CX/Interop.h
+++ b/CharacterMap/CharacterMap.CX/Interop.h
@@ -10,10 +10,12 @@
 #include "DWriteProperties.h"
 #include "DWriteFontFace.h"
 #include "DWriteFontSet.h"
+#include "PathData.h"
 
 
 using namespace Microsoft::Graphics::Canvas;
 using namespace Microsoft::Graphics::Canvas::Text;
+using namespace Microsoft::Graphics::Canvas::Geometry;
 using namespace Microsoft::WRL;
 using namespace Windows::Foundation;
 using namespace Windows::Storage::Streams;
@@ -33,7 +35,8 @@ namespace CharacterMapCX
 		IBuffer^ GetImageDataBuffer(CanvasFontFace^ fontFace, UINT32 pixelsPerEm, UINT unicodeIndex, UINT imageType);
 		CanvasTextLayoutAnalysis^ AnalyzeFontLayout(CanvasTextLayout^ layout, CanvasFontFace^ fontFace);
 		CanvasTextLayoutAnalysis^ AnalyzeCharacterLayout(CanvasTextLayout^ layout);
-		Platform::String^ GetPathGeometry(CanvasTextLayoutAnalysis^ analysis, CanvasFontFace^ set);
+		Platform::String^ GetPathData(CanvasFontFace^ fontFace, UINT16 charIndex);
+		PathData^ GetPathData(CanvasGeometry^ geometry);
 
 		DWriteFontSet^ GetSystemFonts();
 		DWriteFontSet^ GetFonts(Uri^ uri);

--- a/CharacterMap/CharacterMap.CX/PathData.h
+++ b/CharacterMap/CharacterMap.CX/PathData.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <Microsoft.Graphics.Canvas.native.h>
+#include <d2d1_2.h>
+#include <d2d1_3.h>
+#include <dwrite_3.h>
+#include <WindowsNumerics.h>
+
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Numerics;
+using namespace Platform;
+
+namespace CharacterMapCX
+{
+	public ref class PathData sealed
+	{
+	public:
+
+		property String^ Path
+		{
+			String^ get() { return m_path; }
+		}
+
+		property float3x2 Transform
+		{
+			float3x2 get() { return m_matrix; }
+		}
+
+	internal:
+		PathData(String^ path, D2D1::Matrix3x2F* matrix)
+		{
+			m_path = path;
+			m_matrix = { matrix->_11, matrix->_12, matrix->_21, matrix->_22, matrix->_31, matrix->_32 };
+		}
+
+	private:
+		inline PathData() { }
+
+		float3x2 m_matrix;
+		String^ m_path = nullptr;
+	};
+}

--- a/CharacterMap/CharacterMap.CX/SVGGeometrySink.h
+++ b/CharacterMap/CharacterMap.CX/SVGGeometrySink.h
@@ -1,150 +1,148 @@
-//#pragma once
-//
-//#include "pch.h"
-//#include <Microsoft.Graphics.Canvas.native.h>
-//#include <d2d1_2.h>
-//#include <d2d1_3.h>
-//#include <dwrite_3.h>
-//#include "ColorTextAnalyzer.h"
-//#include "GlyphImageFormat.h"
-//#include <vector>
-//#include <string>
-//#include <iostream>
-//
-//using namespace Microsoft::Graphics::Canvas;
-//using namespace Microsoft::Graphics::Canvas::Text;
-//using namespace Microsoft::WRL;
-//using namespace Windows::Foundation;
-//using namespace Windows::Foundation::Collections;
-//using namespace Platform;
-//using namespace std;
-//
-//namespace CharacterMapCX
-//{
-//	class SVGGeometrySink : public IDWriteGeometrySink
-//	{
-//	public:
-//
-//        virtual void STDMETHODCALLTYPE SetFillMode(D2D1_FILL_MODE fillMode)
-//        {
-//            if (b.length == 0)
-//                return;
-//
-//            auto c = to_wstring(fillMode).c_str();
-//
-//            b.append(wstr("F"));
-//            b.append(c);
-//            b.append(wstr(" "));
-//        }
-//
-//        virtual void STDMETHODCALLTYPE SetSegmentFlags(D2D1_PATH_SEGMENT vertexFlags)
-//        {
-//
-//        }
-//
-//        virtual void STDMETHODCALLTYPE BeginFigure(D2D1_POINT_2F startPoint, D2D1_FIGURE_BEGIN figureBegin)
-//        {
-//            b.append(wstr("M "));
-//            b.append(to_wstring(startPoint.x));
-//            b.append(wstr(" "));
-//            b.append(to_wstring(startPoint.y));
-//            b.append(wstr(" "));
-//        }
-//
-//        virtual void STDMETHODCALLTYPE AddLines(const D2D1_POINT_2F* points, UINT pointsCount)
-//        {
-//            for (int i = 0; i < pointsCount; i = i + 1)
-//            {
-//                auto point = points[i];
-//                b.append(wstr("L "));
-//                b.append(to_wstring(point.x));
-//                b.append(wstr(" "));
-//                b.append(to_wstring(point.y));
-//                b.append(wstr(" "));
-//            }
-//        }
-//
-//        virtual void STDMETHODCALLTYPE AddBeziers(const D2D1_BEZIER_SEGMENT* beziers, UINT beziersCount)
-//        {
-//            for (int i = 0; i < beziersCount; i = i + 1)
-//            {
-//                auto z = beziers[i];
-//                b.append(wstr("C "));
-//                b.append(to_wstring(z.point1.x));
-//                b.append(wstr(" "));
-//                b.append(to_wstring(z.point1.y));
-//                b.append(wstr(" "));
-//                b.append(to_wstring(z.point2.x));
-//                b.append(wstr(" "));
-//                b.append(to_wstring(z.point2.y));
-//                b.append(wstr(" "));
-//                b.append(to_wstring(z.point3.x));
-//                b.append(wstr(" "));
-//                b.append(to_wstring(z.point3.y));
-//                b.append(wstr(" "));
-//            }
-//        }
-//
-//        virtual void STDMETHODCALLTYPE EndFigure(D2D1_FIGURE_END figureEnd)
-//        {
-//            b.append(wstr("Z "));
-//            b.append(wstr(" "));
-//        }
-//
-//        virtual HRESULT STDMETHODCALLTYPE Close()
-//        {
-//        }
-//
-//        IFACEMETHODIMP_(unsigned long) AddRef()
-//        {
-//            return InterlockedIncrement(&m_refCount);
-//        }
-//
-//        IFACEMETHODIMP_(unsigned long) Release()
-//        {
-//            unsigned long newCount = InterlockedDecrement(&m_refCount);
-//            if (newCount == 0)
-//            {
-//                delete this;
-//                return 0;
-//            }
-//
-//            return newCount;
-//        }
-//
-//        IFACEMETHODIMP QueryInterface(
-//            IID const& riid,
-//            void** ppvObject
-//        )
-//        {
-//            if (__uuidof(IDWriteGeometrySink) == riid)
-//            {
-//                *ppvObject = this;
-//            }
-//            else if (__uuidof(IUnknown) == riid)
-//            {
-//                *ppvObject = this;
-//            }
-//            else
-//            {
-//                *ppvObject = nullptr;
-//                return E_FAIL;
-//            }
-//
-//            this->AddRef();
-//
-//            return S_OK;
-//        }
-//
-//        String^ GetPathData()
-//        {
-//            String^ s = ref new String(b.c_str());
-//            return s;
-//        }
-//
-//	private:
-//        wstring b = wstr("");
-//        unsigned long m_refCount;
-//
-//	};
-//}
+#pragma once
+
+#include "pch.h"
+#include <Microsoft.Graphics.Canvas.native.h>
+#include <d2d1_2.h>
+#include <d2d1_3.h>
+#include <dwrite_3.h>
+#include "ColorTextAnalyzer.h"
+#include "GlyphImageFormat.h"
+#include <vector>
+#include <string>
+#include <iostream>
+
+using namespace Microsoft::Graphics::Canvas;
+using namespace Microsoft::Graphics::Canvas::Text;
+using namespace Microsoft::WRL;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Platform;
+using namespace std;
+
+namespace CharacterMapCX
+{
+	class SVGGeometrySink : public ID2D1GeometrySink
+	{
+	public:
+
+        virtual void STDMETHODCALLTYPE SetFillMode(D2D1_FILL_MODE fillMode)
+        {
+            b = b + "F" + to_string(fillMode) + " ";
+        }
+
+        virtual void STDMETHODCALLTYPE SetSegmentFlags(D2D1_PATH_SEGMENT vertexFlags)
+        {
+
+        }
+
+        virtual void STDMETHODCALLTYPE BeginFigure(D2D1_POINT_2F startPoint, D2D1_FIGURE_BEGIN figureBegin)
+        {
+            b = b + "M " + to_string(startPoint.x) + " " + to_string(startPoint.y) + " ";
+        }
+
+        virtual void STDMETHODCALLTYPE AddLines(const D2D1_POINT_2F* points, UINT pointsCount)
+        {
+            for (int i = 0; i < pointsCount; i = i + 1)
+            {
+                auto point = points[i];
+                b = b + "L " + to_string(point.x) + " " + to_string(point.y) + " ";
+            }
+        }
+
+        virtual void STDMETHODCALLTYPE AddBeziers(const D2D1_BEZIER_SEGMENT* beziers, UINT beziersCount)
+        {
+            for (int i = 0; i < beziersCount; i = i + 1)
+            {
+                auto z = beziers[i];
+                b = b + "C " + to_string(z.point1.x) + " " + to_string(z.point1.y) + " " + to_string(z.point2.x) + " " + to_string(z.point2.y) + " " + to_string(z.point3.x) + " " + to_string(z.point3.y) + " ";
+            }
+        }
+
+        virtual void STDMETHODCALLTYPE EndFigure(D2D1_FIGURE_END figureEnd)
+        {
+            if (figureEnd == D2D1_FIGURE_END::D2D1_FIGURE_END_CLOSED)
+                b = b + "Z ";
+        }
+
+        virtual HRESULT STDMETHODCALLTYPE Close()
+        {
+            return S_OK;
+        }
+
+        IFACEMETHODIMP_(unsigned long) AddRef()
+        {
+            return InterlockedIncrement(&m_refCount);
+        }
+
+        IFACEMETHODIMP_(unsigned long) Release()
+        {
+            unsigned long newCount = InterlockedDecrement(&m_refCount);
+            if (newCount == 0)
+            {
+                delete this;
+                return 0;
+            }
+
+            return newCount;
+        }
+
+        IFACEMETHODIMP QueryInterface(
+            IID const& riid,
+            void** ppvObject
+        )
+        {
+            if (__uuidof(IDWriteGeometrySink) == riid)
+            {
+                *ppvObject = this;
+            }
+            else if (__uuidof(IUnknown) == riid)
+            {
+                *ppvObject = this;
+            }
+            else
+            {
+                *ppvObject = nullptr;
+                return E_FAIL;
+            }
+
+            this->AddRef();
+
+            return S_OK;
+        }
+
+        String^ GetPathData()
+        {
+            std::wstring wsTmp(b.begin(), b.end());
+            auto ws = wsTmp;
+
+            String^ s = ref new String(ws.c_str());
+            return s;
+        }
+
+	private:
+        string b = "";
+        unsigned long m_refCount;
+
+
+        // Inherited via ID2D1GeometrySink - Not required for text.
+        void __stdcall AddLine(D2D1_POINT_2F point)
+        {
+        }
+
+        void __stdcall AddBezier(const D2D1_BEZIER_SEGMENT* bezier)
+        {
+        }
+
+        void __stdcall AddQuadraticBezier(const D2D1_QUADRATIC_BEZIER_SEGMENT* bezier)
+        {
+        }
+
+        void __stdcall AddQuadraticBeziers(const D2D1_QUADRATIC_BEZIER_SEGMENT* beziers, UINT32 beziersCount)
+        {
+        }
+
+        void __stdcall AddArc(const D2D1_ARC_SEGMENT* arc)
+        {
+        }
+    };
+}

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Views\SettingsView.xaml.cs">
       <DependentUpon>SettingsView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\ViewBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -184,6 +184,7 @@
     <Compile Include="Core\AlphaKeyGroup.cs" />
     <Compile Include="Core\AppSettings.cs" />
     <Compile Include="Core\ExceptionHandlingSynchronizationContext.cs" />
+    <Compile Include="Helpers\CompositionExtensions.cs" />
     <Compile Include="Helpers\InAppNotificationHelper.cs" />
     <Compile Include="Models\Character.cs" />
     <Compile Include="Core\Messages.cs" />

--- a/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
+++ b/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
@@ -46,6 +46,10 @@ namespace CharacterMap.Controls
             DefaultStyleKey = typeof(XamlTitleBar);
             Loaded += XamlTitleBar_Loaded;
             Unloaded += XamlTitleBar_Unloaded;
+
+            // 32px is the default height at default text scaling. 
+            // We'll use this as a placeholder until we get a real value
+            Height = 32;
         }
 
         protected override void OnApplyTemplate()
@@ -68,6 +72,7 @@ namespace CharacterMap.Controls
                 _titleBar = CoreApplication.GetCurrentView().TitleBar;
                 _titleBar.ExtendViewIntoTitleBar = true;
                 UpdateMetrics(_titleBar);
+                UpdateColors();
             }
             catch
             { }
@@ -142,7 +147,10 @@ namespace CharacterMap.Controls
 
         private void UpdateColors()
         {
-            bool active = _window.ActivationMode == CoreWindowActivationMode.ActivatedInForeground;
+            if (_settings == null)
+                return;
+
+            bool active = _window != null && _window.ActivationMode == CoreWindowActivationMode.ActivatedInForeground;
 
             TemplateSettings.BackgroundColor = _settings.GetColorValue(active ? UIColorType.Accent : UIColorType.AccentDark1);
 
@@ -171,6 +179,8 @@ namespace CharacterMap.Controls
             Color? titleInactiveForegroundColor)
         {
             var view = ApplicationView.GetForCurrentView();
+            if (view == null)
+                return;
 
             // active
             view.TitleBar.BackgroundColor = titleBackgroundColor;
@@ -191,6 +201,8 @@ namespace CharacterMap.Controls
             Color? titleButtonInactiveForegroundColor)
         {
             var view = ApplicationView.GetForCurrentView();
+            if (view == null)
+                return;
 
             // button
             view.TitleBar.ButtonBackgroundColor = titleButtonBackgroundColor;
@@ -210,7 +222,8 @@ namespace CharacterMap.Controls
         {
             bool ltr = FlowDirection == FlowDirection.LeftToRight;
 
-            Height = bar.Height;
+            if (bar.Height > 0)
+                Height = bar.Height;
 
             TemplateSettings.LeftColumnWidth 
                 = new GridLength(ltr ? bar.SystemOverlayLeftInset : bar.SystemOverlayRightInset);

--- a/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
+++ b/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
@@ -56,8 +56,12 @@ namespace CharacterMap.Controls
             {
                 _backgroundElement = e;
                 UpdateDragElement();
+                TryUpdateMetrics();
             }
+        }
 
+        public void TryUpdateMetrics()
+        {
             try
             {
                 // Attempts to avoid titlebar not showing immediately when a window is opened

--- a/CharacterMap/CharacterMap/Core/AppSettings.cs
+++ b/CharacterMap/CharacterMap/Core/AppSettings.cs
@@ -28,6 +28,12 @@ namespace CharacterMap.Core
             set => Set(value);
         }
 
+        public bool FitCharacter
+        {
+            get => Get(false);
+            set => BroadcastSet(value);
+        }
+
         public bool ShowDevUtils
         {
             get => Get(true);

--- a/CharacterMap/CharacterMap/Core/Utils.cs
+++ b/CharacterMap/CharacterMap/Core/Utils.cs
@@ -3,10 +3,12 @@ using Microsoft.Graphics.Canvas.Svg;
 using Microsoft.Graphics.Canvas.Text;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.Storage;
 using Windows.UI;
@@ -131,26 +133,32 @@ namespace CharacterMap.Core
 
         public static CanvasSvgDocument GenerateSvgDocument(
             ICanvasResourceCreator device,
-            double width,
-            double height,
+            Rect rect,
             string path)
         {
-            return GenerateSvgDocument(device, width, height, new List<string> { path });
+            return GenerateSvgDocument(device, rect, new List<string> { path });
         }
 
         public static CanvasSvgDocument GenerateSvgDocument(
             ICanvasResourceCreator device,
-            double width, 
-            double height, 
+            Rect rect, 
             IList<string> paths)
         {
-            width = Math.Ceiling(width);
-            height = Math.Ceiling(height);
+            var right = Math.Ceiling(rect.Width);
+            var bottom = Math.Ceiling(rect.Height);
             StringBuilder sb = new StringBuilder();
-            sb.AppendFormat("<svg width=\"100%\" height=\"100%\" viewBox=\"0 0 {0} {1}\" xmlns=\"http://www.w3.org/2000/svg\">", width, height);
+            sb.AppendFormat(
+                CultureInfo.InvariantCulture, 
+                "<svg width=\"100%\" height=\"100%\" viewBox=\"{2} {3} {0} {1}\" xmlns=\"http://www.w3.org/2000/svg\">", 
+                right, bottom, -Math.Floor(rect.Left), -Math.Floor(rect.Top));
+
             foreach (var path in paths)
             {
-                sb.AppendFormat("<path d=\"{0}\" />", path);
+                string p = path;
+                if (path.StartsWith("F1 "))
+                    p = path.Remove(0, 3);
+
+                sb.AppendFormat("<path d=\"{0}\" />", p);
             }
             sb.Append("</svg>");
 

--- a/CharacterMap/CharacterMap/Helpers/Composition.cs
+++ b/CharacterMap/CharacterMap/Helpers/Composition.cs
@@ -92,15 +92,31 @@ namespace CharacterMap.Helpers
             t.InsertKeyFrame(1, new Vector3(0), e);
             t.Duration = TimeSpan.FromMilliseconds(durationMs);
 
-            var o = c.CreateScalarKeyFrameAnimation();
-            o.Target = nameof(Visual.Opacity);
-            o.DelayBehavior = AnimationDelayBehavior.SetInitialValueBeforeDelay;
-            o.DelayTime = delay;
-            o.InsertKeyFrame(0, 0);
-            o.InsertKeyFrame(1, 1);
-            o.Duration = TimeSpan.FromMilliseconds(durationMs * 0.33);
+            var o = CreateFade(c, 1, 0, (int)(durationMs * 0.33), delayMs);
 
             return c.CreateAnimationGroup(t, o);
+        }
+
+        public static CompositionAnimation CreateFade(Compositor c, float to, float? from, int durationMs, int delayMs = 0)
+        {
+            var o = c.CreateScalarKeyFrameAnimation();
+            o.Target = nameof(Visual.Opacity);
+            if (from != null && from.HasValue)
+                o.InsertKeyFrame(0, from.Value);
+            o.InsertKeyFrame(1, to);
+            o.DelayBehavior = AnimationDelayBehavior.SetInitialValueBeforeDelay;
+            o.DelayTime = TimeSpan.FromMilliseconds(delayMs);
+            o.Duration = TimeSpan.FromMilliseconds(durationMs);
+            return o;
+        }
+
+        public static ExpressionAnimation StartCentering(Visual v)
+        {
+            var e = v.Compositor.CreateExpressionAnimation();
+            e.Target = nameof(Visual.CenterPoint);
+            e.Expression = CENTRE_EXPRESSION;
+            v.StartAnimationGroup(e);
+            return e;
         }
 
         public static void PlayScaleEntrance(FrameworkElement target, float from, float to)
@@ -109,10 +125,7 @@ namespace CharacterMap.Helpers
 
             if (target.Tag == null)
             {
-                var c = v.Compositor.CreateExpressionAnimation();
-                c.Target = nameof(Visual.CenterPoint);
-                c.Expression = CENTRE_EXPRESSION;
-                v.StartAnimationGroup(c);
+                StartCentering(v);
                 target.Tag = target;
             }
 
@@ -124,11 +137,7 @@ namespace CharacterMap.Helpers
             t.InsertKeyFrame(1, new Vector3(to, to, 0), e);
             t.Duration = TimeSpan.FromSeconds(0.6);
 
-            var o = v.Compositor.CreateScalarKeyFrameAnimation();
-            o.Target = nameof(Visual.Opacity);
-            o.InsertKeyFrame(0, 0);
-            o.InsertKeyFrame(1, 1);
-            o.Duration = TimeSpan.FromSeconds(0.2);
+            var o = CreateFade(v.Compositor, 1, 0, 200);
 
             var g = v.Compositor.CreateAnimationGroup(t, o);
             v.StartAnimationGroup(g);

--- a/CharacterMap/CharacterMap/Helpers/Composition.cs
+++ b/CharacterMap/CharacterMap/Helpers/Composition.cs
@@ -229,6 +229,65 @@ namespace CharacterMap.Helpers
             e.SetShowAnimation(CreateFade(v.Compositor, 1, null, durationMs));
         }
 
+        public static void StartStartUpAnimation(
+            FrameworkElement barBackground,
+            List<FrameworkElement> barElements,
+            List<FrameworkElement> contentElements)
+        {
+            TimeSpan duration = TimeSpan.FromSeconds(0.65);
+            TimeSpan duration1 = TimeSpan.FromSeconds(0.75);
+
+            var b = barBackground.EnableTranslation(true).GetElementVisual();
+            var c = b.Compositor;
+            var backOut = c.CreateCubicBezierEasingFunction(new Vector2(0.175f, 0.885f), new Vector2(0.32f, 1.175f));
+            var ent = c.CreateEntranceEasingFunction();
+            var lin = c.CreateLinearEasingFunction();
+
+            var a1 = c.CreateVector3KeyFrameAnimation();
+            a1.Target = TRANSLATION;
+            a1.Duration = duration;
+            a1.InsertKeyFrame(0, new Vector3(0, -45, 0));
+            a1.InsertKeyFrame(1, Vector3.Zero, ent);
+            b.StartAnimationGroup(a1);
+
+            double delay = 0.1;
+            foreach (var element in barElements)
+            {
+                var t = c.CreateVector3KeyFrameAnimation();
+                t.Target = TRANSLATION;
+                t.InsertKeyFrame(0, new Vector3(0, -100, 0));
+                t.InsertKeyFrame(1, Vector3.Zero, backOut);
+                t.DelayBehavior = AnimationDelayBehavior.SetInitialValueBeforeDelay;
+                t.DelayTime = TimeSpan.FromSeconds(delay);
+                t.Duration = duration1;
+                delay += 0.055;
+
+                element.EnableTranslation(true).StartAnimation(t);
+            }
+
+            delay = 0.4;
+            foreach (var element in contentElements)
+            {
+                var t = c.CreateVector3KeyFrameAnimation();
+                t.Target = TRANSLATION;
+                t.InsertKeyFrame(0, new Vector3(0, 140, 0));
+                t.InsertKeyFrame(1, Vector3.Zero, ent);
+                t.DelayBehavior = AnimationDelayBehavior.SetInitialValueBeforeDelay;
+                t.DelayTime = TimeSpan.FromSeconds(delay);
+                t.Duration = duration1;
+
+                var o = c.CreateScalarKeyFrameAnimation();
+                o.Target = nameof(Visual.Opacity);
+                o.InsertKeyFrame(0, 0);
+                o.InsertKeyFrame(1, 1, lin);
+                o.DelayBehavior = AnimationDelayBehavior.SetInitialValueBeforeDelay;
+                o.DelayTime = TimeSpan.FromSeconds(delay);
+                o.Duration = TimeSpan.FromSeconds(0.33);
+
+                element.EnableTranslation(true).StartAnimation(c.CreateAnimationGroup(t, o));
+            }
+        }
+
         public static void SetThemeShadow(UIElement target, float depth, params UIElement[] recievers)
         {
             if (!Utils.Supports1903 || !ResourceHelper.AppSettings.EnableShadows)

--- a/CharacterMap/CharacterMap/Helpers/Composition.cs
+++ b/CharacterMap/CharacterMap/Helpers/Composition.cs
@@ -25,9 +25,10 @@ namespace CharacterMap.Helpers
             $"({nameof(Vector3)}(this.Target.{nameof(Visual.Size)}.{nameof(Vector2.X)} * 0.5f, " +
             $"this.Target.{nameof(Visual.Size)}.{nameof(Vector2.Y)} * 0.5f, 0f))";
 
-        private const string TRANSLATION = "Translation";
-        private const string STARTING_VALUE = "this.StartingValue";
-        private const string FINAL_VALUE = "this.FinalValue";
+        public const string TRANSLATION = "Translation";
+        public const string STARTING_VALUE = "this.StartingValue";
+        public const string FINAL_VALUE = "this.FinalValue";
+        public const int DEFAULT_STAGGER_MS = 83;
 
         #region Attached Properties
 
@@ -94,16 +95,12 @@ namespace CharacterMap.Helpers
             var o = c.CreateScalarKeyFrameAnimation();
             o.Target = nameof(Visual.Opacity);
             o.DelayBehavior = AnimationDelayBehavior.SetInitialValueBeforeDelay;
-            t.DelayTime = delay;
+            o.DelayTime = delay;
             o.InsertKeyFrame(0, 0);
             o.InsertKeyFrame(1, 1);
             o.Duration = TimeSpan.FromMilliseconds(durationMs * 0.33);
 
-            var g = c.CreateAnimationGroup();
-            g.Add(t);
-            g.Add(o);
-
-            return g;
+            return c.CreateAnimationGroup(t, o);
         }
 
         public static void PlayScaleEntrance(FrameworkElement target, float from, float to)
@@ -133,10 +130,7 @@ namespace CharacterMap.Helpers
             o.InsertKeyFrame(1, 1);
             o.Duration = TimeSpan.FromSeconds(0.2);
 
-            var g = v.Compositor.CreateAnimationGroup();
-            g.Add(t);
-            g.Add(o);
-
+            var g = v.Compositor.CreateAnimationGroup(t, o);
             v.StartAnimationGroup(g);
         }
 

--- a/CharacterMap/CharacterMap/Helpers/Composition.cs
+++ b/CharacterMap/CharacterMap/Helpers/Composition.cs
@@ -216,6 +216,19 @@ namespace CharacterMap.Helpers
                 child.SetHideAnimation(ht);
         }
 
+        public static void SetStandardFadeInOut(object sender, RoutedEventArgs args)
+        {
+            if (sender is FrameworkElement e)
+                SetFadeInOut(e, 200);
+        }
+
+        private static void SetFadeInOut(FrameworkElement e, int durationMs)
+        {
+            var v = e.GetElementVisual();
+            e.SetHideAnimation(CreateFade(v.Compositor, 0, null, durationMs));
+            e.SetShowAnimation(CreateFade(v.Compositor, 1, null, durationMs));
+        }
+
         public static void SetThemeShadow(UIElement target, float depth, params UIElement[] recievers)
         {
             if (!Utils.Supports1903 || !ResourceHelper.AppSettings.EnableShadows)

--- a/CharacterMap/CharacterMap/Helpers/Composition.cs
+++ b/CharacterMap/CharacterMap/Helpers/Composition.cs
@@ -234,12 +234,13 @@ namespace CharacterMap.Helpers
             List<FrameworkElement> barElements,
             List<FrameworkElement> contentElements)
         {
-            TimeSpan duration = TimeSpan.FromSeconds(0.65);
-            TimeSpan duration1 = TimeSpan.FromSeconds(0.75);
+            TimeSpan duration = TimeSpan.FromSeconds(0.5);
+            TimeSpan duration1 = TimeSpan.FromSeconds(0.7);
 
             var b = barBackground.EnableTranslation(true).GetElementVisual();
             var c = b.Compositor;
-            var backOut = c.CreateCubicBezierEasingFunction(new Vector2(0.175f, 0.885f), new Vector2(0.32f, 1.175f));
+
+            var backOut = c.CreateCubicBezierEasingFunction(new Vector2(0.2f, 0.885f), new Vector2(0.25f, 1.125f));
             var ent = c.CreateEntranceEasingFunction();
             var lin = c.CreateLinearEasingFunction();
 

--- a/CharacterMap/CharacterMap/Helpers/CompositionExtensions.cs
+++ b/CharacterMap/CharacterMap/Helpers/CompositionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Composition;
@@ -37,6 +38,27 @@ namespace CharacterMap.Helpers
 
             composition.ImplicitAnimations[path] = animation;
             return element;
+        }
+
+        public static void SetShowAnimation(this FrameworkElement element, ICompositionAnimationBase animation)
+        {
+            ElementCompositionPreview.SetImplicitShowAnimation(element, animation);
+        }
+
+        public static void SetHideAnimation(this FrameworkElement element, ICompositionAnimationBase animation)
+        {
+            ElementCompositionPreview.SetImplicitHideAnimation(element, animation);
+        }
+
+        public static UIElement EnableTranslation(this UIElement element, bool enable)
+        {
+            ElementCompositionPreview.SetIsTranslationEnabled(element, enable);
+            return element;
+        }
+
+        public static CubicBezierEasingFunction CreateEntranceEasingFunction(this Compositor c)
+        {
+            return c.CreateCubicBezierEasingFunction(new Vector2(.1f, .9f), new Vector2(.2f, 1));
         }
     }
 }

--- a/CharacterMap/CharacterMap/Helpers/CompositionExtensions.cs
+++ b/CharacterMap/CharacterMap/Helpers/CompositionExtensions.cs
@@ -40,12 +40,12 @@ namespace CharacterMap.Helpers
             return element;
         }
 
-        public static void SetShowAnimation(this FrameworkElement element, ICompositionAnimationBase animation)
+        public static void SetShowAnimation(this UIElement element, ICompositionAnimationBase animation)
         {
             ElementCompositionPreview.SetImplicitShowAnimation(element, animation);
         }
 
-        public static void SetHideAnimation(this FrameworkElement element, ICompositionAnimationBase animation)
+        public static void SetHideAnimation(this UIElement element, ICompositionAnimationBase animation)
         {
             ElementCompositionPreview.SetImplicitHideAnimation(element, animation);
         }
@@ -59,6 +59,14 @@ namespace CharacterMap.Helpers
         public static CubicBezierEasingFunction CreateEntranceEasingFunction(this Compositor c)
         {
             return c.CreateCubicBezierEasingFunction(new Vector2(.1f, .9f), new Vector2(.2f, 1));
+        }
+
+        public static CompositionAnimationGroup CreateAnimationGroup(this Compositor c, params CompositionAnimation[] animations)
+        {
+            var group = c.CreateAnimationGroup();
+            foreach (var a in animations)
+                group.Add(a);
+            return group;
         }
     }
 }

--- a/CharacterMap/CharacterMap/Helpers/CompositionExtensions.cs
+++ b/CharacterMap/CharacterMap/Helpers/CompositionExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Composition;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Hosting;
+
+namespace CharacterMap.Helpers
+{
+    public static class CompositionExtensions
+    {
+        public static Visual GetElementVisual(this UIElement element) => ElementCompositionPreview.GetElementVisual(element);
+
+
+        public static T SetImplicitAnimation<T>(this T composition, string path, ICompositionAnimationBase animation)
+            where T : CompositionObject
+        {
+            if (composition.ImplicitAnimations == null)
+            {
+                composition.ImplicitAnimations = composition.Compositor.CreateImplicitAnimationCollection();
+            }
+
+            composition.ImplicitAnimations[path] = animation;
+            return composition;
+        }
+
+        public static FrameworkElement SetImplicitAnimation(this FrameworkElement element, string path, ICompositionAnimationBase animation)
+        {
+            CompositionObject composition = ElementCompositionPreview.GetElementVisual(element);
+
+            if (composition.ImplicitAnimations == null)
+            {
+                composition.ImplicitAnimations = composition.Compositor.CreateImplicitAnimationCollection();
+            }
+
+            composition.ImplicitAnimations[path] = animation;
+            return element;
+        }
+    }
+}

--- a/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
@@ -210,7 +210,9 @@ namespace CharacterMap.Helpers
                         foreach (var m in 
                                 _collections.Items.Select(item => new MenuFlyoutItem
                                 {
-                                    DataContext = item, Text = item.Name, IsEnabled = !item.Fonts.Contains(font.Name)
+                                    DataContext = item, 
+                                    Text = item.Name, 
+                                    IsEnabled = !item.Fonts.Contains(font.Name)
                                 }))
                         {
                             if (m.IsEnabled)

--- a/CharacterMap/CharacterMap/Models/Character.cs
+++ b/CharacterMap/CharacterMap/Models/Character.cs
@@ -4,8 +4,6 @@
     {
         public string Char { get; set; }
 
-        public uint Index { get; set; }
-
         public int UnicodeIndex { get; set; }
 
         public string UnicodeString => "U+" + UnicodeIndex.ToString("x4").ToUpper();

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -726,6 +726,11 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Contributors</source>
           <target state="new">Contributors</target>
         </trans-unit>
+        <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
+          <source>loading fonts</source>
+          <target state="new">loading fonts</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -722,6 +722,10 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Change will apply after restart</source>
           <target state="new">Change will apply after restart</target>
         </trans-unit>
+        <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="new">Contributors</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -726,6 +726,11 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Contributors</source>
           <target state="new">Contributors</target>
         </trans-unit>
+        <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
+          <source>loading fonts</source>
+          <target state="new">loading fonts</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -722,6 +722,10 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Change will apply after restart</source>
           <target state="new">Change will apply after restart</target>
         </trans-unit>
+        <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="new">Contributors</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -726,6 +726,11 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Contributors</source>
           <target state="new">Contributors</target>
         </trans-unit>
+        <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
+          <source>loading fonts</source>
+          <target state="new">loading fonts</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -722,6 +722,10 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Change will apply after restart</source>
           <target state="new">Change will apply after restart</target>
         </trans-unit>
+        <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="new">Contributors</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -726,6 +726,11 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Contributors</source>
           <target state="new">Contributors</target>
         </trans-unit>
+        <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
+          <source>loading fonts</source>
+          <target state="new">loading fonts</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -722,6 +722,10 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Change will apply after restart</source>
           <target state="new">Change will apply after restart</target>
         </trans-unit>
+        <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="new">Contributors</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -726,6 +726,11 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Contributors</source>
           <target state="new">Contributors</target>
         </trans-unit>
+        <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
+          <source>loading fonts</source>
+          <target state="new">loading fonts</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -722,6 +722,10 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Change will apply after restart</source>
           <target state="new">Change will apply after restart</target>
         </trans-unit>
+        <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="new">Contributors</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -722,6 +722,10 @@ Turning this on can have a minor impact on scrolling performance.</source>
           <source>Change will apply after restart</source>
           <target state="translated">จะมีผลเมื่อเปิดแอปครั้งหน้า (เริ่มต้นแอปใหม่)</target>
         </trans-unit>
+        <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="new">Contributors</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -726,6 +726,11 @@ Turning this on can have a minor impact on scrolling performance.</source>
           <source>Contributors</source>
           <target state="new">Contributors</target>
         </trans-unit>
+        <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
+          <source>loading fonts</source>
+          <target state="new">loading fonts</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -722,6 +722,10 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Change will apply after restart</source>
           <target state="translated">应用重启后生效</target>
         </trans-unit>
+        <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="new">Contributors</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -726,6 +726,11 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Contributors</source>
           <target state="new">Contributors</target>
         </trans-unit>
+        <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
+          <source>loading fonts</source>
+          <target state="new">loading fonts</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -726,6 +726,11 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Contributors</source>
           <target state="new">Contributors</target>
         </trans-unit>
+        <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
+          <source>loading fonts</source>
+          <target state="new">loading fonts</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -722,6 +722,10 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <source>Change will apply after restart</source>
           <target state="new">Change will apply after restart</target>
         </trans-unit>
+        <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="new">Contributors</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/Provider/SQLiteGlyphProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/SQLiteGlyphProvider.cs
@@ -141,7 +141,7 @@ namespace CharacterMap.Provider
                     //      If it does then we ask the database, otherwise we can return without query.
                     foreach (var range in variant.UnicodeRanges)
                     {
-                        if (hex >= range.Item1 && hex <= range.Item2)
+                        if (hex >= range.First && hex <= range.Last)
                         {
                             string hexsql = $"SELECT * FROM {table} WHERE Ix == {hex} LIMIT 1";
                             var hexresults = _connection.Query<GlyphDescription>(hexsql, query)?.Cast<IGlyphData>()?.ToList();
@@ -190,14 +190,14 @@ namespace CharacterMap.Provider
                 /// any useful search results. MS Office Symbol is an example of such a font (with no useful search
                 /// results anyway). Certain complex Asian script fonts **may** theoretically hit this limit.
                 /// We don't want to throw an exception if we ever hit this case, we'll just do our best.
-                foreach ((int, int) range in variant.UnicodeRanges.Take(995)) 
+                foreach (var range in variant.UnicodeRanges.Take(995)) 
                 {
                     if (next)
-                        sb.AppendFormat(" OR Ix BETWEEN {0} AND {1}", range.Item1, range.Item2);
+                        sb.AppendFormat(" OR Ix BETWEEN {0} AND {1}", range.First, range.Last);
                     else
                     {
                         next = true;
-                        sb.AppendFormat("WHERE (Ix BETWEEN {0} AND {1}", range.Item1, range.Item2);
+                        sb.AppendFormat("WHERE (Ix BETWEEN {0} AND {1}", range.First, range.Last);
                     }
                 }
                 sb.Append(")");

--- a/CharacterMap/CharacterMap/Services/ActivationService.cs
+++ b/CharacterMap/CharacterMap/Services/ActivationService.cs
@@ -122,9 +122,7 @@ namespace CharacterMap.Services
                 // Ensure the current window is active
                 Window.Current.Activate();
 
-                // Make the window max as much as possible by default
-                ApplicationView.PreferredLaunchViewSize = new Size { Height = 2000, Width = 3000 };
-                ApplicationView.PreferredLaunchWindowingMode = ApplicationViewWindowingMode.PreferredLaunchViewSize;
+                ApplicationView.PreferredLaunchWindowingMode = ApplicationViewWindowingMode.Auto;
 
                 // Tasks after activation
                 await StartupAsync();

--- a/CharacterMap/CharacterMap/Services/GlyphService.cs
+++ b/CharacterMap/CharacterMap/Services/GlyphService.cs
@@ -5,6 +5,7 @@ using CharacterMap.Helpers;
 using CharacterMap.Models;
 using CharacterMap.Provider;
 using CharacterMapCX;
+using GalaSoft.MvvmLight.Ioc;
 using Microsoft.Graphics.Canvas.Text;
 using SQLite;
 using System;
@@ -105,11 +106,19 @@ namespace CharacterMap.Services
             return _provider.SearchAsync(query, variant);
         }
 
-        public static (string Hex, string FontIcon, string Path, string Symbol) GetDevValues(Character c, FontVariant v, CanvasTextLayoutAnalysis analysis, CanvasTypography t, bool isXaml)
+        public static (string Hex, string FontIcon, string Path, string Symbol) GetDevValues(
+            Character c, FontVariant v, CanvasTextLayoutAnalysis a, CanvasTypography t, bool isXaml)
         {
+            Interop interop = SimpleIoc.Default.GetInstance<Interop>();
+
             string h, f, p, s = null;
-            string pathData = ExportManager.GetGeometry(ResourceHelper.AppSettings.GridSize, v, c, analysis, t).Path.Trim();
             bool hasSymbol = FontFinder.IsMDL2(v) && Enum.IsDefined(typeof(Symbol), c.UnicodeIndex);
+            
+            string pathData;
+            using (var geom = ExportManager.CreateGeometry(ResourceHelper.AppSettings.GridSize, v, c, a, t))
+            {
+                pathData = interop.GetPathData(geom).Path;
+            }
 
             var hex = c.UnicodeIndex.ToString("x4").ToUpper();
             if (isXaml)

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -654,4 +654,8 @@ Turning this on can have a minor impact on scrolling performance.</value>
   <data name="BtnContributors.Content" xml:space="preserve">
     <value>Contributors</value>
   </data>
+  <data name="TxtLoadingFonts.Text" xml:space="preserve">
+    <value>loading fonts</value>
+    <comment>intentionally lowercase for design reasons</comment>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -651,4 +651,7 @@ Turning this on can have a minor impact on scrolling performance.</value>
   <data name="SettingsNeedRestart.Text" xml:space="preserve">
     <value>Change will apply after restart</value>
   </data>
+  <data name="BtnContributors.Content" xml:space="preserve">
+    <value>Contributors</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Styles/Button.xaml
+++ b/CharacterMap/CharacterMap/Styles/Button.xaml
@@ -1,4 +1,7 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:helpers="using:CharacterMap.Helpers">
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Dark">
@@ -109,6 +112,7 @@
                 <ControlTemplate TargetType="Button">
                     <Grid
                         x:Name="RootGrid"
+                        helpers:Composition.OpacityDuration="0:0:0.1"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}">
@@ -176,6 +180,7 @@
                             Margin="0,10,10,10"
                             HorizontalAlignment="Right"
                             VerticalAlignment="Center"
+                            helpers:Composition.OpacityDuration="0:0:0.1"
                             AutomationProperties.AccessibilityView="Raw"
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="12"

--- a/CharacterMap/CharacterMap/Styles/ComboBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/ComboBox.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:CharacterMap.Styles">
+    xmlns:helpers="using:CharacterMap.Helpers">
 
     <Style TargetType="ComboBox">
         <Setter Property="Padding" Value="12,5,0,7" />
@@ -222,6 +222,7 @@
                             Margin="0,10,10,10"
                             HorizontalAlignment="Right"
                             VerticalAlignment="Center"
+                            helpers:Composition.OpacityDuration="0:0:0.1"
                             AutomationProperties.AccessibilityView="Raw"
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="12"

--- a/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
@@ -107,6 +107,7 @@ namespace CharacterMap.ViewModels
                     FontFamily = value == null ? null : new FontFamily(value.Source);
                     LoadChars(value);
                     RaisePropertyChanged();
+                    SelectedTypography = value?.XamlTypographyFeatures?.FirstOrDefault();
                     SetDefaultChar();
                 }
             }
@@ -298,6 +299,7 @@ namespace CharacterMap.ViewModels
                     ImportButtonEnabled = false;
                 }
 
+                SelectedTypography = null;
                 SearchResults = null;
                 DebounceSearch(SearchQuery, 100);
                 IsLoadingCharacters = false;

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -9,9 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:views="using:CharacterMap.Views"
-    SizeChanged="UserControl_SizeChanged"
     d:DesignHeight="800"
     d:DesignWidth="1280"
+    SizeChanged="UserControl_SizeChanged"
     mc:Ignorable="d">
 
     <Grid
@@ -501,9 +501,9 @@
                 <!--  Preview Grid  -->
                 <Grid
                     x:Name="PreviewGrid"
-                    SizeChanged="PreviewGrid_SizeChanged"
                     Grid.RowSpan="2"
-                    Grid.Column="2">
+                    Grid.Column="2"
+                    SizeChanged="PreviewGrid_SizeChanged">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
                         <RowDefinition Height="Auto" />
@@ -671,9 +671,10 @@
                         <Button
                             Grid.Row="2"
                             Height="54"
+                            Padding="8 4 0 5"
                             BorderThickness="0 1"
                             Click="BtnSaveAs_OnClick"
-                            Style="{ThemeResource TransparentButton}">
+                            Style="{StaticResource TransparentButton}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="50" />
@@ -702,7 +703,7 @@
                             Grid.RowSpan="6"
                             Height="54"
                             VerticalAlignment="Top"
-                            Style="{ThemeResource SaveAsPNGCommandBar}">
+                            Style="{StaticResource SaveAsPNGCommandBar}">
                             <CommandBar.SecondaryCommands>
                                 <AppBarButton
                                     Background="Transparent"
@@ -731,10 +732,11 @@
                             x:Load="{x:Bind core:Converters.False(ViewModel.IsSvgChar), Mode=OneWay, FallbackValue=False}"
                             Grid.Row="3"
                             Height="54"
+                            Padding="8 4 0 5"
                             BorderThickness="0 1"
                             Click="BtnSaveAsSvg_OnClick"
                             IsEnabled="{Binding SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}"
-                            Style="{ThemeResource TransparentButton}">
+                            Style="{StaticResource TransparentButton}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="50" />
@@ -751,6 +753,7 @@
                                     TextTrimming="CharacterEllipsis" />
                                 <FontIcon
                                     Grid.Column="2"
+                                    HorizontalAlignment="Center"
                                     FontSize="13"
                                     Glyph="&#xE972;" />
                             </Grid>
@@ -761,11 +764,12 @@
                             x:Load="{x:Bind ViewModel.IsSvgChar, Mode=OneWay, FallbackValue=False}"
                             Grid.Row="3"
                             Height="54"
+                            Padding="8 4 0 5"
                             BorderThickness="0 1"
                             Command="{x:Bind ViewModel.CommandSaveSvg}"
                             CommandParameter="{StaticResource TrueValue}"
                             IsEnabled="{Binding SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}"
-                            Style="{ThemeResource TransparentButton}">
+                            Style="{StaticResource TransparentButton}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="50" />

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -374,6 +374,9 @@
                                         SelectionMode="Single"
                                         ShowsScrollingPlaceholders="False"
                                         SingleSelectionFollowsFocus="True">
+                                        <ListView.ItemContainerTransitions>
+                                            <TransitionCollection />
+                                        </ListView.ItemContainerTransitions>
                                         <ListView.Header>
                                             <StackPanel Margin="12,4" Spacing="12">
                                                 <TextBlock

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+﻿<views:ViewBase
     x:Class="CharacterMap.Views.FontMapView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,6 +8,7 @@
     xmlns:helpers="using:CharacterMap.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:views="using:CharacterMap.Views"
     d:DesignHeight="800"
     d:DesignWidth="1280"
     mc:Ignorable="d">
@@ -115,7 +116,8 @@
         <Grid
             x:Name="MainUIGrid"
             Grid.Row="2"
-            Grid.Column="1">
+            Grid.Column="1"
+            Canvas.ZIndex="-1">
             <Grid.Resources>
                 <Storyboard x:Name="BorderFadeInStoryboard">
                     <DoubleAnimationUsingKeyFrames Storyboard.TargetName="BorderCopiedMessage" Storyboard.TargetProperty="Opacity">
@@ -507,22 +509,50 @@
 
                     <Grid>
                         <Viewbox
-                            MinHeight="200"
-                            Margin="30"
+                            Margin="24 12 24 4"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
                             Stretch="Uniform"
                             StretchDirection="Both">
                             <TextBlock
                                 x:Name="TxtPreview"
+                                VerticalAlignment="Center"
                                 FontFamily="{Binding FontFamily}"
+                                FontSize="{x:Bind core:Converters.GetFontSize(ViewModel.Settings.GridSize), Mode=OneTime}"
                                 FontStretch="{Binding SelectedVariant.FontFace.Stretch}"
                                 FontStyle="{Binding SelectedVariant.FontFace.Style}"
                                 FontWeight="{Binding SelectedVariant.FontFace.Weight}"
+                                Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
                                 IsColorFontEnabled="{Binding ShowColorGlyphs}"
                                 Text="{Binding SelectedChar.Char}"
                                 TextAlignment="Center" />
                         </Viewbox>
+
+                        <AppBarButton
+                            x:Name="BtnFit"
+                            Width="50"
+                            Height="50"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            Click="BtnFit_Click">
+                            <Grid>
+                                <FontIcon
+                                    x:Name="ZoomGlyph"
+                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                    FontSize="16"
+                                    Glyph="&#xE73F;"
+                                    Loaded="{x:Bind helpers:Composition.SetStandardFadeInOut}"
+                                    Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.Settings.FitCharacter), Mode=OneTime}" />
+                                <FontIcon
+                                    x:Name="ZoomOutGlyph"
+                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                    FontSize="16"
+                                    Glyph="&#xE740;"
+                                    Loaded="{x:Bind helpers:Composition.SetStandardFadeInOut}"
+                                    Visibility="{x:Bind ViewModel.Settings.FitCharacter, Mode=OneTime}" />
+                            </Grid>
+
+                        </AppBarButton>
 
                         <Border
                             x:Name="BorderCopiedMessage"
@@ -533,6 +563,7 @@
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Bottom"
                             Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+                            IsHitTestVisible="False"
                             Opacity="0">
                             <StackPanel Orientation="Horizontal">
                                 <FontIcon
@@ -1033,4 +1064,4 @@
         </VisualStateManager.VisualStateGroups>
     </Grid>
 
-</UserControl>
+</views:ViewBase>

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -273,8 +273,6 @@ namespace CharacterMap.Views
             }
         }
 
-        
-
         private void UpdateStates()
         {
             // Ideally should have been achieved with VisualState setters, buuuuut didn't work for some reason

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -78,8 +78,6 @@ namespace CharacterMap.Views
 
         private XamlDirect _xamlDirect { get; }
 
-        private UISettings _uiSettings = null;
-
         private long _previewColumnToken = long.MinValue;
 
         public FontMapView()

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -410,13 +410,13 @@ namespace CharacterMap.Views
             if (e.NewSize.Width > e.PreviousSize.Width)
                 return;
 
-            _sizeDebouncer.Debounce(64, () =>
+            _sizeDebouncer.Debounce(250, () =>
             {
                 if (!this.IsLoaded)
                     return;
 
-                var size = CharGrid.ActualWidth + Splitter.ActualWidth + PreviewGrid.ActualWidth;
-                if (this.ActualWidth < size)
+                var size = (int)CharGrid.ActualWidth + (int)Splitter.ActualWidth + (int)PreviewGrid.ActualWidth;
+                if (this.ActualWidth < size && this.ActualWidth < 700)
                 {
                     PreviewColumn.Width = new GridLength((int)(this.ActualWidth - CharGrid.ActualWidth - Splitter.ActualWidth));
                 }

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -109,6 +109,9 @@
                 Click="OpenFontPaneButton_Click"
                 Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                 Visibility="Collapsed">
+                <FrameworkElement.RenderTransform>
+                    <CompositeTransform />
+                </FrameworkElement.RenderTransform>
                 <SymbolIcon Symbol="GlobalNavigationButton" />
             </AppBarButton>
 
@@ -612,13 +615,7 @@
             Canvas.ZIndex="-1"
             Fill="{x:Bind StatusBar.Background, Mode=OneWay}" />
 
-        <!--  Loading Root  -->
-        <ProgressRing
-            x:Name="LoadingRing"
-            Grid.Row="2"
-            Grid.ColumnSpan="2"
-            Width="50"
-            Height="50" />
+
 
         <views:SettingsView
             x:Name="SettingsView"
@@ -668,6 +665,36 @@
             Grid.ColumnSpan="10">
             <wct:InAppNotification x:Name="DefaultNotification" />
         </Grid>
+
+        <!--  Loading Root  -->
+        <Grid
+            x:Name="LoadingRoot"
+            x:Load="{x:Bind ViewModel.IsLoadingFonts, Mode=OneWay}"
+            Grid.RowSpan="20"
+            Grid.ColumnSpan="20"
+            Background="{ThemeResource SystemAccentColor}"
+            Loading="LoadingRoot_Loading">
+
+            <StackPanel
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Spacing="24">
+                <ProgressRing
+                    Width="75"
+                    Height="75"
+                    Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock)}"
+                    IsActive="True" />
+
+                <TextBlock
+                    x:Uid="TxtLoadingFonts"
+                    HorizontalAlignment="Center"
+                    FontSize="18"
+                    FontWeight="SemiLight"
+                    Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock)}" />
+            </StackPanel>
+
+        </Grid>
+
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="ViewStates">
@@ -745,6 +772,11 @@
                                 <LinearDoubleKeyFrame KeyTime="0:0:0.2" Value="-60" />
                                 <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.9" Value="0" />
                             </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OpenFontPaneButton" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.1" Value="-100" />
+                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.8" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontMap" Storyboard.TargetProperty="Opacity">
                                 <LinearDoubleKeyFrame KeyTime="0:0:0" Value="0" />
                                 <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="0" />
@@ -784,7 +816,6 @@
                         <Setter Target="OpenFontPaneButton.IsEnabled" Value="False" />
                         <Setter Target="BtnSettings.IsEnabled" Value="False" />
                         <Setter Target="BtnSettings.Opacity" Value="0" />
-                        <Setter Target="LoadingRing.IsActive" Value="True" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FontsFailedState">

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -672,6 +672,7 @@
             x:Load="{x:Bind ViewModel.IsLoadingFonts, Mode=OneWay}"
             Grid.RowSpan="20"
             Grid.ColumnSpan="20"
+            Opacity="0.98"
             Background="{ThemeResource SystemAccentColor}"
             Loading="LoadingRoot_Loading">
 
@@ -805,7 +806,6 @@
                         <Setter Target="CommandsGrid.Opacity" Value="0" />
                         <Setter Target="SplitView.Opacity" Value="0" />
                         <Setter Target="SplitView.IsHitTestVisible" Value="False" />
-                        <Setter Target="FontTitleBlock.Visibility" Value="Collapsed" />
                         <Setter Target="SearchBox.IsEnabled" Value="False" />
                         <Setter Target="SearchBox.Opacity" Value="0" />
                         <Setter Target="ImportFontsButton.IsEnabled" Value="False" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -320,17 +320,21 @@
                     <Grid
                         x:Name="FontListGrid"
                         Grid.Row="1"
-                        Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
+                        Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
+                        Loading="FontListGrid_Loading">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
-                        <Border x:Name="CollectionControlRow" x:Load="{x:Bind core:Converters.IsNotNull(ViewModel.SelectedCollection), Mode=OneWay, TargetNullValue=False, FallbackValue=False}">
-                            <Border.Background>
-                                <SolidColorBrush Opacity="0.4" Color="{ThemeResource SystemAccentColor}" />
-                            </Border.Background>
+                        <Grid x:Name="CollectionControlRow" Visibility="{x:Bind core:Converters.IsNotNullToVis(ViewModel.SelectedCollection), Mode=OneWay, FallbackValue=Collapsed}">
+                            <Border x:Name="CollectionControlBackground">
+                                <Border.Background>
+                                    <SolidColorBrush Opacity="0.4" Color="{ThemeResource SystemAccentColor}" />
+                                </Border.Background>
+                            </Border>
                             <StackPanel
+                                x:Name="CollectionControlItems"
                                 Padding="0,0"
                                 HorizontalAlignment="Center"
                                 Orientation="Horizontal"
@@ -348,7 +352,7 @@
                                     Icon="Delete"
                                     ToolTipService.Placement="Bottom" />
                             </StackPanel>
-                        </Border>
+                        </Grid>
 
                         <TextBlock
                             x:Name="ImportFontHelpBlock"
@@ -366,11 +370,11 @@
                                     x:Name="LstFontFamily"
                                     IsItemClickEnabled="False"
                                     IsSwipeEnabled="False"
+                                    ItemTemplate="{StaticResource FontListItemTemplate}"
                                     ItemsSource="{Binding Source={StaticResource GroupedFontList}}"
                                     SelectedValuePath="Name"
-                                    SelectionMode="Single"
                                     SelectionChanged="LstFontFamily_SelectionChanged"
-                                    ItemTemplate="{StaticResource FontListItemTemplate}"
+                                    SelectionMode="Single"
                                     ShowsScrollingPlaceholders="False">
 
                                     <ListView.ItemContainerTransitions>
@@ -629,8 +633,7 @@
         </Grid>
 
         <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup
-                x:Name="ViewStates">
+            <VisualStateGroup x:Name="ViewStates">
                 <VisualState x:Name="CompactViewState">
                     <VisualState.Setters>
                         <Setter Target="SplitView.IsPaneOpen" Value="False" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -90,10 +90,6 @@
             Loading="CommandsGrid_Loading"
             RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(ThemeLock), Mode=OneWay}">
 
-            <FrameworkElement.RenderTransform>
-                <CompositeTransform />
-            </FrameworkElement.RenderTransform>
-
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="SplitViewPaneColumn" Width="{StaticResource StatusBarPaneWidth}" />
                 <ColumnDefinition Width="*" />
@@ -109,9 +105,6 @@
                 Click="OpenFontPaneButton_Click"
                 Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                 Visibility="Collapsed">
-                <FrameworkElement.RenderTransform>
-                    <CompositeTransform />
-                </FrameworkElement.RenderTransform>
                 <SymbolIcon Symbol="GlobalNavigationButton" />
             </AppBarButton>
 
@@ -125,11 +118,7 @@
                 Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                 Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
                 Text="{Binding SelectedFont.Name, Mode=OneWay}"
-                TextTrimming="CharacterEllipsis">
-                <FrameworkElement.RenderTransform>
-                    <CompositeTransform />
-                </FrameworkElement.RenderTransform>
-            </TextBlock>
+                TextTrimming="CharacterEllipsis" />
 
             <AutoSuggestBox
                 x:Name="SearchBox"
@@ -149,9 +138,6 @@
                 TextChanged="{x:Bind FontMap.SearchBox_TextChanged}"
                 TextMemberPath="Description"
                 UpdateTextOnSelect="False">
-                <FrameworkElement.RenderTransform>
-                    <CompositeTransform />
-                </FrameworkElement.RenderTransform>
                 <AutoSuggestBox.QueryIcon>
                     <SymbolIcon Symbol="Find" />
                 </AutoSuggestBox.QueryIcon>
@@ -169,9 +155,6 @@
                     VerticalAlignment="Center"
                     FontSize="16"
                     Glyph="&#xE115;" />
-                <FrameworkElement.RenderTransform>
-                    <CompositeTransform />
-                </FrameworkElement.RenderTransform>
             </AppBarButton>
         </Grid>
 
@@ -221,9 +204,6 @@
                             Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                             Style="{StaticResource TransparentHintButton}"
                             ToolTipService.Placement="Bottom">
-                            <FrameworkElement.RenderTransform>
-                                <CompositeTransform />
-                            </FrameworkElement.RenderTransform>
                             <Button.Flyout>
                                 <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
                                     <MenuFlyout.MenuFlyoutPresenterStyle>
@@ -335,9 +315,6 @@
                             VerticalAlignment="Bottom"
                             Click="{x:Bind OpenFont}"
                             Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}">
-                            <FrameworkElement.RenderTransform>
-                                <CompositeTransform />
-                            </FrameworkElement.RenderTransform>
                             <Path
                                 Height="16"
                                 Data="M896,320L1012,320L788,768L0,768L0,128L338.5,128L466.5,0L896,0ZM64,192L64,632.5L220.5,320L832,320L832,64L493.5,64L365.5,192ZM748,704L908,384L260,384L99.5,704Z"
@@ -353,10 +330,6 @@
                         Grid.Row="1"
                         Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                         Loading="FontListGrid_Loading">
-
-                        <FrameworkElement.RenderTransform>
-                            <CompositeTransform />
-                        </FrameworkElement.RenderTransform>
 
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -550,11 +523,7 @@
                 <views:FontMapView
                     x:Name="FontMap"
                     Grid.Row="1"
-                    Font="{x:Bind ViewModel.SelectedFont, Mode=OneWay}">
-                    <FrameworkElement.RenderTransform>
-                        <CompositeTransform />
-                    </FrameworkElement.RenderTransform>
-                </views:FontMapView>
+                    Font="{x:Bind ViewModel.SelectedFont, Mode=OneWay}" />
 
                 <!--  Status Bar  -->
                 <Grid
@@ -672,7 +641,6 @@
             x:Load="{x:Bind ViewModel.IsLoadingFonts, Mode=OneWay}"
             Grid.RowSpan="20"
             Grid.ColumnSpan="20"
-            Opacity="0.98"
             Background="{ThemeResource SystemAccentColor}"
             Loading="LoadingRoot_Loading">
 
@@ -685,7 +653,6 @@
                     Height="75"
                     Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock)}"
                     IsActive="True" />
-
                 <TextBlock
                     x:Uid="TxtLoadingFonts"
                     HorizontalAlignment="Center"
@@ -739,68 +706,6 @@
                 </VisualState>
             </VisualStateGroup>
             <VisualStateGroup x:Name="LoadingStates">
-                <VisualStateGroup.Transitions>
-                    <VisualTransition
-                        GeneratedDuration="0:0:0"
-                        From="FontsLoadingState"
-                        To="FontsLoadedState">
-                        <Storyboard>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="CommandsGrid" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-45" />
-                                <SplineDoubleKeyFrame KeySpline="0.1 0.9 0.2 1.0" KeyTime="0:0:0.5" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontTitleBlock" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
-                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.7" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SearchBox" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.1" Value="-100" />
-                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.8" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="BtnSettings" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.2" Value="-100" />
-                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.9" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OpenFontButton" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.1" Value="-100" />
-                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.8" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontListFilter" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-60" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.2" Value="-60" />
-                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.9" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OpenFontPaneButton" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.1" Value="-100" />
-                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.8" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontMap" Storyboard.TargetProperty="Opacity">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="0" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="0" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.73" Value="1" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontMap" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="140" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="140" />
-                                <SplineDoubleKeyFrame KeySpline="0.1 0.9 0.2 1.0" KeyTime="0:0:1.2" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontListGrid" Storyboard.TargetProperty="Opacity">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="0" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="0" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.73" Value="1" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontListGrid" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="140" />
-                                <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="140" />
-                                <SplineDoubleKeyFrame KeySpline="0.1 0.9 0.2 1.0" KeyTime="0:0:1.2" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualTransition>
-                </VisualStateGroup.Transitions>
                 <VisualState x:Name="FontsLoadingState">
                     <VisualState.Setters>
                         <Setter Target="CommandsGrid.Opacity" Value="0" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -23,6 +23,12 @@
             x:Name="GroupedFontList"
             IsSourceGrouped="True"
             Source="{Binding GroupedFontList}" />
+
+        <BackEase
+            x:Key="BackOut4"
+            Amplitude="0.4"
+            EasingMode="EaseOut" />
+
     </Page.Resources>
 
     <Grid
@@ -47,7 +53,8 @@
         <controls:XamlTitleBar
             x:Name="TitleBar"
             Grid.Row="0"
-            Grid.ColumnSpan="2">
+            Grid.ColumnSpan="2"
+            Canvas.ZIndex="1">
             <Grid ColumnSpacing="7">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -83,6 +90,10 @@
             Loading="CommandsGrid_Loading"
             RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(ThemeLock), Mode=OneWay}">
 
+            <FrameworkElement.RenderTransform>
+                <CompositeTransform />
+            </FrameworkElement.RenderTransform>
+
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="SplitViewPaneColumn" Width="{StaticResource StatusBarPaneWidth}" />
                 <ColumnDefinition Width="*" />
@@ -111,7 +122,11 @@
                 Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                 Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
                 Text="{Binding SelectedFont.Name, Mode=OneWay}"
-                TextTrimming="CharacterEllipsis" />
+                TextTrimming="CharacterEllipsis">
+                <FrameworkElement.RenderTransform>
+                    <CompositeTransform />
+                </FrameworkElement.RenderTransform>
+            </TextBlock>
 
             <AutoSuggestBox
                 x:Name="SearchBox"
@@ -131,6 +146,9 @@
                 TextChanged="{x:Bind FontMap.SearchBox_TextChanged}"
                 TextMemberPath="Description"
                 UpdateTextOnSelect="False">
+                <FrameworkElement.RenderTransform>
+                    <CompositeTransform />
+                </FrameworkElement.RenderTransform>
                 <AutoSuggestBox.QueryIcon>
                     <SymbolIcon Symbol="Find" />
                 </AutoSuggestBox.QueryIcon>
@@ -148,6 +166,9 @@
                     VerticalAlignment="Center"
                     FontSize="16"
                     Glyph="&#xE115;" />
+                <FrameworkElement.RenderTransform>
+                    <CompositeTransform />
+                </FrameworkElement.RenderTransform>
             </AppBarButton>
         </Grid>
 
@@ -164,6 +185,7 @@
             PaneBackground="Transparent">
             <SplitView.Pane>
                 <Grid x:Name="PaneRoot" Loading="PaneRoot_Loading">
+
                     <Grid.RowDefinitions>
                         <RowDefinition Height="{x:Bind TitleBarRow.Height}" />
                         <RowDefinition Height="*" />
@@ -196,6 +218,9 @@
                             Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                             Style="{StaticResource TransparentHintButton}"
                             ToolTipService.Placement="Bottom">
+                            <FrameworkElement.RenderTransform>
+                                <CompositeTransform />
+                            </FrameworkElement.RenderTransform>
                             <Button.Flyout>
                                 <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
                                     <MenuFlyout.MenuFlyoutPresenterStyle>
@@ -307,6 +332,9 @@
                             VerticalAlignment="Bottom"
                             Click="{x:Bind OpenFont}"
                             Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}">
+                            <FrameworkElement.RenderTransform>
+                                <CompositeTransform />
+                            </FrameworkElement.RenderTransform>
                             <Path
                                 Height="16"
                                 Data="M896,320L1012,320L788,768L0,768L0,128L338.5,128L466.5,0L896,0ZM64,192L64,632.5L220.5,320L832,320L832,64L493.5,64L365.5,192ZM748,704L908,384L260,384L99.5,704Z"
@@ -322,6 +350,11 @@
                         Grid.Row="1"
                         Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                         Loading="FontListGrid_Loading">
+
+                        <FrameworkElement.RenderTransform>
+                            <CompositeTransform />
+                        </FrameworkElement.RenderTransform>
+
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
@@ -514,7 +547,11 @@
                 <views:FontMapView
                     x:Name="FontMap"
                     Grid.Row="1"
-                    Font="{x:Bind ViewModel.SelectedFont, Mode=OneWay}" />
+                    Font="{x:Bind ViewModel.SelectedFont, Mode=OneWay}">
+                    <FrameworkElement.RenderTransform>
+                        <CompositeTransform />
+                    </FrameworkElement.RenderTransform>
+                </views:FontMapView>
 
                 <!--  Status Bar  -->
                 <Grid
@@ -674,15 +711,71 @@
                 </VisualState>
             </VisualStateGroup>
             <VisualStateGroup x:Name="LoadingStates">
+                <VisualStateGroup.Transitions>
+                    <VisualTransition
+                        GeneratedDuration="0:0:0"
+                        From="FontsLoadingState"
+                        To="FontsLoadedState">
+                        <Storyboard>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="CommandsGrid" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-45" />
+                                <SplineDoubleKeyFrame KeySpline="0.1 0.9 0.2 1.0" KeyTime="0:0:0.5" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontTitleBlock" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
+                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.7" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SearchBox" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.1" Value="-100" />
+                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.8" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="BtnSettings" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.2" Value="-100" />
+                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.9" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OpenFontButton" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-100" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.1" Value="-100" />
+                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.8" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontListFilter" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="-60" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.2" Value="-60" />
+                                <EasingDoubleKeyFrame EasingFunction="{StaticResource BackOut4}" KeyTime="0:0:0.9" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontMap" Storyboard.TargetProperty="Opacity">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="0" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.73" Value="1" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontMap" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="140" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="140" />
+                                <SplineDoubleKeyFrame KeySpline="0.1 0.9 0.2 1.0" KeyTime="0:0:1.2" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontListGrid" Storyboard.TargetProperty="Opacity">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="0" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.73" Value="1" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FontListGrid" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                                <LinearDoubleKeyFrame KeyTime="0:0:0" Value="140" />
+                                <LinearDoubleKeyFrame KeyTime="0:0:0.4" Value="140" />
+                                <SplineDoubleKeyFrame KeySpline="0.1 0.9 0.2 1.0" KeyTime="0:0:1.2" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualTransition>
+                </VisualStateGroup.Transitions>
                 <VisualState x:Name="FontsLoadingState">
-                    <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind ViewModel.IsLoadingFonts, Mode=OneWay}" />
-                    </VisualState.StateTriggers>
                     <VisualState.Setters>
+                        <Setter Target="CommandsGrid.Opacity" Value="0" />
                         <Setter Target="SplitView.Opacity" Value="0" />
                         <Setter Target="SplitView.IsHitTestVisible" Value="False" />
                         <Setter Target="FontTitleBlock.Visibility" Value="Collapsed" />
                         <Setter Target="SearchBox.IsEnabled" Value="False" />
+                        <Setter Target="SearchBox.Opacity" Value="0" />
                         <Setter Target="ImportFontsButton.IsEnabled" Value="False" />
                         <Setter Target="OpenFontButton.IsEnabled" Value="False" />
                         <Setter Target="OpenFontButton.Opacity" Value="0.4" />
@@ -690,13 +783,11 @@
                         <Setter Target="ShowPaneButton.IsEnabled" Value="False" />
                         <Setter Target="OpenFontPaneButton.IsEnabled" Value="False" />
                         <Setter Target="BtnSettings.IsEnabled" Value="False" />
+                        <Setter Target="BtnSettings.Opacity" Value="0" />
                         <Setter Target="LoadingRing.IsActive" Value="True" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FontsFailedState">
-                    <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind ViewModel.IsLoadingFontsFailed, Mode=OneWay}" />
-                    </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SplitView.Visibility" Value="Collapsed" />
                         <Setter Target="SearchBox.IsEnabled" Value="False" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -86,7 +86,6 @@
             Grid.Row="1"
             Grid.Column="0"
             Grid.ColumnSpan="2"
-            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
             Loading="CommandsGrid_Loading"
             RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(ThemeLock), Mode=OneWay}">
 
@@ -97,6 +96,13 @@
                 <ColumnDefinition Width="0" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
+
+            <!-- Required to work around error with hit-testing and shadowing -->
+            <Border
+                x:Name="CommandsGridBackground"
+                Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+                Grid.ColumnSpan="5"
+                />
 
             <AppBarButton
                 x:Name="OpenFontPaneButton"

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -38,8 +38,6 @@ namespace CharacterMap.Views
 
         private Debouncer _fontListDebouncer { get; } = new Debouncer();
 
-        private Debouncer _fontSelectionDebouncer { get; } = new Debouncer();
-
         public object ThemeLock { get; } = new object();
 
         private UISettings _uiSettings { get; }
@@ -97,6 +95,7 @@ namespace CharacterMap.Views
                 case nameof(ViewModel.IsLoadingFonts):
                 case nameof(ViewModel.IsLoadingFontsFailed):
                     UpdateLoadingStates();
+
                     break;
             }
         }
@@ -115,15 +114,15 @@ namespace CharacterMap.Views
                 if (ViewModel.Settings.UseSelectionAnimations)
                 {
                     Composition.StartStartUpAnimation(
-                        CommandsGrid,
+                        CommandsGridBackground,
                         new List<FrameworkElement>
                         {
+                            OpenFontPaneButton,
+                            FontListFilter,
+                            OpenFontButton,
                             FontTitleBlock,
                             SearchBox,
-                            OpenFontButton,
-                            BtnSettings,
-                            FontListFilter,
-                            OpenFontPaneButton
+                            BtnSettings
                         },
                         new List<FrameworkElement>
                         {
@@ -242,37 +241,6 @@ namespace CharacterMap.Views
             if (e.AddedItems.FirstOrDefault() is InstalledFont font)
             {
                 ViewModel.SelectedFont = font;
-            }
-        }
-
-        private void Grid_DragOver(object sender, DragEventArgs e)
-        {
-            e.AcceptedOperation = DataPackageOperation.Copy;
-        }
-
-        private async void Grid_Drop(object sender, DragEventArgs e)
-        {
-            if (e.DataView.Contains(StandardDataFormats.StorageItems))
-            {
-                ViewModel.IsLoadingFonts = true;
-                try
-                {
-                    var items = await e.DataView.GetStorageItemsAsync();
-                    if (await FontFinder.ImportFontsAsync(items) is FontImportResult result)
-                    {
-                        if (result.Imported.Count > 0)
-                        {
-                            ViewModel.RefreshFontList();
-                            ViewModel.TrySetSelectionFromImport(result);
-                        }
-
-                        ShowImportResult(result);
-                    }
-                }
-                finally
-                {
-                    ViewModel.IsLoadingFonts = false;
-                }
             }
         }
 
@@ -413,6 +381,37 @@ namespace CharacterMap.Views
                 {
                     ViewModel.RefreshFontList(ViewModel.SelectedCollection);
                 });
+            }
+        }
+
+        private void Grid_DragOver(object sender, DragEventArgs e)
+        {
+            e.AcceptedOperation = DataPackageOperation.Copy;
+        }
+
+        private async void Grid_Drop(object sender, DragEventArgs e)
+        {
+            if (e.DataView.Contains(StandardDataFormats.StorageItems))
+            {
+                ViewModel.IsLoadingFonts = true;
+                try
+                {
+                    var items = await e.DataView.GetStorageItemsAsync();
+                    if (await FontFinder.ImportFontsAsync(items) is FontImportResult result)
+                    {
+                        if (result.Imported.Count > 0)
+                        {
+                            ViewModel.RefreshFontList();
+                            ViewModel.TrySetSelectionFromImport(result);
+                        }
+
+                        ShowImportResult(result);
+                    }
+                }
+                finally
+                {
+                    ViewModel.IsLoadingFonts = false;
+                }
             }
         }
 
@@ -577,8 +576,8 @@ namespace CharacterMap.Views
             int duration = 200;
             var ani = v.Compositor.CreateVector3KeyFrameAnimation();
             ani.Target = nameof(v.Scale);
-            ani.InsertKeyFrame(1, new System.Numerics.Vector3(1.1f, 1.1f, 0));
-            ani.Duration = TimeSpan.FromMilliseconds(duration);
+            ani.InsertKeyFrame(1, new System.Numerics.Vector3(1.15f, 1.15f, 0));
+            ani.Duration = TimeSpan.FromMilliseconds(300);
 
             var op = Composition.CreateFade(v.Compositor, 0, null, duration);
 

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -542,5 +542,22 @@ namespace CharacterMap.Views
                 CollectionControlItems.Children.Cast<FrameworkElement>().ToList(),
                 CollectionControlRow);
         }
+
+        private void LoadingRoot_Loading(FrameworkElement sender, object args)
+        {
+            var v = sender.GetElementVisual();
+
+            Composition.StartCentering(v);
+
+            int duration = 200;
+            var ani = v.Compositor.CreateVector3KeyFrameAnimation();
+            ani.Target = nameof(v.Scale);
+            ani.InsertKeyFrame(1, new System.Numerics.Vector3(1.1f, 1.1f, 0));
+            ani.Duration = TimeSpan.FromMilliseconds(duration);
+
+            var op = Composition.CreateFade(v.Compositor, 0, null, duration);
+
+            sender.SetHideAnimation(v.Compositor.CreateAnimationGroup(ani, op));
+        }
     }
 }

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -108,7 +108,7 @@ namespace CharacterMap.Views
             else if (ViewModel.IsLoadingFontsFailed)
                 VisualStateManager.GoToState(this, nameof(FontsFailedState), true);
             else
-                VisualStateManager.GoToState(this, nameof(FontsLoadedState), true);
+                VisualStateManager.GoToState(this, nameof(FontsLoadedState), ViewModel.Settings.UseSelectionAnimations);
         }
 
         private void OnAppSettingsChanged(AppSettingsChangedMessage msg)
@@ -545,6 +545,9 @@ namespace CharacterMap.Views
 
         private void LoadingRoot_Loading(FrameworkElement sender, object args)
         {
+            if (!ViewModel.Settings.UseSelectionAnimations)
+                return;
+
             var v = sender.GetElementVisual();
 
             Composition.StartCentering(v);

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -41,7 +41,7 @@ namespace CharacterMap.Views
         private Debouncer _fontSelectionDebouncer { get; } = new Debouncer();
 
         public object ThemeLock { get; } = new object();
-       
+
         private UISettings _uiSettings { get; }
 
         private bool _isCtrlKeyPressed;
@@ -184,7 +184,7 @@ namespace CharacterMap.Views
 
         private void LayoutRoot_KeyUp(object sender, KeyRoutedEventArgs e)
         {
-            if (e.Key == VirtualKey.Control) 
+            if (e.Key == VirtualKey.Control)
                 _isCtrlKeyPressed = false;
         }
 
@@ -263,59 +263,6 @@ namespace CharacterMap.Views
                     {
                         ViewModel.RefreshFontList(ViewModel.SelectedCollection);
                     });
-                }
-            }
-        }
-
-        private async void PickFonts()
-        {
-            var picker = new FileOpenPicker();
-            foreach (var format in FontFinder.SupportedFormats)
-                picker.FileTypeFilter.Add(format);
-
-            picker.CommitButtonText = Localization.Get("FilePickerConfirm");
-            var files = await picker.PickMultipleFilesAsync();
-            if (files.Any())
-            {
-                ViewModel.IsLoadingFonts = true;
-                try
-                {
-                    if (await FontFinder.ImportFontsAsync(files.ToList()) is FontImportResult result
-                        && result.Imported.Count > 0)
-                    {
-                        ViewModel.RefreshFontList();
-                        ViewModel.TrySetSelectionFromImport(result);
-                    }
-                }
-                finally
-                {
-                    ViewModel.IsLoadingFonts = false;
-                }
-            }
-        }
-
-        private async void OpenFont()
-        {
-            var picker = new FileOpenPicker();
-            foreach (var format in FontFinder.SupportedFormats)
-                picker.FileTypeFilter.Add(format);
-
-            picker.CommitButtonText = Localization.Get("OpenFontPickerConfirm");
-            var file = await picker.PickSingleFileAsync();
-            if (file != null)
-            {
-                try
-                {
-                    ViewModel.IsLoadingFonts = true;
-
-                    if (await FontFinder.LoadFromFileAsync(file) is InstalledFont font)
-                    {
-                        await FontMapView.CreateNewViewForFontAsync(font, file);
-                    }
-                }
-                finally
-                {
-                    ViewModel.IsLoadingFonts = false;
                 }
             }
         }
@@ -399,17 +346,6 @@ namespace CharacterMap.Views
             }
         }
 
-        private void FontContextFlyout_Opening(object sender, object e)
-        {
-            if (sender is MenuFlyout menu && menu.Target.DataContext is InstalledFont font)
-            {
-                FlyoutHelper.CreateMenu(
-                    menu, 
-                    font, 
-                    false);
-            }
-        }
-
         private void RenameFontCollection_Click(object sender, RoutedEventArgs e)
         {
             _ = (new CreateCollectionDialog(ViewModel.SelectedCollection)).ShowAsync();
@@ -450,6 +386,59 @@ namespace CharacterMap.Views
             }
         }
 
+        private async void PickFonts()
+        {
+            var picker = new FileOpenPicker();
+            foreach (var format in FontFinder.SupportedFormats)
+                picker.FileTypeFilter.Add(format);
+
+            picker.CommitButtonText = Localization.Get("FilePickerConfirm");
+            var files = await picker.PickMultipleFilesAsync();
+            if (files.Any())
+            {
+                ViewModel.IsLoadingFonts = true;
+                try
+                {
+                    if (await FontFinder.ImportFontsAsync(files.ToList()) is FontImportResult result
+                        && result.Imported.Count > 0)
+                    {
+                        ViewModel.RefreshFontList();
+                        ViewModel.TrySetSelectionFromImport(result);
+                    }
+                }
+                finally
+                {
+                    ViewModel.IsLoadingFonts = false;
+                }
+            }
+        }
+
+        private async void OpenFont()
+        {
+            var picker = new FileOpenPicker();
+            foreach (var format in FontFinder.SupportedFormats)
+                picker.FileTypeFilter.Add(format);
+
+            picker.CommitButtonText = Localization.Get("OpenFontPickerConfirm");
+            var file = await picker.PickSingleFileAsync();
+            if (file != null)
+            {
+                try
+                {
+                    ViewModel.IsLoadingFonts = true;
+
+                    if (await FontFinder.LoadFromFileAsync(file) is InstalledFont font)
+                    {
+                        await FontMapView.CreateNewViewForFontAsync(font, file);
+                    }
+                }
+                finally
+                {
+                    ViewModel.IsLoadingFonts = false;
+                }
+            }
+        }
+
         private void OnFontImportRequest(ImportMessage msg)
         {
             _ = CoreApplication.MainView.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
@@ -480,9 +469,9 @@ namespace CharacterMap.Views
         void ShowImportResult(FontImportResult result)
         {
             if (result.Imported.Count == 1)
-                InAppNotificationHelper.ShowNotification(this, Localization.Get("NotificationSingleFontAdded",  result.Imported[0].Name), 4000);
+                InAppNotificationHelper.ShowNotification(this, Localization.Get("NotificationSingleFontAdded", result.Imported[0].Name), 4000);
             else if (result.Imported.Count > 1)
-                InAppNotificationHelper.ShowNotification(this, Localization.Get("NotificationMultipleFontsAdded",  result.Imported.Count), 4000);
+                InAppNotificationHelper.ShowNotification(this, Localization.Get("NotificationMultipleFontsAdded", result.Imported.Count), 4000);
             else if (result.Invalid.Count > 0)
             {
                 StringBuilder sb = new StringBuilder();
@@ -502,6 +491,9 @@ namespace CharacterMap.Views
 
 
 
+
+        /* Notifications */
+
         public InAppNotification GetNotifier()
         {
             if (NotificationRoot == null)
@@ -514,6 +506,11 @@ namespace CharacterMap.Views
         {
             InAppNotificationHelper.OnMessage(this, msg);
         }
+
+
+
+
+        /* Composition */
 
         private void PaneRoot_Loading(FrameworkElement sender, object args)
         {
@@ -528,6 +525,14 @@ namespace CharacterMap.Views
         private void CommandsGrid_Loading(FrameworkElement sender, object args)
         {
             Composition.SetThemeShadow(sender, 20, FontMap);
+        }
+
+        private void FontListGrid_Loading(FrameworkElement sender, object args)
+        {
+            Composition.SetDropInOut(
+                CollectionControlBackground,
+                CollectionControlItems.Children.Cast<FrameworkElement>().ToList(),
+                CollectionControlRow);
         }
     }
 }

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -103,12 +103,31 @@ namespace CharacterMap.Views
 
         private void UpdateLoadingStates()
         {
+
             if (ViewModel.IsLoadingFonts && !ViewModel.IsLoadingFontsFailed)
                 VisualStateManager.GoToState(this, nameof(FontsLoadingState), true);
             else if (ViewModel.IsLoadingFontsFailed)
                 VisualStateManager.GoToState(this, nameof(FontsFailedState), true);
             else
-                VisualStateManager.GoToState(this, nameof(FontsLoadedState), ViewModel.Settings.UseSelectionAnimations);
+            {
+                if (ViewModel.Settings.UseSelectionAnimations)
+                {
+                    TitleBar.TryUpdateMetrics();
+                    _ = Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                    {
+                        _ = Dispatcher.RunAsync(CoreDispatcherPriority.Low, async () =>
+                        {
+                            await Task.Delay(32);
+                            if (!ViewModel.IsLoadingFonts && !ViewModel.IsLoadingFontsFailed)
+                                VisualStateManager.GoToState(this, nameof(FontsLoadedState), ViewModel.Settings.UseSelectionAnimations);
+                        });
+                    });
+                }
+                else
+                {
+                    VisualStateManager.GoToState(this, nameof(FontsLoadedState), ViewModel.Settings.UseSelectionAnimations);
+                }
+            }
         }
 
         private void OnAppSettingsChanged(AppSettingsChangedMessage msg)

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -371,7 +371,7 @@ namespace CharacterMap.Views
                     menu.Items.Add(new MenuFlyoutSeparator());
                     foreach (var item in ViewModel.FontCollections.Items)
                     {
-                        var m = new MenuFlyoutItem { DataContext = item, Text = item.Name };
+                        var m = new MenuFlyoutItem { DataContext = item, Text = item.Name, FontSize = 16 };
                         m.Click += (s, a) =>
                         {
                             if (m.DataContext is UserFontCollection u)

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -77,32 +77,38 @@ namespace CharacterMap.Views
 
         private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(ViewModel.GroupedFontList))
+            switch (e.PropertyName)
             {
-                if (ViewModel.IsLoadingFonts)
-                    return;
+                case nameof(ViewModel.GroupedFontList):
+                    if (ViewModel.IsLoadingFonts)
+                        return;
 
-                if (ViewModel.Settings.UseSelectionAnimations)
-                    Composition.PlayEntrance(LstFontFamily, 66, 100);
+                    if (ViewModel.Settings.UseSelectionAnimations)
+                        Composition.PlayEntrance(LstFontFamily, 66, 100);
+
+                    break;
+
+                case nameof(ViewModel.SelectedFont):
+                    if (ViewModel.SelectedFont != null)
+                        LstFontFamily.SelectedItem = ViewModel.SelectedFont;
+
+                    break;
+
+                case nameof(ViewModel.IsLoadingFonts):
+                case nameof(ViewModel.IsLoadingFontsFailed):
+                    UpdateLoadingStates();
+                    break;
             }
-            else if (e.PropertyName == nameof(ViewModel.SelectedFont))
-            {
-                if (ViewModel.SelectedFont != null)
-                    LstFontFamily.SelectedItem = ViewModel.SelectedFont;
+        }
 
-                // Looks weird, important for performance to prevent
-                // reloading CharacterGrid when changing FontList preview font
-                //_fontSelectionDebouncer.Debounce(16, () => { var t = _fontSelectionDebouncer; });
-            }
-            //else if (e.PropertyName == "FontSelectionDebounce")
-            //{
-            //    // Looks weird, important for performance to prevent
-            //    // reloading CharacterGrid when changing FontList preview font
-            //    _fontSelectionDebouncer.Debounce(16, () => { var t = _fontSelectionDebouncer; });
-            //    LstFontFamily.SelectedItem = ViewModel.SelectedFont;
-
-            //    ViewModel_FontListCreated(sender, e);
-            //}
+        private void UpdateLoadingStates()
+        {
+            if (ViewModel.IsLoadingFonts && !ViewModel.IsLoadingFontsFailed)
+                VisualStateManager.GoToState(this, nameof(FontsLoadingState), true);
+            else if (ViewModel.IsLoadingFontsFailed)
+                VisualStateManager.GoToState(this, nameof(FontsFailedState), true);
+            else
+                VisualStateManager.GoToState(this, nameof(FontsLoadedState), true);
         }
 
         private void OnAppSettingsChanged(AppSettingsChangedMessage msg)
@@ -132,6 +138,8 @@ namespace CharacterMap.Views
 
             ViewModel.FontListCreated -= ViewModel_FontListCreated;
             ViewModel.FontListCreated += ViewModel_FontListCreated;
+
+            UpdateLoadingStates();
         }
 
         private void MainPage_Unloaded(object sender, RoutedEventArgs e)

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -103,6 +103,7 @@ namespace CharacterMap.Views
 
         private void UpdateLoadingStates()
         {
+            TitleBar.TryUpdateMetrics();
 
             if (ViewModel.IsLoadingFonts && !ViewModel.IsLoadingFontsFailed)
                 VisualStateManager.GoToState(this, nameof(FontsLoadingState), true);
@@ -110,22 +111,24 @@ namespace CharacterMap.Views
                 VisualStateManager.GoToState(this, nameof(FontsFailedState), true);
             else
             {
+                VisualStateManager.GoToState(this, nameof(FontsLoadedState), false);
                 if (ViewModel.Settings.UseSelectionAnimations)
                 {
-                    TitleBar.TryUpdateMetrics();
-                    _ = Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
-                    {
-                        _ = Dispatcher.RunAsync(CoreDispatcherPriority.Low, async () =>
+                    Composition.StartStartUpAnimation(
+                        CommandsGrid,
+                        new List<FrameworkElement>
                         {
-                            await Task.Delay(32);
-                            if (!ViewModel.IsLoadingFonts && !ViewModel.IsLoadingFontsFailed)
-                                VisualStateManager.GoToState(this, nameof(FontsLoadedState), ViewModel.Settings.UseSelectionAnimations);
+                            FontTitleBlock,
+                            SearchBox,
+                            OpenFontButton,
+                            BtnSettings,
+                            FontListFilter,
+                            OpenFontPaneButton
+                        },
+                        new List<FrameworkElement>
+                        {
+                            FontMap, FontListGrid
                         });
-                    });
-                }
-                else
-                {
-                    VisualStateManager.GoToState(this, nameof(FontsLoadedState), ViewModel.Settings.UseSelectionAnimations);
                 }
             }
         }

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+﻿<views:ViewBase
     x:Class="CharacterMap.Views.SettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,6 +7,7 @@
     xmlns:helpers="using:CharacterMap.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:views="using:CharacterMap.Views"
     xmlns:win1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
     d:DesignHeight="1880"
     d:DesignWidth="1920"
@@ -94,7 +95,10 @@
         </Grid>
 
         <ScrollViewer x:Name="ContentScroller" Grid.Row="1">
-            <Grid x:Name="ContentPanel" ColumnSpacing="16" Margin="20 20 20 120">
+            <Grid
+                x:Name="ContentPanel"
+                ColumnSpacing="16"
+                Margin="20 20 20 120">
 
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" MaxWidth="700" />
@@ -477,4 +481,4 @@
             </Grid>
         </ScrollViewer>
     </Grid>
-</UserControl>
+</views:ViewBase>

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -94,7 +94,7 @@
         </Grid>
 
         <ScrollViewer x:Name="ContentScroller" Grid.Row="1">
-            <Grid ColumnSpacing="16" Margin="20 20 20 120">
+            <Grid x:Name="ContentPanel" ColumnSpacing="16" Margin="20 20 20 120">
 
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" MaxWidth="700" />
@@ -103,7 +103,7 @@
 
                 <!--#region LEFT COLUMN-->
 
-                <StackPanel>
+                <StackPanel x:Name="LeftPanel">
 
                     <!--#region USER INTERFACE-->
 
@@ -418,6 +418,7 @@
                 <!--#region RIGHT COLUMN-->
 
                 <StackPanel
+                    x:Name="RightPanel"
                     Grid.Row="1"
                     Grid.Column="1"
                     MaxWidth="216"

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:core="using:CharacterMap.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:CharacterMap.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:win1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
@@ -15,13 +16,14 @@
 
     <UserControl.Resources>
         <Style x:Key="SubheaderTextBlockStyle" BasedOn="{StaticResource SubheaderTextBlockStyle}" TargetType="TextBlock">
-            <Setter Property="FontSize" Value="26" />
-            <Setter Property="FontWeight" Value="Light" />
-            <Setter Property="Margin" Value="0 12 0 -16" />
+            <Setter Property="FontSize" Value="20" />
+            <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="Margin" Value="0 12 0 4" />
         </Style>
         <Style x:Key="DescriptionStyle" BasedOn="{StaticResource BaseTextBlockStyle}" TargetType="TextBlock">
             <Setter Property="Opacity" Value="0.7" />
             <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="Margin" Value="0 4 0 8" />
             <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
         </Style>
         <Style x:Key="HeaderStyle" TargetType="TextBlock">
@@ -29,9 +31,22 @@
             <Setter Property="FontWeight" Value="Bold" />
             <Setter Property="Margin" Value="0 20 0 0" />
         </Style>
+        <Style x:Key="HintStyle" BasedOn="{StaticResource DescriptionStyle}" TargetType="TextBlock">
+            <Setter Property="Margin" Value="4 4 0 12" />
+            <Setter Property="FontStyle" Value="Italic" />
+            <Setter Property="OpticalMarginAlignment" Value="None" />
+        </Style>
         <Style TargetType="RadioButton">
             <Setter Property="MinWidth" Value="200" />
         </Style>
+
+        <Style x:Key="SpacerStyle" TargetType="Border">
+            <Setter Property="Height" Value="1" />
+            <Setter Property="Background" Value="{ThemeResource AppBarItemForegroundThemeBrush}" />
+            <Setter Property="Opacity" Value="0.3" />
+            <Setter Property="Margin" Value="0 24 0 12" />
+        </Style>
+
     </UserControl.Resources>
 
     <!--
@@ -40,10 +55,10 @@
     <Grid>
         <Grid.Background>
             <AcrylicBrush
-                win1903:TintLuminosityOpacity="0.2"
+                win1903:TintLuminosityOpacity="0.3"
                 BackgroundSource="Backdrop"
                 TintColor="{ThemeResource SystemChromeGrayColor}"
-                TintOpacity="0.5" />
+                TintOpacity="0.6" />
         </Grid.Background>
 
         <Grid.RowDefinitions>
@@ -94,28 +109,8 @@
 
                     <TextBlock
                         x:Uid="SettingsUIHeader"
-                        Margin="0 -4 0 -16"
                         Style="{StaticResource SubheaderTextBlockStyle}"
                         Text="#UserInterface" />
-
-                    <TextBlock
-                        x:Uid="SettingsLanguageHeader"
-                        Style="{StaticResource HeaderStyle}"
-                        Text="#Language" />
-
-                    <ComboBox
-                        Height="48"
-                        ItemsSource="{x:Bind SupportedLanguages}"
-                        PlaceholderText="{x:Bind core:Converters.GetLanguageDisplayFromID(Settings.AppLanguage)}"
-                        SelectedItem="{x:Bind core:Converters.GetSelectedLanguage(Settings.AppLanguage, SupportedLanguages), Mode=TwoWay, BindBack=SelectedLanguageToString}"/>
-                    
-                    <TextBlock
-                        x:Uid="SettingsNeedRestart"
-                        Margin="4 4 0 4"
-                        FontStyle="Italic"
-                        OpticalMarginAlignment="None"
-                        Style="{StaticResource DescriptionStyle}"
-                        Visibility="{x:Bind core:Converters.CompareLanguageToSetting(Settings.AppLanguage), Mode=OneWay}"/> 
 
                     <TextBlock
                         x:Uid="SettingsCharGridHeader"
@@ -214,12 +209,7 @@
 
                     </StackPanel>
 
-                    <TextBlock
-                        x:Uid="SettingsCharPreviewHint"
-                        Margin="4 4 0 12"
-                        FontStyle="Italic"
-                        OpticalMarginAlignment="None"
-                        Style="{StaticResource DescriptionStyle}" />
+                    <TextBlock x:Uid="SettingsCharPreviewHint" Style="{StaticResource HintStyle}" />
 
                     <TextBlock x:Uid="FontListDisplayHeader" Style="{StaticResource HeaderStyle}" />
                     <TextBlock x:Uid="SettingsFontListDescription" Style="{StaticResource DescriptionStyle}" />
@@ -258,12 +248,7 @@
                         </ListView.Resources>
                     </ListView>
 
-                    <TextBlock
-                        x:Uid="SettingsFontListPreviewHint"
-                        Margin="4 4 0 12"
-                        FontStyle="Italic"
-                        OpticalMarginAlignment="None"
-                        Style="{StaticResource DescriptionStyle}" />
+                    <TextBlock x:Uid="SettingsFontListPreviewHint" Style="{StaticResource HintStyle}" />
 
 
                     <TextBlock x:Uid="SettingsThemeHeader" Style="{StaticResource HeaderStyle}" />
@@ -284,41 +269,51 @@
                         GroupName="ThemeSelector" />
 
 
-                    <TextBlock x:Uid="SettingsSimpleAnimationHeader" Style="{StaticResource HeaderStyle}" />
-                    <TextBlock x:Uid="SettingsSimpleAnimationDescription" Style="{StaticResource DescriptionStyle}" />
-                    <ToggleSwitch IsOn="{x:Bind Settings.UseSelectionAnimations, Mode=TwoWay}" />
+                    <StackPanel>
+                        <TextBlock
+                            x:Uid="SettingsLanguageHeader"
+                            Style="{StaticResource HeaderStyle}"
+                            Text="#Language" />
 
-                    <win1903:StackPanel>
-                        <TextBlock x:Uid="SettingsShadowsHeader" Style="{StaticResource HeaderStyle}" />
-                        <TextBlock x:Uid="SettingsShadowsDescription" Style="{StaticResource DescriptionStyle}" />
-                        <ToggleSwitch IsOn="{x:Bind Settings.EnableShadows, Mode=TwoWay}" />
-                    </win1903:StackPanel>
-
-
-                    <TextBlock x:Uid="SettingsExpensiveAnimationHeader" Style="{StaticResource HeaderStyle}" />
-                    <TextBlock x:Uid="SettingsExpensiveAnimationDescription" Style="{StaticResource DescriptionStyle}" />
-                    <ToggleSwitch IsOn="{x:Bind Settings.AllowExpensiveAnimations, Mode=TwoWay}" />
-
-
-
-
-
-                    <StackPanel x:Name="LanguagePanel" Visibility="Collapsed">
-                        <TextBlock x:Uid="SettingsLanguageHeader" Style="{StaticResource HeaderStyle}" />
-                        <TextBlock x:Uid="SettingsLanguageDescription" Style="{StaticResource DescriptionStyle}" />
-                        <ToggleSwitch x:Name="LangOverrideSwitch" x:Uid="SettingsLangOverride" />
                         <ComboBox
-                            x:Name="ComboLanguages"
-                            Width="200"
-                            SelectedIndex="0"
-                            Visibility="{x:Bind LangOverrideSwitch.IsOn, Mode=OneWay}" />
+                            Width="256"
+                            Margin="0 8 0 0"
+                            ItemsSource="{x:Bind SupportedLanguages}"
+                            PlaceholderText="{x:Bind core:Converters.GetLanguageDisplayFromID(Settings.AppLanguage)}"
+                            SelectedItem="{x:Bind core:Converters.GetSelectedLanguage(Settings.AppLanguage, SupportedLanguages), Mode=TwoWay, BindBack=SelectedLanguageToString}"
+                            Style="{StaticResource DefaultComboBoxStyle}" />
+
+                        <TextBlock
+                            x:Uid="SettingsNeedRestart"
+                            Margin="4 4 0 4"
+                            Style="{StaticResource HintStyle}"
+                            Visibility="{x:Bind core:Converters.CompareLanguageToSetting(Settings.AppLanguage), Mode=OneWay}" />
+                    </StackPanel>
+
+                    <StackPanel Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
+                        <TextBlock x:Uid="SettingsSimpleAnimationHeader" Style="{StaticResource HeaderStyle}" />
+                        <TextBlock x:Uid="SettingsSimpleAnimationDescription" Style="{StaticResource DescriptionStyle}" />
+                        <ToggleSwitch IsOn="{x:Bind Settings.UseSelectionAnimations, Mode=TwoWay}" />
+
+                        <win1903:StackPanel>
+                            <TextBlock x:Uid="SettingsShadowsHeader" Style="{StaticResource HeaderStyle}" />
+                            <TextBlock x:Uid="SettingsShadowsDescription" Style="{StaticResource DescriptionStyle}" />
+                            <ToggleSwitch IsOn="{x:Bind Settings.EnableShadows, Mode=TwoWay}" />
+                        </win1903:StackPanel>
+
+
+                        <TextBlock x:Uid="SettingsExpensiveAnimationHeader" Style="{StaticResource HeaderStyle}" />
+                        <TextBlock x:Uid="SettingsExpensiveAnimationDescription" Style="{StaticResource DescriptionStyle}" />
+                        <ToggleSwitch IsOn="{x:Bind Settings.AllowExpensiveAnimations, Mode=TwoWay}" />
                     </StackPanel>
 
                     <!--#endregion-->
 
+                    <Border Loaded="{x:Bind helpers:Composition.SetStandardReposition}" Style="{StaticResource SpacerStyle}" />
+
                     <!--#region EXPORT-->
 
-                    <StackPanel Margin="0 12 0 0">
+                    <StackPanel Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
                         <TextBlock x:Uid="SettingsExportHeader" Style="{StaticResource SubheaderTextBlockStyle}" />
                         <TextBlock x:Uid="SettingsPNGExportHeader" Style="{StaticResource HeaderStyle}" />
                         <TextBlock x:Uid="SettingsPNGExportDescription" Style="{StaticResource DescriptionStyle}" />
@@ -343,14 +338,11 @@
 
                     <!--#endregion-->
 
+                    <Border Loaded="{x:Bind helpers:Composition.SetStandardReposition}" Style="{StaticResource SpacerStyle}" />
+
                     <!--#region CHARACTER SEARCH-->
 
-                    <StackPanel Margin="0 0 0 0">
-                        <StackPanel.ChildrenTransitions>
-                            <TransitionCollection>
-                                <RepositionThemeTransition IsStaggeringEnabled="False" />
-                            </TransitionCollection>
-                        </StackPanel.ChildrenTransitions>
+                    <StackPanel Margin="0 0 0 0" Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
 
                         <TextBlock x:Uid="SettingsCharacterSearchHeader" Style="{StaticResource SubheaderTextBlockStyle}" />
 
@@ -386,18 +378,22 @@
                             AcceptsExpression="False"
                             Header="#Search Results"
                             LargeChange="10"
+                            Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
                             Maximum="100"
                             Minimum="5"
                             SmallChange="5"
                             SpinButtonPlacementMode="Inline"
                             Value="{x:Bind Settings.MaxSearchResult, Mode=TwoWay}" />
+
                     </StackPanel>
 
                     <!--#endregion-->
 
+                    <Border Loaded="{x:Bind helpers:Composition.SetStandardReposition}" Style="{StaticResource SpacerStyle}" />
+
                     <!--#region DEVELOPER FEATURES-->
 
-                    <StackPanel x:Name="DeveloperPanel" Margin="0 24 0 0">
+                    <StackPanel x:Name="DeveloperPanel" Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
                         <TextBlock x:Uid="SettingsDevToolsGroupHeader" Style="{StaticResource SubheaderTextBlockStyle}" />
 
                         <StackPanel Visibility="Collapsed">
@@ -443,6 +439,7 @@
                         Text="#Settings_AboutDescription"
                         TextWrapping="Wrap" />
                     <HyperlinkButton Content="GitHub" NavigateUri="https://github.com/EdiWang/UWP-CharacterMap" />
+                    <HyperlinkButton x:Uid="BtnContributors" NavigateUri="https://github.com/EdiWang/Character-Map-UWP/graphs/contributors" />
 
 
                     <StackPanel

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -46,45 +46,18 @@ namespace CharacterMap.Views
         public SettingsView()
         {
             Settings = ResourceHelper.AppSettings;
-
             FontCollections = SimpleIoc.Default.GetInstance<UserCollectionsService>();
             Messenger.Default.Register<AppSettingsChangedMessage>(this, OnAppSettingsUpdated);
 
             this.InitializeComponent();
+            SetupAnimations();
 
-            ElementCompositionPreview.SetIsTranslationEnabled(this, true);
-            Visual v = ElementCompositionPreview.GetElementVisual(this);
-
-            var o = v.Compositor.CreateScalarKeyFrameAnimation();
-            o.Target = nameof(Visual.Opacity);
-            o.InsertKeyFrame(1, 0);
-            o.Duration = TimeSpan.FromSeconds(0.2);
-
-            var t = v.Compositor.CreateVector3KeyFrameAnimation();
-            t.Target = "Translation";
-            t.InsertKeyFrame(1, new Vector3(0, 200, 0));
-            t.Duration = TimeSpan.FromSeconds(0.375);
-
-            var g = v.Compositor.CreateAnimationGroup();
-            g.Add(t);
-            g.Add(o);
-            ElementCompositionPreview.SetImplicitHideAnimation(this, g);
-
-            var show = Composition.CreateEntranceAnimation(this, new Vector3(0, 200, 0), 0, 550);
-            ElementCompositionPreview.SetImplicitShowAnimation(this, show);
-
-
-            RbLanguage.ItemsSource = new List<String>
-            {
-                "XAML", "C#"
-            };
-
+            RbLanguage.ItemsSource = new List<String> { "XAML", "C#" };
             RbLanguage.SelectedIndex = Settings.DevToolsLanguage;
 
             SupportedLanguages = new List<SupportedLanguage>(
                 ApplicationLanguages.ManifestLanguages.
                 Select(language => new SupportedLanguage(language)));
-
             SupportedLanguages.Insert(0, SupportedLanguage.SystemLanguage);
         }
 
@@ -92,6 +65,27 @@ namespace CharacterMap.Views
         {
             if (msg.PropertyName == nameof(Settings.UserRequestedTheme))
                 OnPropertyChanged(nameof(Settings));
+        }
+
+        private void SetupAnimations()
+        {
+            Visual v = this.EnableTranslation(true).GetElementVisual();
+
+            var o = v.Compositor.CreateScalarKeyFrameAnimation();
+            o.Target = nameof(Visual.Opacity);
+            o.InsertKeyFrame(1, 0);
+            o.Duration = TimeSpan.FromSeconds(0.2);
+
+            var t = v.Compositor.CreateVector3KeyFrameAnimation();
+            t.Target = Composition.TRANSLATION;
+            t.InsertKeyFrame(1, new Vector3(0, 200, 0));
+            t.Duration = TimeSpan.FromSeconds(0.375);
+
+            this.SetHideAnimation(v.Compositor.CreateAnimationGroup(t, o));
+
+            this.SetShowAnimation(Composition.CreateEntranceAnimation(this, new Vector3(0, 200, 0), 0, 550));
+            LeftPanel.SetShowAnimation(Composition.CreateEntranceAnimation(LeftPanel, new Vector3(0, 140, 0), Composition.DEFAULT_STAGGER_MS, 850));
+            RightPanel.SetShowAnimation(Composition.CreateEntranceAnimation(RightPanel, new Vector3(0, 140, 0), Composition.DEFAULT_STAGGER_MS * 2, 850));
         }
 
         public void Show(FontVariant variant, InstalledFont font)

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -103,13 +103,14 @@ namespace CharacterMap.Views
 
 #pragma warning disable CS0618 // ChangeView doesn't work well when not properly visible
             ContentScroller.ScrollToVerticalOffset(0);
-#pragma warning restore CS0618 
+#pragma warning restore CS0618
 
-            // Note: it is legal for both "variant" and "font" to be *null*
-            //       when calling, so test both cases.
+
 
 
             // 2. Get the fonts used for Font List  & Character Grid previews
+            // Note: it is legal for both "variant" and "font" to be NULL
+            //       when calling, so test both cases.
             bool isSymbol = FontCollections.IsSymbolFont(font);
 
             Preview1.FontFamily = Preview2.FontFamily = Preview3.FontFamily 

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -33,10 +33,8 @@ using Windows.UI.Xaml.Navigation;
 
 namespace CharacterMap.Views
 {
-    public sealed partial class SettingsView : UserControl, INotifyPropertyChanged
+    public sealed partial class SettingsView : ViewBase
     {
-        public event PropertyChangedEventHandler PropertyChanged;
-
         private Random _random { get; } = new Random();
 
         public AppSettings Settings { get; }
@@ -204,12 +202,6 @@ namespace CharacterMap.Views
             var items = LstFontFamily.ItemsSource;
             LstFontFamily.ItemsSource = null;
             LstFontFamily.ItemsSource = items;
-        }
-
-        [NotifyPropertyChangedInvocator]
-        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         public void SelectedLanguageToString(object selected) => 

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -69,16 +69,12 @@ namespace CharacterMap.Views
         {
             Visual v = this.EnableTranslation(true).GetElementVisual();
 
-            var o = v.Compositor.CreateScalarKeyFrameAnimation();
-            o.Target = nameof(Visual.Opacity);
-            o.InsertKeyFrame(1, 0);
-            o.Duration = TimeSpan.FromSeconds(0.2);
-
             var t = v.Compositor.CreateVector3KeyFrameAnimation();
             t.Target = Composition.TRANSLATION;
             t.InsertKeyFrame(1, new Vector3(0, 200, 0));
             t.Duration = TimeSpan.FromSeconds(0.375);
 
+            var o = Composition.CreateFade(v.Compositor, 0, null, 200);
             this.SetHideAnimation(v.Compositor.CreateAnimationGroup(t, o));
 
             this.SetShowAnimation(Composition.CreateEntranceAnimation(this, new Vector3(0, 200, 0), 0, 550));
@@ -96,9 +92,6 @@ namespace CharacterMap.Views
 #pragma warning disable CS0618 // ChangeView doesn't work well when not properly visible
             ContentScroller.ScrollToVerticalOffset(0);
 #pragma warning restore CS0618
-
-
-
 
             // 2. Get the fonts used for Font List  & Character Grid previews
             // Note: it is legal for both "variant" and "font" to be NULL

--- a/CharacterMap/CharacterMap/Views/ViewBase.cs
+++ b/CharacterMap/CharacterMap/Views/ViewBase.cs
@@ -1,0 +1,31 @@
+﻿using CharacterMap.Annotations;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace CharacterMap.Views
+{
+    public abstract class ViewBase : UserControl, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        protected void RunOnUI(Action a)
+        {
+            if (Dispatcher.HasThreadAccess)
+                a();
+            else
+                _ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => a());
+        }
+    }
+}

--- a/CharacterMap/Settings.XamlStyler
+++ b/CharacterMap/Settings.XamlStyler
@@ -3,7 +3,7 @@
     "KeepFirstAttributeOnSameLine": false,
     "MaxAttributeCharactersPerLine": 0,
     "MaxAttributesPerLine": 1,
-    "NewlineExemptionElements": "RadialGradientBrush, GradientStop, LinearGradientBrush, ScaleTransform, SkewTransform, RotateTransform, TranslateTransform, Trigger, Condition, Style, Setter",
+    "NewlineExemptionElements": "RadialGradientBrush, GradientStop, LinearGradientBrush, ScaleTransform, SkewTransform, RotateTransform, TranslateTransform, Trigger, Condition, Style, Setter, SplineDoubleKeyFrame, KeySpline, EasingDoubleKeyFrame",
     "SeparateByGroups": false,
     "AttributeIndentation": 0,
     "AttributeIndentationStyle": 1,


### PR DESCRIPTION
- Make settings view more readable by increasing contrast and spacing. Taking design cues from Windows Store settings app.
- Minor fade animations when switching between dropdown states
- Transition on start up after font loading has completed
- Optimise memory usage during extended sessions by reusing `Character`s
- An attempt at #70. Imperfect, but works by providing a zoom mode option that zooms the preview glyph to the same scale as that of the character grid, which helps in 95% of cases.