### PR TITLE
Export COLR font glyphs as Color svg

### DIFF
--- a/CharacterMap/CharacterMap.CX/CanvasTextLayoutAnalysis.cpp
+++ b/CharacterMap/CharacterMap.CX/CanvasTextLayoutAnalysis.cpp
@@ -15,7 +15,7 @@ CharacterMapCX::CanvasTextLayoutAnalysis::CanvasTextLayoutAnalysis(ComPtr<ColorT
 		m_glyphLayerCount = analyzer->GlyphLayerCount;
 
 		auto colors = ref new Array<Color>(analyzer->RunColors.size());
-		float max = 255;
+		float max = 255.0;
 		for (unsigned int a = 0; a < analyzer->RunColors.size(); a = a + 1)
 		{
 			DWRITE_COLOR_F color = analyzer->RunColors[a];
@@ -63,17 +63,15 @@ CharacterMapCX::CanvasTextLayoutAnalysis::CanvasTextLayoutAnalysis(ComPtr<ColorT
 	auto vec = ref new Vector<GlyphImageFormat>(std::move(analyzer->GlyphFormats));
 	m_glyphFormats = vec->GetView();
 
-	// If we're analysing the character only, we're done here.
+	// If we're analyzing the character only, we're done here.
 	if (analyzer->IsCharacterAnalysisMode || fontFaceRef == nullptr)
 		return;
-
-
 
 	// Get File Size
 	m_fileSize = fontFaceRef->GetFileSize();
 
 	// Attempt to get FilePath. 
-	// This involves aquiring the FileLoader and querying it
+	// This involves acquiring the FileLoader and querying it
 	// for the file path;
 	ComPtr<IDWriteFontFile> file;
 	if (fontFaceRef->GetFontFile(&file) != S_OK)

--- a/CharacterMap/CharacterMap.CX/Interop.cpp
+++ b/CharacterMap/CharacterMap.CX/Interop.cpp
@@ -244,6 +244,7 @@ Platform::String^ Interop::GetPathData(CanvasFontFace^ fontFace, UINT16 glyphInd
 
 	ComPtr<SVGGeometrySink> sink = new (std::nothrow) SVGGeometrySink();
 	geom->Stream(sink.Get());
+	sink->Close();
 
 	return sink->GetPathData();
 }
@@ -300,6 +301,9 @@ IVectorView<PathData^>^ Interop::GetPathDatas(CanvasFontFace^ fontFace, const Pl
 				ref new PathData(sink->GetPathData(), Rect(bounds.left, bounds.top, bounds.right - bounds.left, bounds.bottom - bounds.top)));
 		}
 
+		sink->Close();
+
+		sink = nullptr;
 		geometrySink = nullptr;
 		geom = nullptr;
 	}
@@ -330,7 +334,10 @@ PathData^ Interop::GetPathData(CanvasGeometry^ geometry)
 
 	p->Stream(sink.Get());
 
-	return ref new PathData(sink->GetPathData(), m);
+	auto data = ref new PathData(sink->GetPathData(), m);
+	sink->Close();
+
+	return data;
 }
 
 CanvasTextLayoutAnalysis^ Interop::AnalyzeFontLayout(CanvasTextLayout^ layout, CanvasFontFace^ fontFace)

--- a/CharacterMap/CharacterMap.CX/Interop.cpp
+++ b/CharacterMap/CharacterMap.CX/Interop.cpp
@@ -215,14 +215,14 @@ IBuffer^ Interop::GetImageDataBuffer(CanvasFontFace^ fontFace, UINT32 pixelsPerE
 	return buffer;
 }
 
-Platform::String^ Interop::GetPathData(CanvasFontFace^ fontFace, UINT16 charIndex)
+Platform::String^ Interop::GetPathData(CanvasFontFace^ fontFace, UINT16 glyphIndicie)
 {
 	ComPtr<IDWriteFontFaceReference> faceRef = GetWrappedResource<IDWriteFontFaceReference>(fontFace);
 	ComPtr<IDWriteFontFace3> face;
 	faceRef->CreateFontFace(&face);
 
 	uint16 indicies[1];
-	indicies[0] = charIndex;
+	indicies[0] = glyphIndicie;
 
 	ComPtr<ID2D1PathGeometry> geom;
 	m_d2dFactory->CreatePathGeometry(&geom);
@@ -246,6 +246,65 @@ Platform::String^ Interop::GetPathData(CanvasFontFace^ fontFace, UINT16 charInde
 	geom->Stream(sink.Get());
 
 	return sink->GetPathData();
+}
+
+IVectorView<PathData^>^ Interop::GetPathDatas(CanvasFontFace^ fontFace, const Platform::Array<UINT16>^ glyphIndicies)
+{
+	ComPtr<IDWriteFontFaceReference> faceRef = GetWrappedResource<IDWriteFontFaceReference>(fontFace);
+	ComPtr<IDWriteFontFace3> face;
+	faceRef->CreateFontFace(&face);
+
+	Vector<PathData^>^ paths = ref new Vector<PathData^>();
+
+	for (int i = 0; i < glyphIndicies->Length; i++)
+	{
+		auto ind = glyphIndicies[i];
+		if (ind == 0)
+			continue;
+
+		uint16 indicies[1];
+		indicies[0] = ind;
+
+		ComPtr<ID2D1PathGeometry> geom;
+		m_d2dFactory->CreatePathGeometry(&geom);
+
+		ComPtr<ID2D1GeometrySink> geometrySink;
+		geom->Open(&geometrySink);
+
+		face->GetGlyphRunOutline(
+			256,
+			indicies,
+			nullptr,
+			nullptr,
+			ARRAYSIZE(indicies),
+			false,
+			false,
+			geometrySink.Get());
+
+		geometrySink->Close();
+
+		ComPtr<SVGGeometrySink> sink = new (std::nothrow) SVGGeometrySink();
+		geom->Stream(sink.Get());
+
+		D2D1_RECT_F bounds;
+		geom->GetBounds(D2D1_MATRIX_3X2_F { 1, 0, 0, 1, 0, 0 }, &bounds);
+		
+		if (isinf(bounds.left) || isinf(bounds.top))
+		{
+			paths->Append(
+				ref new PathData(ref new String(), Rect::Empty));
+		}
+		else
+		{
+			paths->Append(
+				ref new PathData(sink->GetPathData(), Rect(bounds.left, bounds.top, bounds.right - bounds.left, bounds.bottom - bounds.top)));
+		}
+
+		geometrySink = nullptr;
+		geom = nullptr;
+	}
+
+	return paths->GetView();
 }
 
 PathData^ Interop::GetPathData(CanvasGeometry^ geometry)

--- a/CharacterMap/CharacterMap.CX/Interop.h
+++ b/CharacterMap/CharacterMap.CX/Interop.h
@@ -18,6 +18,7 @@ using namespace Microsoft::Graphics::Canvas::Text;
 using namespace Microsoft::Graphics::Canvas::Geometry;
 using namespace Microsoft::WRL;
 using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
 using namespace Windows::Storage::Streams;
 
 namespace CharacterMapCX
@@ -35,7 +36,8 @@ namespace CharacterMapCX
 		IBuffer^ GetImageDataBuffer(CanvasFontFace^ fontFace, UINT32 pixelsPerEm, UINT unicodeIndex, UINT imageType);
 		CanvasTextLayoutAnalysis^ AnalyzeFontLayout(CanvasTextLayout^ layout, CanvasFontFace^ fontFace);
 		CanvasTextLayoutAnalysis^ AnalyzeCharacterLayout(CanvasTextLayout^ layout);
-		Platform::String^ GetPathData(CanvasFontFace^ fontFace, UINT16 charIndex);
+		IVectorView<PathData^>^ GetPathDatas(CanvasFontFace^ fontFace, const Platform::Array<UINT16>^ glyphIndicies);
+		Platform::String^ GetPathData(CanvasFontFace^ fontFace, UINT16 glyphIndicie);
 		PathData^ GetPathData(CanvasGeometry^ geometry);
 
 		DWriteFontSet^ GetSystemFonts();

--- a/CharacterMap/CharacterMap.CX/PathData.h
+++ b/CharacterMap/CharacterMap.CX/PathData.h
@@ -26,6 +26,11 @@ namespace CharacterMapCX
 			float3x2 get() { return m_matrix; }
 		}
 
+		property Rect Bounds
+		{
+			Rect get() { return m_bounds; }
+		}
+
 	internal:
 		PathData(String^ path, D2D1::Matrix3x2F* matrix)
 		{
@@ -33,9 +38,16 @@ namespace CharacterMapCX
 			m_matrix = { matrix->_11, matrix->_12, matrix->_21, matrix->_22, matrix->_31, matrix->_32 };
 		}
 
+		PathData(String^ path, Rect bounds)
+		{
+			m_path = path;
+			m_bounds = bounds;
+		}
+
 	private:
 		inline PathData() { }
 
+		Rect m_bounds = Rect::Empty;
 		float3x2 m_matrix;
 		String^ m_path = nullptr;
 	};

--- a/CharacterMap/CharacterMap/Services/GlyphService.cs
+++ b/CharacterMap/CharacterMap/Services/GlyphService.cs
@@ -109,6 +109,9 @@ namespace CharacterMap.Services
         public static (string Hex, string FontIcon, string Path, string Symbol) GetDevValues(
             Character c, FontVariant v, CanvasTextLayoutAnalysis a, CanvasTypography t, bool isXaml)
         {
+            if (v == FontFinder.DefaultFont.DefaultVariant)
+                return (string.Empty, string.Empty, string.Empty, string.Empty);
+
             Interop interop = SimpleIoc.Default.GetInstance<Interop>();
 
             string h, f, p, s = null;

--- a/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
@@ -42,7 +42,7 @@ namespace CharacterMap.ViewModels
 
         public IDialogService DialogService { get; }
         public RelayCommand<ExportStyle> CommandSavePng { get; }
-        public RelayCommand<bool> CommandSaveSvg { get; }
+        public RelayCommand<ExportStyle> CommandSaveSvg { get; }
 
         internal bool IsLoadingCharacters { get; private set; }
 
@@ -255,7 +255,7 @@ namespace CharacterMap.ViewModels
             Settings = settings;
 
             CommandSavePng = new RelayCommand<ExportStyle>(async (b) => await SavePngAsync(b));
-            CommandSaveSvg = new RelayCommand<bool>(async (b) => await SaveSvgAsync(b));
+            CommandSaveSvg = new RelayCommand<ExportStyle>(async (b) => await SaveSvgAsync(b));
 
             _interop = SimpleIoc.Default.GetInstance<Interop>();
 
@@ -333,13 +333,13 @@ namespace CharacterMap.ViewModels
 
             using (CanvasTextLayout layout = new CanvasTextLayout(Utils.CanvasDevice, $"{SelectedChar.Char}", new CanvasTextFormat
             {
-                FontSize = 20,
+                FontSize = (float)Core.Converters.GetFontSize(Settings.GridSize),
                 FontFamily = SelectedVariant.Source,
                 FontStretch = SelectedVariant.FontFace.Stretch,
                 FontWeight = SelectedVariant.FontFace.Weight,
                 FontStyle = SelectedVariant.FontFace.Style,
-                HorizontalAlignment = CanvasHorizontalAlignment.Center,
-            }, 100, 100))
+                HorizontalAlignment = CanvasHorizontalAlignment.Left,
+            }, Settings.GridSize, Settings.GridSize))
             {
                 layout.Options = CanvasDrawTextOptions.EnableColorFont;
                 ApplyEffectiveTypography(layout);
@@ -451,10 +451,10 @@ namespace CharacterMap.ViewModels
                 MessengerInstance.Send(new AppNotificationMessage(true, result));
         }
 
-        private async Task SaveSvgAsync(bool isBlackText)
+        private async Task SaveSvgAsync(ExportStyle style)
         {
             ExportResult result = await ExportManager.ExportSvgAsync(
-                isBlackText ? ExportStyle.Black : ExportStyle.White,
+                style,
                 SelectedFont,
                 SelectedVariant,
                 SelectedChar,

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -514,6 +514,7 @@
                             Margin="24 12 24 4"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            IsHitTestVisible="False"
                             Stretch="Uniform"
                             StretchDirection="Both">
                             <TextBlock
@@ -526,6 +527,7 @@
                                 FontWeight="{Binding SelectedVariant.FontFace.Weight}"
                                 Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
                                 IsColorFontEnabled="{Binding ShowColorGlyphs}"
+                                IsTextScaleFactorEnabled="False"
                                 Text="{Binding SelectedChar.Char}"
                                 TextAlignment="Center" />
                         </Viewbox>
@@ -553,7 +555,6 @@
                                     Loaded="{x:Bind helpers:Composition.SetStandardFadeInOut}"
                                     Visibility="{x:Bind ViewModel.Settings.FitCharacter, Mode=OneTime}" />
                             </Grid>
-
                         </AppBarButton>
 
                         <Border
@@ -706,9 +707,18 @@
                             Style="{StaticResource SaveAsPNGCommandBar}">
                             <CommandBar.SecondaryCommands>
                                 <AppBarButton
+                                    Command="{Binding CommandSaveSvg}"
+                                    CommandParameter="{x:Bind ViewModel.GlyphColor}"
+                                    Style="{ThemeResource TransparentButton}"
+                                    Visibility="{x:Bind ViewModel.SelectedCharAnalysis.HasColorGlyphs, Mode=OneWay}">
+                                    <AppBarButton.Content>
+                                        <TextBlock x:Uid="ColoredGlyphLabel" Margin="12,10" />
+                                    </AppBarButton.Content>
+                                </AppBarButton>
+                                <AppBarButton
                                     Background="Transparent"
                                     Command="{Binding CommandSaveSvg}"
-                                    CommandParameter="{StaticResource TrueValue}"
+                                    CommandParameter="{x:Bind ViewModel.BlackColor}"
                                     Style="{ThemeResource TransparentButton}">
                                     <AppBarButton.Content>
                                         <TextBlock x:Uid="BlackFill" Margin="12,10" />
@@ -718,7 +728,7 @@
                                     VerticalContentAlignment="Stretch"
                                     Background="Transparent"
                                     Command="{Binding CommandSaveSvg}"
-                                    CommandParameter="{StaticResource FalseValue}"
+                                    CommandParameter="{x:Bind ViewModel.WhiteColor}"
                                     Style="{ThemeResource TransparentButton}">
                                     <AppBarButton.Content>
                                         <TextBlock x:Uid="WhiteFill" Margin="12,10" />
@@ -745,7 +755,7 @@
                                 </Grid.ColumnDefinitions>
                                 <FontIcon Foreground="{ThemeResource SystemControlForegroundAccentBrush}" Glyph="&#xEB9F;" />
                                 <TextBlock
-                                    x:Uid="BtnSaveSvg"
+                                    x:Uid="BtnSaveSvgRaw"
                                     Grid.Column="1"
                                     Margin="0,0,5,0"
                                     VerticalAlignment="Center"
@@ -767,7 +777,7 @@
                             Padding="8 4 0 5"
                             BorderThickness="0 1"
                             Command="{x:Bind ViewModel.CommandSaveSvg}"
-                            CommandParameter="{StaticResource TrueValue}"
+                            CommandParameter="{x:Bind ViewModel.GlyphColor}"
                             IsEnabled="{Binding SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}"
                             Style="{StaticResource TransparentButton}">
                             <Grid>


### PR DESCRIPTION
Been trying to work out how to do this on and off for a while, accidentally stumbled upon the solution whilst trying to work out how to fix converting D2D Geometry to the SVG path syntax.


- Fonts with coloured glyphs using the Microsoft COLR format (like Segoe UI Emoji, MS Office Symbol), can now export multi-layered colour SVG versions of glyphs.
     - (May extend this to XAML path geometry at some point on the future)
- Fonts with SVG glyphs that store their SVG glyph data GZip'd rather than as a plain string (like EmojiOne Color) can now properly export to SVG.



Another example COLR font is one I made a few years ago. The heart glyph is a good test as it is one of the most complex COLR glyphs you can find (25 layers).

[Font Candy 90s.zip](https://github.com/EdiWang/Character-Map-UWP/files/4333102/Font.Candy.90s.zip)


Another example COLR font can be found here:
https://github.com/mozilla/twemoji-colr/releases