### PR TITLE
Safer title bar & loading, use no composition layer if Window animation is disabled (#89)

### DIFF
--- a/CharacterMap/CharacterMap/Controls/CharacterGridView.cs
+++ b/CharacterMap/CharacterMap/Controls/CharacterGridView.cs
@@ -156,7 +156,7 @@ namespace CharacterMap.Controls
             {
                 if (d is CharacterGridView g && e.NewValue is bool b)
                 {
-                    g._templateSettings.EnableReposition = b;
+                    g._templateSettings.EnableReposition = b && Composition.UISettings.AnimationsEnabled;
                     g.UpdateAnimation(b);
                 }
             }));
@@ -357,6 +357,9 @@ namespace CharacterMap.Controls
         private void UpdateAnimation(bool newValue)
         {
             if (this.ItemsPanelRoot == null)
+                return;
+
+            if (!Composition.UISettings.AnimationsEnabled)
                 return;
 
             foreach (var item in this.ItemsPanelRoot.Children)

--- a/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
+++ b/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
@@ -68,7 +68,7 @@ namespace CharacterMap.Controls
         {
             try
             {
-                // Attempts to avoid titlebar not showing immediately when a window is opened
+                // Attempts to avoid title bar not showing immediately when a window is opened
                 _titleBar = CoreApplication.GetCurrentView().TitleBar;
                 _titleBar.ExtendViewIntoTitleBar = true;
                 UpdateMetrics(_titleBar);
@@ -145,6 +145,17 @@ namespace CharacterMap.Controls
             UpdateMetrics(sender);
         }
 
+        private static ApplicationView TryGetCurrentView()
+        {
+            ApplicationView view = null;
+            try
+            {
+                view = ApplicationView.GetForCurrentView();
+            }
+            catch { }
+            return view;
+        }
+
         private void UpdateColors()
         {
             if (_settings == null)
@@ -178,7 +189,7 @@ namespace CharacterMap.Controls
             Color? titleInactiveBackgroundColor,
             Color? titleInactiveForegroundColor)
         {
-            var view = ApplicationView.GetForCurrentView();
+            var view = TryGetCurrentView();
             if (view == null)
                 return;
 
@@ -200,7 +211,7 @@ namespace CharacterMap.Controls
             Color? titleButtonInactiveBackgroundColor,
             Color? titleButtonInactiveForegroundColor)
         {
-            var view = ApplicationView.GetForCurrentView();
+            var view = TryGetCurrentView();
             if (view == null)
                 return;
 

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -158,6 +158,8 @@ namespace CharacterMap.ViewModels
                     GlyphService.InitializeAsync(),
                     FontFinder.LoadFontsAsync(),
                     FontCollections.LoadCollectionsAsync());
+
+                RefreshFontList();
             }
             catch (Exception ex)
             {
@@ -170,7 +172,6 @@ namespace CharacterMap.ViewModels
                 return;
             }
 
-            RefreshFontList();
             IsLoadingFonts = false;
         }
 

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -85,7 +85,12 @@ namespace CharacterMap.Views
         public void Show(FontVariant variant, InstalledFont font)
         {
             this.Visibility = Visibility.Visible;
-            
+            if (!Composition.UISettings.AnimationsEnabled)
+            {
+                this.GetElementVisual().Opacity = 1;
+                this.GetElementVisual().Properties.InsertVector3(Composition.TRANSLATION, Vector3.Zero);
+            }
+
             // 1. Focus the close button to ensure keyboard focus is retained inside the settings panel
             BtnClose.Focus(FocusState.Programmatic);
 


### PR DESCRIPTION
REgarding #89, I've not found anyway to get this stuck on loading fonts. Tried to make Titlebar a little safer, and as some diagnostics to rule out this being a problem with any of the composition stuff, switching "Show animations in Windows" to *off* in Windows Settings will disable all composition code (and shadows) - so if the user could get a build with these fixes and try that it would be good to know what happens.

![image](https://user-images.githubusercontent.com/2319473/76700134-584beb80-66ac-11ea-99fc-d24498ece8f0.png)
