### PR TITLE
Workaround Composition issue in 1809 ( #89 )

### DIFF
--- a/CharacterMap/CharacterMap/Helpers/Composition.cs
+++ b/CharacterMap/CharacterMap/Helpers/Composition.cs
@@ -292,7 +292,8 @@ namespace CharacterMap.Helpers
                 t.Duration = duration1;
                 delay += 0.055;
 
-                element.EnableTranslation(true).StartAnimation(t);
+                var v = element.EnableTranslation(true).GetElementVisual();
+                v.StartAnimationGroup(t);
             }
 
             delay = 0.4;
@@ -314,7 +315,8 @@ namespace CharacterMap.Helpers
                 o.DelayTime = TimeSpan.FromSeconds(delay);
                 o.Duration = TimeSpan.FromSeconds(0.33);
 
-                element.EnableTranslation(true).StartAnimation(c.CreateAnimationGroup(t, o));
+                var v = element.EnableTranslation(true).GetElementVisual();
+                v.StartAnimationGroup(c.CreateAnimationGroup(t, o));
             }
         }
 

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -566,7 +566,8 @@ namespace CharacterMap.Views
 
         private void LoadingRoot_Loading(FrameworkElement sender, object args)
         {
-            if (!ViewModel.Settings.UseSelectionAnimations)
+            if (!ViewModel.Settings.UseSelectionAnimations 
+                || !Composition.UISettings.AnimationsEnabled)
                 return;
 
             var v = sender.GetElementVisual();

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -303,11 +303,10 @@
                         <ToggleSwitch IsOn="{x:Bind Settings.UseSelectionAnimations, Mode=TwoWay}" />
 
                         <win1903:StackPanel>
-                            <TextBlock x:Uid="SettingsShadowsHeader" Style="{StaticResource HeaderStyle}" />
-                            <TextBlock x:Uid="SettingsShadowsDescription" Style="{StaticResource DescriptionStyle}" />
-                            <ToggleSwitch IsOn="{x:Bind Settings.EnableShadows, Mode=TwoWay}" />
+                            <win1903:TextBlock x:Uid="SettingsShadowsHeader" Style="{StaticResource HeaderStyle}" />
+                            <win1903:TextBlock x:Uid="SettingsShadowsDescription" Style="{StaticResource DescriptionStyle}" />
+                            <win1903:ToggleSwitch IsOn="{x:Bind Settings.EnableShadows, Mode=TwoWay}" />
                         </win1903:StackPanel>
-
 
                         <TextBlock x:Uid="SettingsExpensiveAnimationHeader" Style="{StaticResource HeaderStyle}" />
                         <TextBlock x:Uid="SettingsExpensiveAnimationDescription" Style="{StaticResource DescriptionStyle}" />


### PR DESCRIPTION
Turns out this is an issue with how StartAnimation works in 1809 (i.e., it hates `Translation`), changing to StartAnimationGroup fixes.

Keeps all the previous changes to disable animation entirely if turned off in Windows.

Double checked the rest of the additions on 1809, all seems good.


Should also fix #79  - Any child element of an element that is declared with conditional XAML needs to *also* be declared with conditional XAML if the child uses x:Bind,  otherwise the compiler will still generate the x:Bind code for the child even though it is never created at runtime - thereby throwing a null ref exception at runtime when the x:Bind code tries to connect to and update the child. Will probably open an issue for this one with Microsoft.