### PR TITLE
Basic fluent theme

### DIFF
--- a/CharacterMap/CharacterMap/App.xaml
+++ b/CharacterMap/CharacterMap/App.xaml
@@ -40,6 +40,24 @@
                         <Setter Property="TextLineBounds" Value="Tight" />
                     </Style>
 
+                    <Style x:Key="Mfsi" TargetType="MenuFlyoutSubItem">
+                        <Setter Property="MinHeight" Value="50" />
+                    </Style>
+                    <Style x:Key="Mfi" TargetType="MenuFlyoutItem">
+                        <Setter Property="MinHeight" Value="40" />
+                        <Setter Property="MinWidth" Value="160" />
+                    </Style>
+
+                    <Style x:Key="MFlyoutHeaderStyle" TargetType="MenuFlyoutItem">
+                        <Setter Property="IsEnabled" Value="False" />
+                        <Setter Property="FontSize" Value="13.333" />
+                        <Setter Property="Height" Value="30" />
+                        <Setter Property="Padding" Value="10 16 10 0" />
+                        <Setter Property="Margin" Value="0 0 0 -4" />
+                    </Style>
+                    
+                    
+                    
                     <SolidColorBrush x:Key="WhiteBrush" Color="White" />
                     <SolidColorBrush x:Key="BlackBrush" Color="Black" />
                     <SolidColorBrush x:Key="PrintBorderBrush" Color="LightGray" />
@@ -55,7 +73,7 @@
                         BackgroundSource="HostBackdrop"
                         FallbackColor="{ThemeResource SystemChromeMediumColor}"
                         TintColor="{ThemeResource SystemAltHighColor}"
-                        TintOpacity="0.75" />
+                        TintOpacity="0.775" />
 
                     <AcrylicBrush
                         x:Key="AltHostBrush"
@@ -71,6 +89,8 @@
                         FallbackColor="{ThemeResource SystemAltHighColor}"
                         TintColor="{ThemeResource SystemChromeGrayColor}"
                         TintOpacity="0.65" />
+
+                    <StaticResource x:Key="StatusBarBrush" ResourceKey="AltHostBrush" />
 
                     <x:Double x:Key="StatusBarHeight">26</x:Double>
                     <GridLength x:Key="StatusBarGridHeight">26</GridLength>

--- a/CharacterMap/CharacterMap/App.xaml
+++ b/CharacterMap/CharacterMap/App.xaml
@@ -55,9 +55,9 @@
                         <Setter Property="Padding" Value="10 16 10 0" />
                         <Setter Property="Margin" Value="0 0 0 -4" />
                     </Style>
-                    
-                    
-                    
+
+
+
                     <SolidColorBrush x:Key="WhiteBrush" Color="White" />
                     <SolidColorBrush x:Key="BlackBrush" Color="Black" />
                     <SolidColorBrush x:Key="PrintBorderBrush" Color="LightGray" />
@@ -74,7 +74,7 @@
                         FallbackColor="{ThemeResource SystemChromeMediumColor}"
                         TintColor="{ThemeResource SystemAltHighColor}"
                         TintOpacity="0.775" />
-
+                 
                     <AcrylicBrush
                         x:Key="AltHostBrush"
                         BackgroundSource="HostBackdrop"

--- a/CharacterMap/CharacterMap/App.xaml
+++ b/CharacterMap/CharacterMap/App.xaml
@@ -21,7 +21,7 @@
                     <x:Boolean x:Key="TrueValue">True</x:Boolean>
                     <x:Boolean x:Key="FalseValue">False</x:Boolean>
                     <TransitionCollection x:Key="NoTransitions" />
-                    <TransitionCollection x:Key="RepositionTransitions" >
+                    <TransitionCollection x:Key="RepositionTransitions">
                         <RepositionThemeTransition IsStaggeringEnabled="False" />
                     </TransitionCollection>
 
@@ -40,13 +40,30 @@
                     <Thickness x:Key="ListViewItemRevealBorderThemeThickness">0</Thickness>
                     <SolidColorBrush x:Key="ListViewItemRevealBackgroundSelectedPressed" Color="Transparent" />
                     <SolidColorBrush x:Key="ListViewItemRevealPlaceholderBackground" Color="Transparent" />
+
+                    <AcrylicBrush
+                        x:Key="DefaultHostBrush"
+                        win1903:TintLuminosityOpacity="0.55"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemAltHighColor}"
+                        TintOpacity="0.7" />
+
+                    <AcrylicBrush
+                        x:Key="AltHostBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeLowColor}"
+                        TintColor="{ThemeResource SystemAltHighColor}"
+                        TintOpacity="0.75" />
+
                     <AcrylicBrush
                         x:Name="DefaultAcrylicBrush"
                         win1903:TintLuminosityOpacity="0.3"
                         BackgroundSource="Backdrop"
                         FallbackColor="{ThemeResource SystemAltHighColor}"
                         TintColor="{ThemeResource SystemChromeGrayColor}"
-                        TintOpacity="0.6" />
+                        TintOpacity="0.65" />
+
                 </ResourceDictionary>
                 <ResourceDictionary Source="/Styles/TextBox.xaml" />
                 <ResourceDictionary Source="/Styles/CommandBar.xaml" />

--- a/CharacterMap/CharacterMap/App.xaml
+++ b/CharacterMap/CharacterMap/App.xaml
@@ -32,6 +32,14 @@
                         <Setter Property="TextAlignment" Value="Center" />
                         <Setter Property="Foreground" Value="#888" />
                     </Style>
+
+                    <Style x:Key="StatusBarTextStyle" TargetType="TextBlock">
+                        <Setter Property="FontSize" Value="12" />
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                        <Setter Property="Margin" Value="12 0" />
+                        <Setter Property="TextLineBounds" Value="Tight" />
+                    </Style>
+
                     <SolidColorBrush x:Key="WhiteBrush" Color="White" />
                     <SolidColorBrush x:Key="BlackBrush" Color="Black" />
                     <SolidColorBrush x:Key="PrintBorderBrush" Color="LightGray" />
@@ -47,14 +55,14 @@
                         BackgroundSource="HostBackdrop"
                         FallbackColor="{ThemeResource SystemChromeMediumColor}"
                         TintColor="{ThemeResource SystemAltHighColor}"
-                        TintOpacity="0.7" />
+                        TintOpacity="0.75" />
 
                     <AcrylicBrush
                         x:Key="AltHostBrush"
                         BackgroundSource="HostBackdrop"
                         FallbackColor="{ThemeResource SystemChromeLowColor}"
                         TintColor="{ThemeResource SystemAltHighColor}"
-                        TintOpacity="0.75" />
+                        TintOpacity="0.8" />
 
                     <AcrylicBrush
                         x:Name="DefaultAcrylicBrush"
@@ -63,6 +71,12 @@
                         FallbackColor="{ThemeResource SystemAltHighColor}"
                         TintColor="{ThemeResource SystemChromeGrayColor}"
                         TintOpacity="0.65" />
+
+                    <x:Double x:Key="StatusBarHeight">26</x:Double>
+                    <GridLength x:Key="StatusBarGridHeight">26</GridLength>
+
+                    <x:Double x:Key="TitleRowHeight">45</x:Double>
+                    <GridLength x:Key="TitleRowGridHeight">45</GridLength>
 
                 </ResourceDictionary>
                 <ResourceDictionary Source="/Styles/TextBox.xaml" />

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -32,6 +32,7 @@
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
     <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppInstallerUpdateFrequency>0</AppInstallerUpdateFrequency>
     <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -28,6 +28,7 @@
     <SccProvider>
     </SccProvider>
     <PackageCertificateThumbprint>F4C1BC290432ACAE9C11F15DB762EDD9CCF2D498</PackageCertificateThumbprint>
+    <LangVersion>8.0</LangVersion>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
     <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
@@ -193,7 +194,7 @@
     <Compile Include="Helpers\PrintHelper.cs" />
     <Compile Include="Helpers\Unicode.cs" />
     <Compile Include="Models\Character.cs" />
-    <Compile Include="Core\Messages.cs" />
+    <Compile Include="Models\Messages.cs" />
     <Compile Include="Core\Converters.cs" />
     <Compile Include="Core\ExportManager.cs" />
     <Compile Include="Helpers\Composition.cs" />

--- a/CharacterMap/CharacterMap/Controls/CreateCollectionDialog.xaml
+++ b/CharacterMap/CharacterMap/Controls/CreateCollectionDialog.xaml
@@ -13,6 +13,15 @@
     SecondaryButtonStyle="{StaticResource ButtonRevealStyle}"
     mc:Ignorable="d">
 
+    <ContentDialog.TitleTemplate>
+        <DataTemplate>
+            <TextBlock
+                FontSize="22"
+                FontWeight="Bold"
+                Text="{Binding}" />
+        </DataTemplate>
+    </ContentDialog.TitleTemplate>
+
     <TextBox
         x:Name="InputBox"
         x:Uid="CreateCollectionEntryBox"

--- a/CharacterMap/CharacterMap/Controls/FontMapPrintPage.xaml
+++ b/CharacterMap/CharacterMap/Controls/FontMapPrintPage.xaml
@@ -5,6 +5,7 @@
     xmlns:controls="using:CharacterMap.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    IsTabStop="False"
     RequestedTheme="Light"
     mc:Ignorable="d">
 
@@ -39,6 +40,7 @@
                     ItemsSource="{x:Bind Items}">
                     <ListView.Resources>
                         <Style TargetType="ListViewItem">
+                            <Setter Property="IsTabStop" Value="False" />
                             <Setter Property="HorizontalAlignment" Value="Stretch" />
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                             <Setter Property="Padding" Value="0" />

--- a/CharacterMap/CharacterMap/Controls/FontMapPrintPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Controls/FontMapPrintPage.xaml.cs
@@ -161,6 +161,7 @@ namespace CharacterMap.Controls
         {
             if (!args.InRecycleQueue && args.ItemContainer is GridViewItem item)
             {
+                item.IsTabStop = false;
                 if (PrintModel.ShowBorders)
                 {
                     item.BorderBrush = ResourceHelper.Get<Brush>("PrintBorderBrush");

--- a/CharacterMap/CharacterMap/Converters/ZoomBackgroundConverter.cs
+++ b/CharacterMap/CharacterMap/Converters/ZoomBackgroundConverter.cs
@@ -10,15 +10,13 @@ namespace CharacterMap.Converters
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-
             if (value != null)
             {
                 var count = int.Parse(value.ToString());
                 if (count > 0)
-                    return new SolidColorBrush(Utils.GetAccentColor());
+                    return 1;
             }
-            return new SolidColorBrush(Windows.UI.Colors.Gray);
-
+            return 0.3;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/CharacterMap/CharacterMap/Core/AlphaKeyGroup.cs
+++ b/CharacterMap/CharacterMap/Core/AlphaKeyGroup.cs
@@ -8,27 +8,15 @@ namespace CharacterMap.Core
 {
     public class AlphaKeyGroup<T> : List<T>
     {
-        const string GlobeGroupKey = "?";
         public string Key { get; private set; }
-        //public List<T> this { get; private set; }
+
         public AlphaKeyGroup(string key)
         {
             Key = key;
         }
 
-        //private static List<AlphaKeyGroup<T>> CreateDefaultGroups(CharacterGroupings slg)
-        //{
-        //    return (from cg 
-        //            in slg
-        //            where cg.Label != string.Empty
-        //            select cg.Label == "..." ? 
-        //                new AlphaKeyGroup<T>(GlobeGroupKey) : 
-        //                new AlphaKeyGroup<T>(cg.Label))
-        //            .ToList();
-        //}
-
         // Work around for Chinese version of Windows
-        // By default, Chinese lanugage group will create useless "拼音A-Z" groups.
+        // By default, Chinese language group will create useless "拼音A-Z" groups.
         private static List<AlphaKeyGroup<T>> CreateAZGroups()
         {
             char[] alpha = "#ABCDEFGHIJKLMNOPQRSTUVWXYZ&".ToCharArray();

--- a/CharacterMap/CharacterMap/Core/AppSettings.cs
+++ b/CharacterMap/CharacterMap/Core/AppSettings.cs
@@ -38,7 +38,7 @@ namespace CharacterMap.Core
         public bool ShowDevUtils
         {
             get => Get(true);
-            set => Set(value);
+            set => BroadcastSet(value);
         }
 
         public bool IsTransparencyEnabled

--- a/CharacterMap/CharacterMap/Core/AppSettings.cs
+++ b/CharacterMap/CharacterMap/Core/AppSettings.cs
@@ -41,6 +41,12 @@ namespace CharacterMap.Core
             set => Set(value);
         }
 
+        public bool IsTransparencyEnabled
+        {
+            get => Get(true);
+            set { if (Set(value)) UpdateTransparency(value); }
+        }
+
         public bool UseInstantSearch
         {
             get => Get(true);
@@ -179,6 +185,11 @@ namespace CharacterMap.Core
             {
                 Messenger.Default.Send(new AppSettingsChangedMessage(nameof(GridSize)));
             });
+        }
+
+        public void UpdateTransparency(bool value)
+        {
+            _ = ResourceHelper.SetTransparencyAsync(value);
         }
     }
 }

--- a/CharacterMap/CharacterMap/Core/AppSettings.cs
+++ b/CharacterMap/CharacterMap/Core/AppSettings.cs
@@ -61,13 +61,13 @@ namespace CharacterMap.Core
 
         public int MaxSearchResult
         {
-            get => Get(20);
+            get => Get(26);
             set => Set(value);
         }
 
         public double LastColumnWidth
         {
-            get => Get(330d);
+            get => Get(326d);
             set => Set(value);
         }
 

--- a/CharacterMap/CharacterMap/Core/Converters.cs
+++ b/CharacterMap/CharacterMap/Core/Converters.cs
@@ -32,6 +32,8 @@ namespace CharacterMap.Core
         public static Visibility FalseToVis(bool b) => !b ? Visibility.Visible : Visibility.Collapsed;
         public static Visibility TrueToVis(bool b) => b ? Visibility.Visible : Visibility.Collapsed;
         public static Visibility IsNotNullToVis(object obj) => obj != null ? Visibility.Visible : Visibility.Collapsed;
+        public static Visibility TrueAndFalseToVis(bool a, bool b) => a && !b ? Visibility.Visible : Visibility.Collapsed;
+        public static Visibility TrueAndTrueAndFalseToVis(bool a, bool b, bool c) => a && b && !c ? Visibility.Visible : Visibility.Collapsed;
 
 
         public static bool IsNull(object obj) => obj == null;

--- a/CharacterMap/CharacterMap/Core/Utils.cs
+++ b/CharacterMap/CharacterMap/Core/Utils.cs
@@ -15,10 +15,12 @@ using Windows.UI;
 using Windows.UI.Text;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 namespace CharacterMap.Core
 {
-    public class Utils
+    public static class Utils
     {
         public static CanvasDevice CanvasDevice { get; } = CanvasDevice.GetSharedDevice();
 
@@ -51,6 +53,14 @@ namespace CharacterMap.Core
             }
             hex = 0;
             return false;
+        }
+
+        public static MenuFlyoutPresenter GetPresenter(this MenuFlyout flyout)
+        {
+            if (flyout.Items.Count == 0)
+                return null;
+
+            return flyout.Items[0].GetFirstAncestorOfType<MenuFlyoutPresenter>();
         }
 
         public static bool IsAccentColorDark()

--- a/CharacterMap/CharacterMap/Helpers/Composition.cs
+++ b/CharacterMap/CharacterMap/Helpers/Composition.cs
@@ -128,7 +128,7 @@ namespace CharacterMap.Helpers
             return c.CreateAnimationGroup(t, o);
         }
 
-        public static void PlayEntrance(List<UIElement> targets, int delayMs = 0, int fromOffset = 140, int durationMs = 800, int staggerMs = 83)
+        public static void PlayEntrance(List<UIElement> targets, int delayMs = 0, int fromOffsetY = 140, int fromOffsetX = 0, int durationMs = 880, int staggerMs = 83)
         {
             if (!UISettings.AnimationsEnabled)
                 return;
@@ -137,7 +137,7 @@ namespace CharacterMap.Helpers
 
             foreach (var target in targets)
             {
-                var animation = CreateEntranceAnimation(target, new Vector3(0, fromOffset, 0), start, durationMs);
+                var animation = CreateEntranceAnimation(target, new Vector3(fromOffsetX, fromOffsetY, 0), start, durationMs);
                 target.GetElementVisual().StartAnimationGroup(animation);
                 start += staggerMs;
             }

--- a/CharacterMap/CharacterMap/Helpers/Composition.cs
+++ b/CharacterMap/CharacterMap/Helpers/Composition.cs
@@ -99,12 +99,12 @@ namespace CharacterMap.Helpers
             e.SetShowAnimation(Composition.CreateEntranceAnimation(e, new Vector3(0, 200, 0), 0, 550));
         }
 
-        public static void PlayEntrance(UIElement target, int delayMs = 0, int fromOffset = 140)
+        public static void PlayEntrance(UIElement target, int delayMs = 0, int fromOffsetY = 140, int fromOffsetX = 0, int durationMs = 880)
         {
             if (!UISettings.AnimationsEnabled)
                 return;
 
-            var animation = CreateEntranceAnimation(target, new Vector3(0, fromOffset, 0), delayMs);
+            var animation = CreateEntranceAnimation(target, new Vector3(fromOffsetX, fromOffsetY, 0), delayMs, durationMs);
             target.GetElementVisual().StartAnimationGroup(animation);
         }
 
@@ -288,28 +288,16 @@ namespace CharacterMap.Helpers
         }
 
         public static void StartStartUpAnimation(
-            FrameworkElement barBackground,
             List<FrameworkElement> barElements,
             List<UIElement> contentElements)
         {
             if (!UISettings.AnimationsEnabled)
                 return;
 
-            TimeSpan duration = TimeSpan.FromSeconds(0.5);
             TimeSpan duration1 = TimeSpan.FromSeconds(0.7);
 
-            var b = barBackground.EnableTranslation(true).GetElementVisual();
-            var c = b.Compositor;
-
+            var c = barElements[0].GetElementVisual().Compositor;
             var backOut = c.CreateCubicBezierEasingFunction(new Vector2(0.2f, 0.885f), new Vector2(0.25f, 1.125f));
-            var ent = c.CreateEntranceEasingFunction();
-
-            var a1 = c.CreateVector3KeyFrameAnimation();
-            a1.Target = TRANSLATION;
-            a1.Duration = duration;
-            a1.InsertKeyFrame(0, new Vector3(0, -45, 0));
-            a1.InsertKeyFrame(1, Vector3.Zero, ent);
-            b.StartAnimationGroup(a1);
 
             double delay = 0.1;
             foreach (var element in barElements)

--- a/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
@@ -96,6 +96,7 @@ namespace CharacterMap.Helpers
                         : main.SelectedCollection;
 
                     await _collections.RemoveFromCollectionAsync(fnt, collection);
+                    Messenger.Default.Send(new AppNotificationMessage(true, new CollectionUpdatedArgs(fnt, collection, false)));
                     Messenger.Default.Send(new CollectionsUpdatedMessage());
                 }
             }

--- a/CharacterMap/CharacterMap/Helpers/InAppNotificationHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/InAppNotificationHelper.cs
@@ -1,4 +1,5 @@
 ﻿using CharacterMap.Core;
+using CharacterMap.Models;
 using CharacterMap.Services;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using System;
@@ -37,6 +38,11 @@ namespace CharacterMap.Helpers
                     return;
 
                 var content = ResourceHelper.InflateDataTemplate("AddedToCollectionNotificationTemplate", added);
+                ShowNotification(presenter, content, 5000);
+            }
+            else if (msg.Data is CollectionUpdatedArgs cua)
+            {
+                var content = ResourceHelper.InflateDataTemplate("RemoveFromCollectionNotification", cua);
                 ShowNotification(presenter, content, 5000);
             }
             else if (msg.Data is string s)

--- a/CharacterMap/CharacterMap/Helpers/PrintHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/PrintHelper.cs
@@ -1,6 +1,9 @@
 ﻿using CharacterMap.Controls;
+using CharacterMap.Core;
+using CharacterMap.Models;
 using CharacterMap.ViewModels;
 using CharacterMap.Views;
+using GalaSoft.MvvmLight.Messaging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -187,10 +190,10 @@ namespace CharacterMap.Helpers
                 // Choose the printer options to be shown.
                 // The order in which the options are appended determines the order in which they appear in the UI
                 displayedOptions.Clear();
-                displayedOptions.Add(Windows.Graphics.Printing.StandardPrintTaskOptions.Orientation);
                 displayedOptions.Add(Windows.Graphics.Printing.StandardPrintTaskOptions.Duplex);
                 displayedOptions.Add(Windows.Graphics.Printing.StandardPrintTaskOptions.Copies);
                 displayedOptions.Add(Windows.Graphics.Printing.StandardPrintTaskOptions.ColorMode);
+                displayedOptions.Add(Windows.Graphics.Printing.StandardPrintTaskOptions.PrintQuality);
 
 
                 // Print Task event handler is invoked when the print job is completed.
@@ -205,7 +208,7 @@ namespace CharacterMap.Helpers
                     // Notify the user when the print operation fails.
                     if (args.Completion == PrintTaskCompletion.Failed)
                     {
-                        // .....
+                        Messenger.Default.Send(new AppNotificationMessage(true, "Failure encountered whilst printing."));
                     }
                 };
 

--- a/CharacterMap/CharacterMap/Helpers/ResourceHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/ResourceHelper.cs
@@ -1,15 +1,19 @@
 ﻿using CharacterMap.Core;
+using CharacterMap.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 
 namespace CharacterMap.Helpers
 {
     public static class ResourceHelper
     {
+        #region Generic
+
         public static bool TryGet<T>(string resourceKey, out T value)
         {
             if (TryGetInternal(Application.Current.Resources, resourceKey, out value))
@@ -51,13 +55,36 @@ namespace CharacterMap.Helpers
             return content;
         }
 
+        #endregion
+
+
 
 
         /* Character Map Specific resources */
+
         private static AppSettings _settings;
         public static AppSettings AppSettings
         {
             get => _settings ?? (_settings = Get<AppSettings>(nameof(AppSettings)));
+        }
+
+        public static ElementTheme GetEffectiveTheme()
+        {
+            return AppSettings.UserRequestedTheme switch
+            {
+                ElementTheme.Default => App.Current.RequestedTheme == ApplicationTheme.Dark ? ElementTheme.Dark : ElementTheme.Light,
+                _ => AppSettings.UserRequestedTheme
+            };
+        }
+
+        public static Task SetTransparencyAsync(bool enable)
+        {
+            return WindowService.RunOnViewsAsync(() =>
+            {
+                Get<AcrylicBrush>("DefaultHostBrush").AlwaysUseFallback = !enable;
+                Get<AcrylicBrush>("AltHostBrush").AlwaysUseFallback = !enable;
+                Get<AcrylicBrush>("DefaultAcrylicBrush").AlwaysUseFallback = !enable;
+            });
         }
     }
 

--- a/CharacterMap/CharacterMap/Models/Messages.cs
+++ b/CharacterMap/CharacterMap/Models/Messages.cs
@@ -1,12 +1,35 @@
-﻿using System;
+﻿using CharacterMap.Core;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
 
-namespace CharacterMap.Core
+namespace CharacterMap.Models
 {
+    public class CollectionUpdatedArgs
+    {
+        public InstalledFont Font { get; }
+        public UserFontCollection Collection { get; }
+        public bool IsAdd { get; }
+
+        public CollectionUpdatedArgs(InstalledFont font, UserFontCollection collection, bool isAdd)
+        {
+            Font = font;
+            Collection = collection;
+            IsAdd = isAdd;
+        }
+
+        public string GetMessage()
+        {
+            if (IsAdd)
+                return $"{Font.Name} was added to the \"{Collection.Name}\" collection";
+            else
+                return $"{Font.Name} was removed from the \"{Collection.Name}\" collection";
+        }
+    }
+
     public class ImportMessage
     {
         public ImportMessage(FontImportResult result)

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -915,6 +915,20 @@ May have a minor effect on performance on older or weaker devices.</target>
           <source>Enable transparency</source>
           <target state="new">Enable transparency</target>
         </trans-unit>
+        <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
+          <source>Show Details</source>
+          <target state="new">Show Details</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
+          <source>Uh Oh</source>
+          <target state="new">Uh Oh</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
+          <source>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</source>
+          <target state="new">Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -905,6 +905,16 @@ You can change the page range in the Page Setup section.</target>
           <source>Two Columns</source>
           <target state="new">Two Columns</target>
         </trans-unit>
+        <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</source>
+          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</target>
+        </trans-unit>
+        <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
+          <source>Enable transparency</source>
+          <target state="new">Enable transparency</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -728,9 +728,8 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <target state="new">Contributors</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
-          <source>loading fonts</source>
-          <target state="new">loading fonts</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+          <source>Loading Fonts</source>
+          <target state="new">Loading Fonts</target>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -40,8 +40,8 @@
           <target state="new">Char(s)</target>
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
-          <source>Colorization</source>
-          <target state="new">Colorization</target>
+          <source>Colored Glyph</source>
+          <target state="new">Colored Glyph</target>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Monochrome glyphs</source>
@@ -262,10 +262,6 @@
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="new">Open</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="new">Collection Name</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -928,6 +924,54 @@ May have a minor effect on performance on older or weaker devices.</target>
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
           <target state="new">Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
+        <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
+          <source>Keystroke: {0:0000}</source>
+          <target state="new">Keystroke: {0:0000}</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as SVG Image</source>
+          <target state="new">Save as SVG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportPNGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as PNG Image</source>
+          <target state="new">Save as PNG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
+          <source>SVG Glyph</source>
+          <target state="new">SVG Glyph</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Copy to clipboard</source>
+          <target state="new">Copy to clipboard</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Fit Character</source>
+          <target state="new">Fit Character</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
+          <source>was removed from</source>
+          <target state="new">was removed from</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
+          <source>was added to</source>
+          <target state="new">was added to</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="new">Collection Name</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -19,8 +19,9 @@
           <target state="new">Black Fill</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
-          <source>Copy (character only)</source>
-          <target state="translated">Kopie (nur Charakter)</target>
+          <source>Copy as text</source>
+          <target state="needs-review-translation">Kopie (nur Charakter)</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnSavePng.Text" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
@@ -906,9 +907,9 @@ You can change the page range in the Page Setup section.</target>
           <target state="new">Two Columns</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
-          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <target state="new">Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -915,6 +915,20 @@ May have a minor effect on performance on older or weaker devices.</target>
           <source>Enable transparency</source>
           <target state="new">Enable transparency</target>
         </trans-unit>
+        <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
+          <source>Show Details</source>
+          <target state="new">Show Details</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
+          <source>Uh Oh</source>
+          <target state="new">Uh Oh</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
+          <source>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</source>
+          <target state="new">Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -39,8 +39,9 @@
           <target state="new">Char(s)</target>
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
-          <source>Colorization</source>
-          <target state="translated">Colourization</target>
+          <source>Colored Glyph</source>
+          <target state="needs-review-translation">Colourization</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Monochrome glyphs</source>
@@ -261,10 +262,6 @@
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="new">Open</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="new">Collection Name</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -927,6 +924,54 @@ May have a minor effect on performance on older or weaker devices.</target>
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
           <target state="new">Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
+        <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
+          <source>Keystroke: {0:0000}</source>
+          <target state="new">Keystroke: {0:0000}</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as SVG Image</source>
+          <target state="new">Save as SVG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportPNGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as PNG Image</source>
+          <target state="new">Save as PNG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
+          <source>SVG Glyph</source>
+          <target state="new">SVG Glyph</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Copy to clipboard</source>
+          <target state="new">Copy to clipboard</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Fit Character</source>
+          <target state="new">Fit Character</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
+          <source>was removed from</source>
+          <target state="new">was removed from</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
+          <source>was added to</source>
+          <target state="new">was added to</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="new">Collection Name</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -905,6 +905,16 @@ You can change the page range in the Page Setup section.</target>
           <source>Two Columns</source>
           <target state="new">Two Columns</target>
         </trans-unit>
+        <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</source>
+          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</target>
+        </trans-unit>
+        <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
+          <source>Enable transparency</source>
+          <target state="new">Enable transparency</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -727,9 +727,8 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <target state="new">Contributors</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
-          <source>loading fonts</source>
-          <target state="new">loading fonts</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+          <source>Loading Fonts</source>
+          <target state="new">Loading Fonts</target>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -19,8 +19,8 @@
           <target state="new">Black Fill</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
-          <source>Copy (character only)</source>
-          <target state="new">Copy (character only)</target>
+          <source>Copy as text</source>
+          <target state="new">Copy as text</target>
         </trans-unit>
         <trans-unit id="BtnSavePng.Text" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
@@ -906,9 +906,9 @@ You can change the page range in the Page Setup section.</target>
           <target state="new">Two Columns</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
-          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <target state="new">Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -915,6 +915,20 @@ May have a minor effect on performance on older or weaker devices.</target>
           <source>Enable transparency</source>
           <target state="new">Enable transparency</target>
         </trans-unit>
+        <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
+          <source>Show Details</source>
+          <target state="new">Show Details</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
+          <source>Uh Oh</source>
+          <target state="new">Uh Oh</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
+          <source>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</source>
+          <target state="new">Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -19,8 +19,9 @@
           <target state="new">Black Fill</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
-          <source>Copy (character only)</source>
-          <target state="translated">Copier (caractère uniquement)</target>
+          <source>Copy as text</source>
+          <target state="needs-review-translation">Copier (caractère uniquement)</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnSavePng.Text" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
@@ -906,9 +907,9 @@ You can change the page range in the Page Setup section.</target>
           <target state="new">Two Columns</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
-          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <target state="new">Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -905,6 +905,16 @@ You can change the page range in the Page Setup section.</target>
           <source>Two Columns</source>
           <target state="new">Two Columns</target>
         </trans-unit>
+        <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</source>
+          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</target>
+        </trans-unit>
+        <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
+          <source>Enable transparency</source>
+          <target state="new">Enable transparency</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -728,9 +728,8 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <target state="new">Contributors</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
-          <source>loading fonts</source>
-          <target state="new">loading fonts</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+          <source>Loading Fonts</source>
+          <target state="new">Loading Fonts</target>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -40,8 +40,8 @@
           <target state="new">Char(s)</target>
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
-          <source>Colorization</source>
-          <target state="new">Colorization</target>
+          <source>Colored Glyph</source>
+          <target state="new">Colored Glyph</target>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Monochrome glyphs</source>
@@ -262,10 +262,6 @@
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="new">Open</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="new">Collection Name</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -928,6 +924,54 @@ May have a minor effect on performance on older or weaker devices.</target>
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
           <target state="new">Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
+        <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
+          <source>Keystroke: {0:0000}</source>
+          <target state="new">Keystroke: {0:0000}</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as SVG Image</source>
+          <target state="new">Save as SVG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportPNGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as PNG Image</source>
+          <target state="new">Save as PNG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
+          <source>SVG Glyph</source>
+          <target state="new">SVG Glyph</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Copy to clipboard</source>
+          <target state="new">Copy to clipboard</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Fit Character</source>
+          <target state="new">Fit Character</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
+          <source>was removed from</source>
+          <target state="new">was removed from</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
+          <source>was added to</source>
+          <target state="new">was added to</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="new">Collection Name</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -915,6 +915,20 @@ May have a minor effect on performance on older or weaker devices.</target>
           <source>Enable transparency</source>
           <target state="new">Enable transparency</target>
         </trans-unit>
+        <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
+          <source>Show Details</source>
+          <target state="new">Show Details</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
+          <source>Uh Oh</source>
+          <target state="new">Uh Oh</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
+          <source>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</source>
+          <target state="new">Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -19,8 +19,9 @@
           <target state="new">Black Fill</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
-          <source>Copy (character only)</source>
-          <target state="translated">Kopiuj (tylko znak)</target>
+          <source>Copy as text</source>
+          <target state="needs-review-translation">Kopiuj (tylko znak)</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnSavePng.Text" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
@@ -906,9 +907,9 @@ You can change the page range in the Page Setup section.</target>
           <target state="new">Two Columns</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
-          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <target state="new">Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -905,6 +905,16 @@ You can change the page range in the Page Setup section.</target>
           <source>Two Columns</source>
           <target state="new">Two Columns</target>
         </trans-unit>
+        <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</source>
+          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</target>
+        </trans-unit>
+        <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
+          <source>Enable transparency</source>
+          <target state="new">Enable transparency</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -728,9 +728,8 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <target state="new">Contributors</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
-          <source>loading fonts</source>
-          <target state="new">loading fonts</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+          <source>Loading Fonts</source>
+          <target state="new">Loading Fonts</target>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -40,8 +40,8 @@
           <target state="new">Char(s)</target>
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
-          <source>Colorization</source>
-          <target state="new">Colorization</target>
+          <source>Colored Glyph</source>
+          <target state="new">Colored Glyph</target>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Monochrome glyphs</source>
@@ -262,10 +262,6 @@
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="new">Open</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="new">Collection Name</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -928,6 +924,54 @@ May have a minor effect on performance on older or weaker devices.</target>
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
           <target state="new">Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
+        <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
+          <source>Keystroke: {0:0000}</source>
+          <target state="new">Keystroke: {0:0000}</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as SVG Image</source>
+          <target state="new">Save as SVG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportPNGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as PNG Image</source>
+          <target state="new">Save as PNG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
+          <source>SVG Glyph</source>
+          <target state="new">SVG Glyph</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Copy to clipboard</source>
+          <target state="new">Copy to clipboard</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Fit Character</source>
+          <target state="new">Fit Character</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
+          <source>was removed from</source>
+          <target state="new">was removed from</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
+          <source>was added to</source>
+          <target state="new">was added to</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="new">Collection Name</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -915,6 +915,20 @@ May have a minor effect on performance on older or weaker devices.</target>
           <source>Enable transparency</source>
           <target state="new">Enable transparency</target>
         </trans-unit>
+        <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
+          <source>Show Details</source>
+          <target state="new">Show Details</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
+          <source>Uh Oh</source>
+          <target state="new">Uh Oh</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
+          <source>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</source>
+          <target state="new">Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -19,8 +19,9 @@
           <target state="new">Black Fill</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
-          <source>Copy (character only)</source>
-          <target state="translated">Копировать (только символ)</target>
+          <source>Copy as text</source>
+          <target state="needs-review-translation">Копировать (только символ)</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnSavePng.Text" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
@@ -906,9 +907,9 @@ You can change the page range in the Page Setup section.</target>
           <target state="new">Two Columns</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
-          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <target state="new">Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -905,6 +905,16 @@ You can change the page range in the Page Setup section.</target>
           <source>Two Columns</source>
           <target state="new">Two Columns</target>
         </trans-unit>
+        <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</source>
+          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</target>
+        </trans-unit>
+        <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
+          <source>Enable transparency</source>
+          <target state="new">Enable transparency</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -728,9 +728,8 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <target state="new">Contributors</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
-          <source>loading fonts</source>
-          <target state="new">loading fonts</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+          <source>Loading Fonts</source>
+          <target state="new">Loading Fonts</target>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -40,8 +40,8 @@
           <target state="new">Char(s)</target>
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
-          <source>Colorization</source>
-          <target state="new">Colorization</target>
+          <source>Colored Glyph</source>
+          <target state="new">Colored Glyph</target>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Monochrome glyphs</source>
@@ -262,10 +262,6 @@
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="new">Open</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="new">Collection Name</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -928,6 +924,54 @@ May have a minor effect on performance on older or weaker devices.</target>
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
           <target state="new">Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
+        <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
+          <source>Keystroke: {0:0000}</source>
+          <target state="new">Keystroke: {0:0000}</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as SVG Image</source>
+          <target state="new">Save as SVG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportPNGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as PNG Image</source>
+          <target state="new">Save as PNG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
+          <source>SVG Glyph</source>
+          <target state="new">SVG Glyph</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Copy to clipboard</source>
+          <target state="new">Copy to clipboard</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Fit Character</source>
+          <target state="new">Fit Character</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
+          <source>was removed from</source>
+          <target state="new">was removed from</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
+          <source>was added to</source>
+          <target state="new">was added to</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="new">Collection Name</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -19,8 +19,9 @@
           <target state="translated">เติมสีดำ</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
-          <source>Copy (character only)</source>
-          <target state="translated">คัดลอกตัวอักษรนี้</target>
+          <source>Copy as text</source>
+          <target state="needs-review-translation">คัดลอกตัวอักษรนี้</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnSavePng.Text" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
@@ -908,9 +909,9 @@ You can change the page range in the Page Setup section.</target>
           <target state="new">Two Columns</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
-          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <target state="new">Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -917,6 +917,20 @@ May have a minor effect on performance on older or weaker devices.</target>
           <source>Enable transparency</source>
           <target state="new">Enable transparency</target>
         </trans-unit>
+        <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
+          <source>Show Details</source>
+          <target state="new">Show Details</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
+          <source>Uh Oh</source>
+          <target state="new">Uh Oh</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
+          <source>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</source>
+          <target state="new">Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -907,6 +907,16 @@ You can change the page range in the Page Setup section.</target>
           <source>Two Columns</source>
           <target state="new">Two Columns</target>
         </trans-unit>
+        <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</source>
+          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</target>
+        </trans-unit>
+        <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
+          <source>Enable transparency</source>
+          <target state="new">Enable transparency</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -40,8 +40,9 @@
           <target state="translated">ตัว</target>
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
-          <source>Colorization</source>
-          <target state="translated">เติมสี</target>
+          <source>Colored Glyph</source>
+          <target state="needs-review-translation">เติมสี</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Monochrome glyphs</source>
@@ -263,10 +264,6 @@
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="translated">เปิด</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="translated">ชื่อรายการสะสม</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -930,6 +927,54 @@ May have a minor effect on performance on older or weaker devices.</target>
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
           <target state="new">Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
+        <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
+          <source>Keystroke: {0:0000}</source>
+          <target state="new">Keystroke: {0:0000}</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as SVG Image</source>
+          <target state="new">Save as SVG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportPNGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as PNG Image</source>
+          <target state="new">Save as PNG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
+          <source>SVG Glyph</source>
+          <target state="new">SVG Glyph</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Copy to clipboard</source>
+          <target state="new">Copy to clipboard</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Fit Character</source>
+          <target state="new">Fit Character</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
+          <source>was removed from</source>
+          <target state="new">was removed from</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
+          <source>was added to</source>
+          <target state="new">was added to</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="new">Collection Name</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -730,9 +730,8 @@ Turning this on can have a minor impact on scrolling performance.</source>
           <target state="new">Contributors</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
-          <source>loading fonts</source>
-          <target state="new">loading fonts</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+          <source>Loading Fonts</source>
+          <target state="new">Loading Fonts</target>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -729,9 +729,9 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <target state="translated">贡献者</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
-          <source>loading fonts</source>
-          <target state="translated">正在加载字体</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+          <source>Loading Fonts</source>
+          <target state="needs-review-translation">正在加载字体</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -40,8 +40,9 @@
           <target state="translated">个字符</target>
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
-          <source>Colorization</source>
-          <target state="translated">颜色选择</target>
+          <source>Colored Glyph</source>
+          <target state="needs-review-translation">颜色选择</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Monochrome glyphs</source>
@@ -263,10 +264,6 @@
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="translated">打开</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="translated">收藏名称</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -930,6 +927,54 @@ May have a minor effect on performance on older or weaker devices.</target>
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
           <target state="new">Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
+        <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
+          <source>Keystroke: {0:0000}</source>
+          <target state="new">Keystroke: {0:0000}</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as SVG Image</source>
+          <target state="new">Save as SVG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportPNGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as PNG Image</source>
+          <target state="new">Save as PNG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
+          <source>SVG Glyph</source>
+          <target state="new">SVG Glyph</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Copy to clipboard</source>
+          <target state="new">Copy to clipboard</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Fit Character</source>
+          <target state="new">Fit Character</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
+          <source>was removed from</source>
+          <target state="new">was removed from</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
+          <source>was added to</source>
+          <target state="new">was added to</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="new">Collection Name</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -916,6 +916,20 @@ May have a minor effect on performance on older or weaker devices.</target>
           <source>Enable transparency</source>
           <target state="new">Enable transparency</target>
         </trans-unit>
+        <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
+          <source>Show Details</source>
+          <target state="new">Show Details</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
+          <source>Uh Oh</source>
+          <target state="new">Uh Oh</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
+          <source>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</source>
+          <target state="new">Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -906,6 +906,16 @@ You can change the page range in the Page Setup section.</target>
           <source>Two Columns</source>
           <target state="translated">两列</target>
         </trans-unit>
+        <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</source>
+          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</target>
+        </trans-unit>
+        <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
+          <source>Enable transparency</source>
+          <target state="new">Enable transparency</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -19,8 +19,9 @@
           <target state="translated">黑色填充</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
-          <source>Copy (character only)</source>
-          <target state="translated">复制 (仅字符)</target>
+          <source>Copy as text</source>
+          <target state="needs-review-translation">复制 (仅字符)</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnSavePng.Text" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
@@ -907,9 +908,9 @@ You can change the page range in the Page Setup section.</target>
           <target state="translated">两列</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
-          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <target state="new">Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -906,6 +906,16 @@ You can change the page range in the Page Setup section.</target>
           <source>Two Columns</source>
           <target state="new">Two Columns</target>
         </trans-unit>
+        <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</source>
+          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</target>
+        </trans-unit>
+        <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
+          <source>Enable transparency</source>
+          <target state="new">Enable transparency</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -19,8 +19,9 @@
           <target state="translated">黑色填充</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
-          <source>Copy (character only)</source>
-          <target state="translated">復制 (僅字符)</target>
+          <source>Copy as text</source>
+          <target state="needs-review-translation">復制 (僅字符)</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnSavePng.Text" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
@@ -907,9 +908,9 @@ You can change the page range in the Page Setup section.</target>
           <target state="new">Two Columns</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
-          <source>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="new">Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+          <target state="new">Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -729,9 +729,8 @@ Turning this on can have a minor impact on scrolling performance.</target>
           <target state="new">Contributors</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
-          <source>loading fonts</source>
-          <target state="new">loading fonts</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">intentionally lowercase for design reasons</note>
+          <source>Loading Fonts</source>
+          <target state="new">Loading Fonts</target>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -916,6 +916,20 @@ May have a minor effect on performance on older or weaker devices.</target>
           <source>Enable transparency</source>
           <target state="new">Enable transparency</target>
         </trans-unit>
+        <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
+          <source>Show Details</source>
+          <target state="new">Show Details</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
+          <source>Uh Oh</source>
+          <target state="new">Uh Oh</target>
+        </trans-unit>
+        <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
+          <source>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</source>
+          <target state="new">Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -40,8 +40,9 @@
           <target state="translated">個字符</target>
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
-          <source>Colorization</source>
-          <target state="translated">顏色選擇</target>
+          <source>Colored Glyph</source>
+          <target state="needs-review-translation">顏色選擇</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Monochrome glyphs</source>
@@ -263,10 +264,6 @@
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="translated">打開</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="translated">收藏名稱</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -929,6 +926,54 @@ May have a minor effect on performance on older or weaker devices.</target>
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
           <target state="new">Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</target>
+        </trans-unit>
+        <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
+          <source>Keystroke: {0:0000}</source>
+          <target state="new">Keystroke: {0:0000}</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as SVG Image</source>
+          <target state="new">Save as SVG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportPNGLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save as PNG Image</source>
+          <target state="new">Save as PNG Image</target>
+        </trans-unit>
+        <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
+          <source>SVG Glyph</source>
+          <target state="new">SVG Glyph</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Copy to clipboard</source>
+          <target state="new">Copy to clipboard</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save As</source>
+          <target state="new">Save As</target>
+        </trans-unit>
+        <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Fit Character</source>
+          <target state="new">Fit Character</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
+          <source>was removed from</source>
+          <target state="new">was removed from</target>
+        </trans-unit>
+        <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
+          <source>was added to</source>
+          <target state="new">was added to</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="new">Collection Name</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/Package.appxmanifest
+++ b/CharacterMap/CharacterMap/Package.appxmanifest
@@ -23,7 +23,7 @@
             <uap:ShowOn Tile="wide310x150Logo" />
           </uap:ShowNameOnTiles>
         </uap:DefaultTile>
-        <uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true" BackgroundColor="#BBBBBB" />
       </uap:VisualElements>
       <Extensions>
         <uap:Extension Category="windows.fileTypeAssociation">

--- a/CharacterMap/CharacterMap/Package.appxmanifest
+++ b/CharacterMap/CharacterMap/Package.appxmanifest
@@ -23,7 +23,7 @@
             <uap:ShowOn Tile="wide310x150Logo" />
           </uap:ShowNameOnTiles>
         </uap:DefaultTile>
-        <uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true" BackgroundColor="#BBBBBB" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true" />
       </uap:VisualElements>
       <Extensions>
         <uap:Extension Category="windows.fileTypeAssociation">

--- a/CharacterMap/CharacterMap/Services/ActivationService.cs
+++ b/CharacterMap/CharacterMap/Services/ActivationService.cs
@@ -39,7 +39,7 @@ namespace CharacterMap.Services
                 // Initialize things like registering background task before the app is loaded
                 await InitializeAsync();
 
-                // We spawn a seperate Window for files.
+                // We spawn a separate Window for files.
                 if (activationArgs is FileActivatedEventArgs fileArgs)
                 {
                     bool mainView = Window.Current.Content == null;
@@ -86,15 +86,9 @@ namespace CharacterMap.Services
                     _ = ApplicationViewSwitcher.TryShowAsStandaloneAsync(WindowService.MainWindow.View.Id);
                     WindowService.MainWindow.CoreView.CoreWindow.Activate();
                 }
-
-
-                //else if (Window.Current.Visible == false
-                //    || WindowService.MainWindow.CoreView.CoreWindow.ActivationMode != CoreWindowActivationMode.ActivatedInForeground)
-                //{
-                //    _ = ApplicationViewSwitcher.TryShowAsStandaloneAsync(WindowService.MainWindow.View.Id);
-                //    WindowService.MainWindow.CoreView.CoreWindow.Activate();
-                //}
             }
+
+           
 
             try
             {

--- a/CharacterMap/CharacterMap/Services/GlyphService.cs
+++ b/CharacterMap/CharacterMap/Services/GlyphService.cs
@@ -81,21 +81,21 @@ namespace CharacterMap.Services
             return Task.CompletedTask;
         }
 
-        internal static string GetCharacterDescription(int unicodeIndex, FontVariant variant, bool includeKeystroke = false)
+        internal static string GetCharacterDescription(int unicodeIndex, FontVariant variant)
         {
             if (variant == null || _provider == null)
                 return null;
 
-            string description = _provider.GetCharacterDescription(unicodeIndex, variant);
+            return _provider.GetCharacterDescription(unicodeIndex, variant);
+        }
 
-            if (includeKeystroke)
-            {
-                // Add Unicode keystroke details
-                if (unicodeIndex >= 128 && unicodeIndex <= 255)
-                    description += $" - Alt + {unicodeIndex:0000}";
-            }
+        internal static string GetCharacterKeystroke(int unicodeIndex)
+        {
+            // Add Unicode keystroke details
+            if (unicodeIndex >= 128 && unicodeIndex <= 255)
+                return $"Keystroke: Alt+{unicodeIndex:0000}";
 
-            return description;
+            return null;
         }
 
         internal static Task<IReadOnlyList<IGlyphData>> SearchAsync(string query, FontVariant variant)

--- a/CharacterMap/CharacterMap/Services/GlyphService.cs
+++ b/CharacterMap/CharacterMap/Services/GlyphService.cs
@@ -91,9 +91,8 @@ namespace CharacterMap.Services
 
         internal static string GetCharacterKeystroke(int unicodeIndex)
         {
-            // Add Unicode keystroke details
             if (unicodeIndex >= 128 && unicodeIndex <= 255)
-                return $"Keystroke: Alt+{unicodeIndex:0000}";
+                return Localization.Get("CharacterKeystrokeLabel",  unicodeIndex);
 
             return null;
         }

--- a/CharacterMap/CharacterMap/Services/WindowService.cs
+++ b/CharacterMap/CharacterMap/Services/WindowService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CharacterMap.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -109,6 +110,9 @@ namespace CharacterMap.Services
                     if (mainView)
                         MainWindow = info;
                 }
+
+                var settings = ResourceHelper.AppSettings;
+                settings.UpdateTransparency(settings.IsTransparencyEnabled);
             }
 
             if (view.Dispatcher.HasThreadAccess)
@@ -193,6 +197,14 @@ namespace CharacterMap.Services
                     });
                 }
             });
+        }
+
+        public static async Task RunOnViewsAsync(DispatchedHandler a)
+        {
+            await MainWindow.CoreView.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, a);
+
+            if (_childWindows.Count > 0)
+                await Task.WhenAll(_childWindows.Select(w => w.Value.CoreView.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, a).AsTask()));
         }
     }
 }

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -788,4 +788,11 @@ You can change the page range in the Page Setup section.</value>
   <data name="PrintLayout_TwoColumn" xml:space="preserve">
     <value>Two Columns</value>
   </data>
+  <data name="SettingsTransparencyDescription.Text" xml:space="preserve">
+    <value>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+May have a minor effect on performance on older or weaker devices.</value>
+  </data>
+  <data name="SettingsTransparencyHeader.Text" xml:space="preserve">
+    <value>Enable transparency</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -795,4 +795,14 @@ May have a minor effect on performance on older or weaker devices.</value>
   <data name="SettingsTransparencyHeader.Text" xml:space="preserve">
     <value>Enable transparency</value>
   </data>
+  <data name="StartupFailedButton.Content" xml:space="preserve">
+    <value>Show Details</value>
+  </data>
+  <data name="StartupFailedHeader.Text" xml:space="preserve">
+    <value>Uh Oh</value>
+  </data>
+  <data name="StartupFailedMessage.Text" xml:space="preserve">
+    <value>Something went wrong and we couldn't start the app right now.
+Please consider posting details about this error to GitHub so we can help you fix it.</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -655,8 +655,7 @@ Turning this on can have a minor impact on scrolling performance.</value>
     <value>Contributors</value>
   </data>
   <data name="TxtLoadingFonts.Text" xml:space="preserve">
-    <value>loading fonts</value>
-    <comment>intentionally lowercase for design reasons</comment>
+    <value>Loading Fonts</value>
   </data>
   <data name="AppBtnClear.Label" xml:space="preserve">
     <value>Clear</value>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -142,7 +142,7 @@
     <value>Char(s)</value>
   </data>
   <data name="ColoredGlyphLabel.Text" xml:space="preserve">
-    <value>Colorization</value>
+    <value>Colored Glyph</value>
   </data>
   <data name="ColorGlyphToggle.OffContent" xml:space="preserve">
     <value>Monochrome glyphs</value>
@@ -803,5 +803,38 @@ May have a minor effect on performance on older or weaker devices.</value>
   <data name="StartupFailedMessage.Text" xml:space="preserve">
     <value>Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</value>
+  </data>
+  <data name="CharacterKeystrokeLabel" xml:space="preserve">
+    <value>Keystroke: {0:0000}</value>
+  </data>
+  <data name="ExportSVGLabel.Text" xml:space="preserve">
+    <value>Save as SVG Image</value>
+  </data>
+  <data name="ExportPNGLabel.Text" xml:space="preserve">
+    <value>Save as PNG Image</value>
+  </data>
+  <data name="ExportSVGGlyphLabel.Text" xml:space="preserve">
+    <value>SVG Glyph</value>
+  </data>
+  <data name="BtnCopyGlyph.Label" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Copy to clipboard</value>
+  </data>
+  <data name="BtnSaveGlyph.Label" xml:space="preserve">
+    <value>Save As</value>
+  </data>
+  <data name="BtnSaveGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Save As</value>
+  </data>
+  <data name="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Fit Character</value>
+  </data>
+  <data name="NotificationFontRemovedBody.Text" xml:space="preserve">
+    <value>was removed from</value>
+  </data>
+   <data name="NotificationFontAddedBody.Text" xml:space="preserve">
+    <value>was added to</value>
   </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -127,7 +127,7 @@
     <value>Black Fill</value>
   </data>
   <data name="BtnCopy.Text" xml:space="preserve">
-    <value>Copy (character only)</value>
+    <value>Copy as text</value>
   </data>
   <data name="BtnSavePng.Text" xml:space="preserve">
     <value>Save as PNG</value>
@@ -789,7 +789,7 @@ You can change the page range in the Page Setup section.</value>
     <value>Two Columns</value>
   </data>
   <data name="SettingsTransparencyDescription.Text" xml:space="preserve">
-    <value>Enables transparency effects in the UI. If transparency in disabled in Windows settings, this will have no effect.
+    <value>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</value>
   </data>
   <data name="SettingsTransparencyHeader.Text" xml:space="preserve">

--- a/CharacterMap/CharacterMap/Strings/th-TH/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/th-TH/Resources.resw
@@ -204,9 +204,6 @@
   <data name="OpenFontPickerConfirm" xml:space="preserve">
     <value>เปิด</value>
   </data>
-  <data name="CreateCollectionEntryBox.Header" xml:space="preserve">
-    <value>ชื่อรายการสะสม</value>
-  </data>
   <data name="DigCreateCollection.PrimaryButtonText" xml:space="preserve">
     <value>สร้าง</value>
   </data>

--- a/CharacterMap/CharacterMap/Strings/zh-CN/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/zh-CN/Resources.resw
@@ -449,7 +449,6 @@
   </data>
   <data name="TxtLoadingFonts.Text" xml:space="preserve">
     <value>正在加载字体</value>
-    <comment>intentionally lowercase for design reasons</comment>
   </data>
   <data name="AppBtnClear.Label" xml:space="preserve">
     <value>清除</value>

--- a/CharacterMap/CharacterMap/Strings/zh-CN/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/zh-CN/Resources.resw
@@ -204,9 +204,6 @@
   <data name="OpenFontPickerConfirm" xml:space="preserve">
     <value>打开</value>
   </data>
-  <data name="CreateCollectionEntryBox.Header" xml:space="preserve">
-    <value>收藏名称</value>
-  </data>
   <data name="DigCreateCollection.PrimaryButtonText" xml:space="preserve">
     <value>创建</value>
   </data>

--- a/CharacterMap/CharacterMap/Strings/zh-TW/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/zh-TW/Resources.resw
@@ -204,9 +204,6 @@
   <data name="OpenFontPickerConfirm" xml:space="preserve">
     <value>打開</value>
   </data>
-  <data name="CreateCollectionEntryBox.Header" xml:space="preserve">
-    <value>收藏名稱</value>
-  </data>
   <data name="DigCreateCollection.PrimaryButtonText" xml:space="preserve">
     <value>創建</value>
   </data>

--- a/CharacterMap/CharacterMap/Styles/Button.xaml
+++ b/CharacterMap/CharacterMap/Styles/Button.xaml
@@ -451,7 +451,6 @@
                                 </VisualState>
                                 <VisualState x:Name="Checked">
                                     <VisualState.Setters>
-                                        <Setter Target="Border.Background" Value="{ThemeResource SystemAltLowColor}" />
                                         <Setter Target="Text.Content">
                                             <Setter.Value>
                                                 <FontIcon FontSize="14" Glyph="&#xE1D8;" />

--- a/CharacterMap/CharacterMap/Styles/Button.xaml
+++ b/CharacterMap/CharacterMap/Styles/Button.xaml
@@ -313,9 +313,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="AppBarButton">
-                    <Grid
-                        x:Name="Root"
-                        Background="{TemplateBinding Background}">
+                    <Grid x:Name="Root" Background="{TemplateBinding Background}">
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
@@ -396,9 +394,9 @@
                                 Foreground="{TemplateBinding Foreground}" />
 
                             <TextBlock
-                                FontSize="12"
                                 Margin="12 0 0 0"
                                 VerticalAlignment="Center"
+                                FontSize="12"
                                 Text="{TemplateBinding Label}" />
                         </StackPanel>
 
@@ -419,53 +417,74 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ButtonBase">
-                    <ContentPresenter
-                        x:Name="Text"
-                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                        Background="{TemplateBinding Background}"
-                        Content="{TemplateBinding Content}">
+                    <Border x:Name="Border" Background="{TemplateBinding Background}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Normal">
+                                    <Storyboard>
+                                        <PointerUpThemeAnimation TargetName="Border" />
+                                    </Storyboard>
+                                </VisualState>
                                 <VisualState x:Name="PointerOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Background">
+                                        <PointerUpThemeAnimation TargetName="Border" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundListLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Background">
+                                        <PointerDownThemeAnimation TargetName="Border" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundListMediumBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Disabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+                                        <PointerUpThemeAnimation TargetName="Border" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="Opacity">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="0.4" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Checked">
+                                    <VisualState.Setters>
+                                        <Setter Target="Text.Background" Value="{ThemeResource SystemAltLowColor}" />
+                                        <Setter Target="Text.Content">
+                                            <Setter.Value>
+                                                <FontIcon FontSize="14" Glyph="&#xE1D8;" />
+                                            </Setter.Value>
+                                        </Setter>
+                                    </VisualState.Setters>
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundAccentBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
+                                        <PointerUpThemeAnimation TargetName="Border" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CheckedPointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="Text.Background" Value="{ThemeResource SystemControlBackgroundListLowBrush}" />
+                                        <Setter Target="Text.Content">
+                                            <Setter.Value>
+                                                <FontIcon FontSize="14" Glyph="&#xE1D8;" />
+                                            </Setter.Value>
+                                        </Setter>
+                                    </VisualState.Setters>
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundListLowBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
+                                        <PointerUpThemeAnimation TargetName="Border" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                    </ContentPresenter>
+                        <ContentPresenter
+                            x:Name="Text"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Content="{TemplateBinding Content}"
+                            Foreground="{TemplateBinding Foreground}" />
+
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/CharacterMap/CharacterMap/Styles/Button.xaml
+++ b/CharacterMap/CharacterMap/Styles/Button.xaml
@@ -451,7 +451,7 @@
                                 </VisualState>
                                 <VisualState x:Name="Checked">
                                     <VisualState.Setters>
-                                        <Setter Target="Text.Background" Value="{ThemeResource SystemAltLowColor}" />
+                                        <Setter Target="Border.Background" Value="{ThemeResource SystemAltLowColor}" />
                                         <Setter Target="Text.Content">
                                             <Setter.Value>
                                                 <FontIcon FontSize="14" Glyph="&#xE1D8;" />
@@ -464,7 +464,20 @@
                                 </VisualState>
                                 <VisualState x:Name="CheckedPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="Text.Background" Value="{ThemeResource SystemControlBackgroundListLowBrush}" />
+                                        <Setter Target="Border.Background" Value="{ThemeResource SystemControlBackgroundListLowBrush}" />
+                                        <Setter Target="Text.Content">
+                                            <Setter.Value>
+                                                <FontIcon FontSize="14" Glyph="&#xE1D8;" />
+                                            </Setter.Value>
+                                        </Setter>
+                                    </VisualState.Setters>
+                                    <Storyboard>
+                                        <PointerUpThemeAnimation TargetName="Border" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="Border.Background" Value="{ThemeResource SystemControlBackgroundListLowBrush}" />
                                         <Setter Target="Text.Content">
                                             <Setter.Value>
                                                 <FontIcon FontSize="14" Glyph="&#xE1D8;" />

--- a/CharacterMap/CharacterMap/Styles/Button.xaml
+++ b/CharacterMap/CharacterMap/Styles/Button.xaml
@@ -18,7 +18,7 @@
     <Style x:Key="TransparentButton" BasedOn="{StaticResource ButtonRevealStyle}" TargetType="Button">
         <Setter Property="Background" Value="{ThemeResource ListViewItemRevealBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource ButtonRevealBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="8,4,8,5" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -97,7 +97,7 @@
     <Style x:Key="TransparentHintButton" BasedOn="{StaticResource ButtonRevealStyle}" TargetType="Button">
         <Setter Property="Background" Value="{ThemeResource ListViewItemRevealBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource ButtonRevealBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="8,4,8,5" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -139,7 +139,7 @@
                                 <VisualState x:Name="Pressed">
                                     <VisualState.Setters>
                                         <Setter Target="RootGrid.(RevealBrush.State)" Value="Pressed" />
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource ButtonRevealBackgroundPressed}" />
+                                        <Setter Target="RootGrid.Background" Value="{ThemeResource ListViewItemRevealBackgroundPressed}" />
                                         <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ButtonRevealBorderBrushPressed}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ButtonForegroundPressed}" />
                                     </VisualState.Setters>

--- a/CharacterMap/CharacterMap/Styles/ComboBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/ComboBox.xaml
@@ -3,12 +3,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:helpers="using:CharacterMap.Helpers">
 
-    <Style TargetType="ComboBox">
+    <Style x:Key="VariantComboBoxStyle" TargetType="ComboBox">
         <Setter Property="Padding" Value="12,5,0,7" />
         <Setter Property="MinWidth" Value="{ThemeResource ComboBoxThemeMinWidth}" />
         <Setter Property="Foreground" Value="{ThemeResource ComboBoxForeground}" />
         <Setter Property="Background" Value="{ThemeResource ListViewItemRevealBackground}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource ButtonRevealBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="TabNavigation" Value="Once" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
@@ -56,7 +56,7 @@
 
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="32" />
+                            <ColumnDefinition Width="36" />
                         </Grid.ColumnDefinitions>
 
                         <VisualStateManager.VisualStateGroups>
@@ -82,6 +82,7 @@
                                 <VisualState x:Name="Disabled">
                                     <VisualState.Setters>
                                         <Setter Target="DropDownGlyph.Opacity" Value="0" />
+                                        <Setter Target="Background.BorderBrush" Value="Transparent" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -203,12 +204,22 @@
                             Grid.Row="1"
                             Margin="{TemplateBinding Padding}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                            <TextBlock
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Visibility="Collapsed">
+                            <!--<TextBlock
                                 x:Name="PlaceholderTextBlock"
                                 Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource ComboBoxPlaceHolderForeground}}"
-                                Text="{TemplateBinding PlaceholderText}" />
+                                Text="{TemplateBinding PlaceholderText}" />-->
                         </ContentPresenter>
+                        <StackPanel
+                            Grid.Row="1"
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            <ContentPresenter Content="{TemplateBinding SelectedItem}" FontSize="{TemplateBinding FontSize}" />
+                            <TextBlock Text="{TemplateBinding PlaceholderText}"  FontSize="12"
+                                Opacity="0.6"/>
+                        </StackPanel>
                         <FontIcon
                             x:Name="DropDownGlyph"
                             Grid.Row="1"

--- a/CharacterMap/CharacterMap/Styles/ComboBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/ComboBox.xaml
@@ -39,19 +39,13 @@
                             <Storyboard x:Key="OverlayOpeningAnimation">
                                 <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0.0" />
-                                    <SplineDoubleKeyFrame
-                                        KeySpline="0.1,0.9 0.2,1.0"
-                                        KeyTime="0:0:0.383"
-                                        Value="1.0" />
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.383" Value="1.0" />
                                 </DoubleAnimationUsingKeyFrames>
                             </Storyboard>
                             <Storyboard x:Key="OverlayClosingAnimation">
                                 <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1.0" />
-                                    <SplineDoubleKeyFrame
-                                        KeySpline="0.1,0.9 0.2,1.0"
-                                        KeyTime="0:0:0.216"
-                                        Value="0.0" />
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.216" Value="0.0" />
                                 </DoubleAnimationUsingKeyFrames>
                             </Storyboard>
                         </Grid.Resources>

--- a/CharacterMap/CharacterMap/Styles/CommandBar.xaml
+++ b/CharacterMap/CharacterMap/Styles/CommandBar.xaml
@@ -18,19 +18,13 @@
                             <Storyboard x:Key="OverlayOpeningAnimation">
                                 <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0" />
-                                    <SplineDoubleKeyFrame
-                                        KeySpline="0.1,0.9 0.2,1.0"
-                                        KeyTime="0:0:0.467"
-                                        Value="1" />
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.467" Value="1" />
                                 </DoubleAnimationUsingKeyFrames>
                             </Storyboard>
                             <Storyboard x:Key="OverlayClosingAnimation">
                                 <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1" />
-                                    <SplineDoubleKeyFrame
-                                        KeySpline="0.2,0 0,1"
-                                        KeyTime="0:0:0.167"
-                                        Value="0" />
+                                    <SplineDoubleKeyFrame KeySpline="0.2,0 0,1" KeyTime="0:0:0.167" Value="0" />
                                 </DoubleAnimationUsingKeyFrames>
                             </Storyboard>
                         </Grid.Resources>
@@ -113,24 +107,15 @@
                                             </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ClipGeometryTransform" Storyboard.TargetProperty="Y">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CompactVerticalDelta}" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.1,0.9 0.2,1.0"
-                                                    KeyTime="0:0:0.467"
-                                                    Value="0" />
+                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.467" Value="0" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OverflowContentRootTransform" Storyboard.TargetProperty="Y">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{ThemeResource AppBarThemeCompactHeight}" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.1,0.9 0.2,1.0"
-                                                    KeyTime="0:0:0.467"
-                                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.ContentHeight}" />
+                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.467" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.ContentHeight}" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OverflowContentTransform" Storyboard.TargetProperty="Y">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.NegativeOverflowContentHeight}" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.1,0.9 0.2,1.0"
-                                                    KeyTime="0:0:0.467"
-                                                    Value="0" />
+                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.467" Value="0" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
@@ -153,24 +138,15 @@
                                             </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ClipGeometryTransform" Storyboard.TargetProperty="Y">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.7, 0, 1, 0.5"
-                                                    KeyTime="0:0:0.167"
-                                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CompactVerticalDelta}" />
+                                                <SplineDoubleKeyFrame KeySpline="0.7, 0, 1, 0.5" KeyTime="0:0:0.167" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CompactVerticalDelta}" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OverflowContentRootTransform" Storyboard.TargetProperty="Y">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.ContentHeight}" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.7, 0, 1, 0.5"
-                                                    KeyTime="0:0:0.167"
-                                                    Value="{ThemeResource AppBarThemeCompactHeight}" />
+                                                <SplineDoubleKeyFrame KeySpline="0.7, 0, 1, 0.5" KeyTime="0:0:0.167" Value="{ThemeResource AppBarThemeCompactHeight}" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="OverflowContentTransform" Storyboard.TargetProperty="Y">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.7, 0, 1, 0.5"
-                                                    KeyTime="0:0:0.167"
-                                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.NegativeOverflowContentHeight}" />
+                                                <SplineDoubleKeyFrame KeySpline="0.7, 0, 1, 0.5" KeyTime="0:0:0.167" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.NegativeOverflowContentHeight}" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>

--- a/CharacterMap/CharacterMap/Styles/Controls.xaml
+++ b/CharacterMap/CharacterMap/Styles/Controls.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Style  TargetType="ContentDialog">
+    <Style TargetType="ContentDialog">
         <Setter Property="Foreground" Value="{ThemeResource ContentDialogForeground}" />
         <Setter Property="Background" Value="{ThemeResource ContentDialogBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ContentDialogBorderBrush}" />
@@ -29,17 +29,11 @@
                                             </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ScaleTransform" Storyboard.TargetProperty="ScaleX">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1.0" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.1,0.9 0.2,1.0"
-                                                    KeyTime="0:0:1.5"
-                                                    Value="1.3" />
+                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:1.5" Value="1.3" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ScaleTransform" Storyboard.TargetProperty="ScaleY">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1.0" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.1,0.9 0.2,1.0"
-                                                    KeyTime="0:0:1.5"
-                                                    Value="1.3" />
+                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:1.5" Value="1.3" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Opacity">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1.0" />
@@ -54,17 +48,11 @@
                                             </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ScaleTransform" Storyboard.TargetProperty="ScaleX">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1.4" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.1,0.9 0.2,1.0"
-                                                    KeyTime="0:0:0.5"
-                                                    Value="1.0" />
+                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.5" Value="1.0" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ScaleTransform" Storyboard.TargetProperty="ScaleY">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1.4" />
-                                                <SplineDoubleKeyFrame
-                                                    KeySpline="0.1,0.9 0.2,1.0"
-                                                    KeyTime="0:0:0.5"
-                                                    Value="1.0" />
+                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.5" Value="1.0" />
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Opacity">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0.0" />

--- a/CharacterMap/CharacterMap/Styles/Controls.xaml
+++ b/CharacterMap/CharacterMap/Styles/Controls.xaml
@@ -366,4 +366,41 @@
         </Setter>
     </Style>
 
+    <Style x:Key="MenuFlyoutItemReadOnlyHeaderStyle" TargetType="MenuFlyoutItem">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+        <Setter Property="BorderThickness" Value="0 0 0 1" />
+        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+        <Setter Property="Padding" Value="10 12 10 8" />
+        <Setter Property="FontSize" Value="13.333" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="IsEnabled" Value="False" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+        <Setter Property="KeyboardAcceleratorPlacementMode" Value="Hidden" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="MenuFlyoutItem">
+                    <Border
+                        x:Name="LayoutRoot"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
+                        <TextBlock
+                            x:Name="TextBlock"
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Foreground="{TemplateBinding Foreground}"
+                            Text="{TemplateBinding Text}"
+                            TextTrimming="Clip" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
 </ResourceDictionary>

--- a/CharacterMap/CharacterMap/Styles/InAppNotification.xaml
+++ b/CharacterMap/CharacterMap/Styles/InAppNotification.xaml
@@ -48,9 +48,14 @@
                         </Border>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Normal">
+                                    <Storyboard>
+                                        <PointerUpThemeAnimation TargetName="Text" />
+                                    </Storyboard>
+                                </VisualState>
                                 <VisualState x:Name="PointerOver">
                                     <Storyboard>
+                                        <PointerUpThemeAnimation TargetName="Text" />
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverForegroundBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -61,6 +66,7 @@
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <Storyboard>
+                                        <PointerDownThemeAnimation TargetName="Text" />
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverForegroundBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -98,18 +104,12 @@
                         <Storyboard>
                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
                                 <EasingDoubleKeyFrame KeyTime="0" Value="0" />
-                                <SplineDoubleKeyFrame
-                                    KeySpline="0.7, 0, 1, 0.5"
-                                    KeyTime="0:0:0.225"
-                                    Value="{Binding HorizontalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
+                                <SplineDoubleKeyFrame KeySpline="0.7, 0, 1, 0.5" KeyTime="0:0:0.225" Value="{Binding HorizontalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
                             </DoubleAnimationUsingKeyFrames>
 
                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
                                 <EasingDoubleKeyFrame KeyTime="0" Value="0" />
-                                <SplineDoubleKeyFrame
-                                    KeySpline="0.7, 0, 1, 0.5"
-                                    KeyTime="0:0:0.225"
-                                    Value="{Binding VerticalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
+                                <SplineDoubleKeyFrame KeySpline="0.7, 0, 1, 0.5" KeyTime="0:0:0.225" Value="{Binding VerticalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
                             </DoubleAnimationUsingKeyFrames>
 
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="(UIElement.Visibility)">
@@ -123,26 +123,17 @@
                         <Storyboard>
                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="(UIElement.Opacity)">
                                 <EasingDoubleKeyFrame KeyTime="0" Value="0" />
-                                <SplineDoubleKeyFrame
-                                    KeySpline="0.1, 0.9, 0.2, 1"
-                                    KeyTime="0:0:0.3"
-                                    Value="1" />
+                                <SplineDoubleKeyFrame KeySpline="0.1, 0.9, 0.2, 1" KeyTime="0:0:0.3" Value="1" />
                             </DoubleAnimationUsingKeyFrames>
 
                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
                                 <EasingDoubleKeyFrame KeyTime="0" Value="{Binding HorizontalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
-                                <SplineDoubleKeyFrame
-                                    KeySpline="0.1, 0.9, 0.2, 1"
-                                    KeyTime="0:0:0.5"
-                                    Value="0" />
+                                <SplineDoubleKeyFrame KeySpline="0.1, 0.9, 0.2, 1" KeyTime="0:0:0.5" Value="0" />
                             </DoubleAnimationUsingKeyFrames>
 
                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
                                 <EasingDoubleKeyFrame KeyTime="0" Value="{Binding VerticalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
-                                <SplineDoubleKeyFrame
-                                    KeySpline="0.1, 0.9, 0.2, 1"
-                                    KeyTime="0:0:0.5"
-                                    Value="0" />
+                                <SplineDoubleKeyFrame KeySpline="0.1, 0.9, 0.2, 1" KeyTime="0:0:0.5" Value="0" />
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
@@ -176,7 +167,22 @@
                     VerticalContentAlignment="Center"
                     TextWrapping="WrapWholeWords" />
 
-                <Button
+                <AppBarButton
+                    x:Name="PART_DismissButton"
+                    Grid.Column="1"
+                    Width="40"
+                    Height="40"
+                    AutomationProperties.Name="Dismiss">
+                    <Button.RenderTransform>
+                        <TranslateTransform x:Name="DismissButtonTransform" X="18" />
+                    </Button.RenderTransform>
+                    <SymbolIcon
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Symbol="Cancel" />
+                </AppBarButton>
+
+                <!--<Button
                     x:Name="PART_DismissButton"
                     Grid.Column="1"
                     AutomationProperties.Name="Dismiss"
@@ -187,7 +193,7 @@
                     <Button.RenderTransform>
                         <TranslateTransform x:Name="DismissButtonTransform" X="18" />
                     </Button.RenderTransform>
-                </Button>
+                </Button>-->
             </Grid>
         </Grid>
     </ControlTemplate>

--- a/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml
+++ b/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml
@@ -106,24 +106,20 @@
             </Grid.ColumnDefinitions>
             <TextBlock VerticalAlignment="Center">
                 <Run FontWeight="SemiBold" Text="{x:Bind Font.Name}" />
-                <Run Text="was added to" />
+                <Run x:Uid="NotificationFontAddedBody" />
                 <Hyperlink Click="BtnViewCollection_Click">
                     <Run Text="{x:Bind Collection.Name}" />
                 </Hyperlink>
             </TextBlock>
 
-            <AppBarButton
+            <Button
                 Grid.Column="1"
-                Width="40"
-                Height="40"
                 Margin="12 0 0 0"
+                VerticalAlignment="Center"
                 Click="BtnUndo_Click"
-                Tag="{x:Bind}">
-                <SymbolIcon
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    Symbol="Undo" />
-            </AppBarButton>
+                Content="Undo"
+                Style="{StaticResource ButtonRevealStyle}"
+                Tag="{x:Bind}" />
         </Grid>
     </DataTemplate>
 
@@ -135,24 +131,20 @@
             </Grid.ColumnDefinitions>
             <TextBlock VerticalAlignment="Center">
                 <Run FontWeight="SemiBold" Text="{x:Bind Font.Name}" />
-                <Run Text="was removed from" />
+                <Run x:Uid="NotificationFontRemovedBody" />
                 <Hyperlink>
                     <Run Text="{x:Bind Collection.Name}" />
                 </Hyperlink>
             </TextBlock>
 
-            <AppBarButton
+            <Button
                 Grid.Column="1"
-                Width="40"
-                Height="40"
                 Margin="12 0 0 0"
+                VerticalAlignment="Center"
                 Click="BtnUndo_Click"
-                Tag="{x:Bind}">
-                <SymbolIcon
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    Symbol="Undo" />
-            </AppBarButton>
+                Content="Undo"
+                Style="{StaticResource ButtonRevealStyle}"
+                Tag="{x:Bind}" />
         </Grid>
     </DataTemplate>
 

--- a/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml
+++ b/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml
@@ -5,6 +5,7 @@
     xmlns:core="using:CharacterMap.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:CharacterMap.Models"
     xmlns:services="using:CharacterMap.Services"
     mc:Ignorable="d">
 
@@ -103,19 +104,55 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <TextBlock
-                VerticalAlignment="Center"
-                FontSize="16"
-                IsColorFontEnabled="True"
-                Text="{x:Bind GetMessage()}"
-                TextWrapping="Wrap" />
+            <TextBlock VerticalAlignment="Center">
+                <Run FontWeight="SemiBold" Text="{x:Bind Font.Name}" />
+                <Run Text="was added to" />
+                <Hyperlink Click="BtnViewCollection_Click">
+                    <Run Text="{x:Bind Collection.Name}" />
+                </Hyperlink>
+            </TextBlock>
 
-            <Button
-                x:Uid="BtnViewCollection"
+            <AppBarButton
                 Grid.Column="1"
+                Width="40"
+                Height="40"
                 Margin="12 0 0 0"
-                Click="BtnViewCollection_Click"
-                Style="{StaticResource ButtonRevealStyle}" />
+                Click="BtnUndo_Click"
+                Tag="{x:Bind}">
+                <SymbolIcon
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Symbol="Undo" />
+            </AppBarButton>
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="RemoveFromCollectionNotification" x:DataType="models:CollectionUpdatedArgs">
+        <Grid ColumnSpacing="12" HorizontalAlignment="Stretch">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock VerticalAlignment="Center">
+                <Run FontWeight="SemiBold" Text="{x:Bind Font.Name}" />
+                <Run Text="was removed from" />
+                <Hyperlink>
+                    <Run Text="{x:Bind Collection.Name}" />
+                </Hyperlink>
+            </TextBlock>
+
+            <AppBarButton
+                Grid.Column="1"
+                Width="40"
+                Height="40"
+                Margin="12 0 0 0"
+                Click="BtnUndo_Click"
+                Tag="{x:Bind}">
+                <SymbolIcon
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Symbol="Undo" />
+            </AppBarButton>
         </Grid>
     </DataTemplate>
 

--- a/CharacterMap/CharacterMap/Styles/ListView.xaml
+++ b/CharacterMap/CharacterMap/Styles/ListView.xaml
@@ -3,6 +3,7 @@
     <Style x:Key="FontListHeaderItem" TargetType="ListViewHeaderItem">
         <Setter Property="Padding" Value="0" />
         <Setter Property="Margin" Value="0" />
+        <Setter Property="BorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListViewHeaderItem">

--- a/CharacterMap/CharacterMap/Styles/TextBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/TextBox.xaml
@@ -1,4 +1,7 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:helpers="using:CharacterMap.Helpers">
 
     <Style x:Key="CopyTextBox" TargetType="TextBox">
         <Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
@@ -78,7 +81,7 @@
         <Setter Property="MinHeight" Value="{ThemeResource TextControlThemeMinHeight}" />
         <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
         <Setter Property="Background" Value="{ThemeResource TextControlBackground}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource TextControlBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource TextControlForeground}" />
         <Setter Property="SelectionHighlightColor" Value="{ThemeResource TextControlSelectionHighlightColor}" />
         <Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}" />
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
@@ -239,9 +242,6 @@
                                 <VisualState x:Name="Disabled">
 
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlHeaderForegroundDisabled}" />
-                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -261,6 +261,9 @@
                                 <VisualState x:Name="PointerOver">
 
                                     <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderDefaultElement" Storyboard.TargetProperty="Opacity">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="0.4" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemAccentColorDark1}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -287,6 +290,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemAccentColorDark1}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Opacity">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="1" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -305,11 +311,7 @@
 
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DeleteButton" Storyboard.TargetProperty="Visibility">
-                                            <DiscreteObjectKeyFrame KeyTime="0">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Visible</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -330,39 +332,41 @@
                             <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
+
                         <Border
-                            x:Name="BorderElement"
-                            CornerRadius="{TemplateBinding CornerRadius}"
+                            x:Name="BorderDefaultElement"
                             Grid.Row="1"
                             Grid.RowSpan="1"
                             Grid.ColumnSpan="3"
+                            Margin="2 0"
+                            helpers:Composition.OpacityDuration="0:0:0.15"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Opacity="0"
+                            RequestedTheme="Light" />
+                        <Border
+                            x:Name="BorderElement"
+                            Grid.Row="1"
+                            Grid.RowSpan="1"
+                            Grid.ColumnSpan="3"
+                            helpers:Composition.OpacityDuration="0:0:0.15"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}" />
-                        <ContentPresenter
-                            x:Name="HeaderContentPresenter"
-                            x:DeferLoadStrategy="Lazy"
-                            Grid.Row="0"
-                            Grid.ColumnSpan="3"
-                            Margin="{ThemeResource AutoSuggestBoxTopHeaderMargin}"
-                            Content="{TemplateBinding Header}"
-                            ContentTemplate="{TemplateBinding HeaderTemplate}"
-                            FontWeight="Normal"
-                            Foreground="{ThemeResource TextControlHeaderForeground}"
-                            TextWrapping="Wrap"
-                            Visibility="Collapsed" />
+                            BorderThickness="1"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Opacity="0" />
                         <ScrollViewer
                             x:Name="ContentElement"
                             Grid.Row="1"
                             Margin="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}"
                             AutomationProperties.AccessibilityView="Raw"
+                            CornerRadius="{TemplateBinding CornerRadius}"
                             HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                             HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
                             IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
                             IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
                             IsTabStop="False"
-                            CornerRadius="{TemplateBinding CornerRadius}"
                             IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
                             VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                             VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
@@ -374,6 +378,7 @@
                             Margin="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}"
                             Content="{TemplateBinding PlaceholderText}"
+                            FontStyle="Italic"
                             Foreground="{ThemeResource TextControlPlaceholderForeground}"
                             IsHitTestVisible="False"
                             IsTabStop="False" />
@@ -401,17 +406,7 @@
                             FontSize="{TemplateBinding FontSize}"
                             IsTabStop="False"
                             Style="{StaticResource QueryButtonStyle}" />
-                        <ContentPresenter
-                            x:Name="DescriptionPresenter"
-                            x:Load="False"
-                            Grid.Row="2"
-                            Grid.ColumnSpan="3"
-                            AutomationProperties.AccessibilityView="Raw"
-                            Content="{TemplateBinding Description}"
-                            Foreground="{ThemeResource SystemControlDescriptionTextForegroundBrush}" />
-
                     </Grid>
-
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -426,6 +421,7 @@
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="TextBoxStyle" Value="{StaticResource AutoSuggestBoxTextBoxStyle}" />
         <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+        <Setter Property="BorderThickness" Value="0 0 0 1" />
         <Setter Property="ItemContainerStyle">
             <Setter.Value>
                 <Style TargetType="ListViewItem">
@@ -443,6 +439,7 @@
                             x:Name="TextBox"
                             Width="{TemplateBinding Width}"
                             Margin="0"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Canvas.ZIndex="0"
                             CornerRadius="{TemplateBinding CornerRadius}"
                             Description="{TemplateBinding Description}"

--- a/CharacterMap/CharacterMap/Styles/TextBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/TextBox.xaml
@@ -96,7 +96,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="TextBox">
-                    <Grid>
+                    <Grid x:Name="Root">
 
                         <Grid.Resources>
                             <Style x:Name="DeleteButtonStyle" TargetType="Button">
@@ -105,6 +105,7 @@
                                         <ControlTemplate TargetType="Button">
                                             <Grid
                                                 x:Name="ButtonLayoutGrid"
+                                                CornerRadius="{TemplateBinding CornerRadius}"
                                                 Background="{ThemeResource TextControlButtonBackground}"
                                                 BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}">
@@ -173,6 +174,7 @@
                                         <ControlTemplate TargetType="Button">
                                             <ContentPresenter
                                                 x:Name="ContentPresenter"
+                                                CornerRadius="{TemplateBinding CornerRadius}"
                                                 Padding="{TemplateBinding Padding}"
                                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -238,29 +240,20 @@
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
-
                                 <VisualState x:Name="Disabled">
-
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundDisabled}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushDisabled}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundDisabled}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundDisabled}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
+                                    <VisualState.Setters>
+                                        <Setter Target="Root.Opacity" Value="0.4" />
+                                    </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Normal" />
-
                                 <VisualState x:Name="PointerOver">
-
                                     <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContent" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderDefaultElement" Storyboard.TargetProperty="Opacity">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="0.4" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -270,18 +263,17 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundPointerOver}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundPointerOver}" />
-                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundPointerOver}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Focused">
-
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContent" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderIcon" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundFocused}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
@@ -304,21 +296,15 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
-
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="ButtonStates">
                                 <VisualState x:Name="ButtonVisible">
-
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DeleteButton" Storyboard.TargetProperty="Visibility">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
+                                    <VisualState.Setters>
+                                        <Setter Target="DeleteButton.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="ButtonCollapsed" />
-
                             </VisualStateGroup>
-
                         </VisualStateManager.VisualStateGroups>
 
                         <Grid.ColumnDefinitions>
@@ -371,22 +357,35 @@
                             VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                             VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
                             ZoomMode="Disabled" />
-                        <ContentControl
+                        <StackPanel
                             x:Name="PlaceholderTextContentPresenter"
                             Grid.Row="1"
                             Grid.ColumnSpan="3"
+                            Spacing="8"
                             Margin="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}"
-                            Content="{TemplateBinding PlaceholderText}"
-                            FontStyle="Italic"
-                            Foreground="{ThemeResource TextControlPlaceholderForeground}"
-                            IsHitTestVisible="False"
-                            IsTabStop="False" />
+                            Orientation="Horizontal">
+                            <FontIcon
+                                x:Name="PlaceholderIcon"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                Foreground="{ThemeResource TextControlPlaceholderForeground}"
+                                FontSize="12"
+                                Glyph="&#xE11A;" />
+                            <ContentControl
+                                x:Name="PlaceholderTextContent"
+                                Content="{TemplateBinding PlaceholderText}"
+                                FontStyle="Italic"
+                                Foreground="{ThemeResource TextControlPlaceholderForeground}"
+                                IsHitTestVisible="False"
+                                IsTabStop="False" />
+                        </StackPanel>
+
                         <Button
                             x:Name="DeleteButton"
                             Grid.Row="1"
                             Grid.Column="1"
                             MinWidth="34"
+                            CornerRadius="0 2 2 0"
                             VerticalAlignment="Stretch"
                             AutomationProperties.AccessibilityView="Raw"
                             BorderThickness="{TemplateBinding BorderThickness}"
@@ -398,6 +397,7 @@
                             x:Name="QueryButton"
                             Grid.Row="1"
                             Grid.Column="2"
+                            CornerRadius="0 2 2 0"
                             Width="{TemplateBinding Height}"
                             MinWidth="34"
                             VerticalAlignment="Stretch"
@@ -454,7 +454,7 @@
                             Style="{TemplateBinding TextBoxStyle}"
                             UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}" />
 
-                        <Popup x:Name="SuggestionsPopup" RequestedTheme="Default">
+                        <Popup x:Name="SuggestionsPopup">
                             <Border
                                 x:Name="SuggestionsContainer"
                                 Padding="{ThemeResource AutoSuggestListMargin}"

--- a/CharacterMap/CharacterMap/Themes/Generic.xaml
+++ b/CharacterMap/CharacterMap/Themes/Generic.xaml
@@ -8,9 +8,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:XamlTitleBar">
-                    <Grid
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}">
+                    <Grid BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
                         <Rectangle x:Name="BackgroundElement">
                             <Rectangle.Fill>
                                 <SolidColorBrush Color="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.BackgroundColor}" />

--- a/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/FontMapViewModel.cs
@@ -361,10 +361,8 @@ namespace CharacterMap.ViewModels
 
         private void ApplyEffectiveTypography(CanvasTextLayout layout)
         {
-            using (var type = GetEffectiveTypography())
-            {
-                layout.SetTypography(0, 1, type);
-            }
+            using var type = GetEffectiveTypography();
+            layout.SetTypography(0, 1, type);
         }
 
         internal void UpdateDevValues()
@@ -403,16 +401,23 @@ namespace CharacterMap.ViewModels
             }
         }
 
+        public string GetCharName(Character c)
+        {
+            if (SelectedVariant == null || c == null)
+                return null;
+
+            return GlyphService.GetCharacterDescription(c.UnicodeIndex, SelectedVariant);
+        }
+
         public string GetCharDescription(Character c)
         {
             if (SelectedVariant == null || c == null)
                 return null;
 
-            string desc = GlyphService.GetCharacterDescription(c.UnicodeIndex, SelectedVariant, true);
-            if (!string.IsNullOrEmpty(desc))
-                return $"{desc} - {c.UnicodeString}";
-
-            return c.UnicodeString;
+            if (GlyphService.GetCharacterKeystroke(c.UnicodeIndex) is string k)
+                return $"{c.UnicodeString} - {k}";
+            else
+                return c.UnicodeString;
         }
 
         public void DebounceSearch(string query, int delayMilliseconds = 500, SearchSource from = SearchSource.AutoProperty)

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -20,9 +20,9 @@
         DataContext="{x:Bind ViewModel}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="{StaticResource TitleRowGridHeight}" />
             <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="{StaticResource StatusBarGridHeight}" />
         </Grid.RowDefinitions>
 
         <controls:XamlTitleBar
@@ -30,37 +30,49 @@
             x:Load="{x:Bind IsStandalone}"
             Canvas.ZIndex="101" />
 
+        <!--  Title row  -->
         <Grid
             x:Name="TitleGrid"
-            x:Load="{x:Bind IsStandalone}"
             Grid.RowSpan="2"
             Canvas.ZIndex="1">
             <Grid.RowDefinitions>
-                <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, FallbackValue=Auto}" />
-                <RowDefinition Height="45" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="{StaticResource TitleRowGridHeight}" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="0" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
+
+            <Border
+                x:Name="TitleBarSpacer"
+                x:Load="{x:Bind IsStandalone}"
+                Grid.ColumnSpan="10"
+                Height="{x:Bind TitleBar.Height, Mode=OneWay}" />
+
+            <ContentPresenter Grid.Row="1" Content="{x:Bind TitleLeftContent, Mode=OneWay}" />
+
             <TextBlock
                 x:Name="FontTitleBlock"
+                x:FieldModifier="public"
                 Grid.Row="1"
-                Grid.Column="0"
-                Margin="24,0"
+                Grid.Column="1"
+                Margin="24 0 8 0"
                 VerticalAlignment="Center"
                 FontSize="22"
                 FontWeight="Bold"
+                Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
                 Text="{Binding SelectedFont.Name}"
                 TextTrimming="CharacterEllipsis"
                 ToolTipService.ToolTip="{Binding SelectedFont.Name}" />
 
             <Button
                 Grid.Row="1"
-                Grid.Column="1"
-                Height="45"
+                Grid.Column="2"
+                Height="{StaticResource TitleRowHeight}"
                 Padding="12,0"
                 HorizontalAlignment="Right"
                 Click="{x:Bind ViewModel.ImportFile}"
@@ -83,8 +95,9 @@
             <AutoSuggestBox
                 x:Name="SearchBox"
                 x:Uid="SearchBox"
+                x:FieldModifier="public"
                 Grid.Row="1"
-                Grid.Column="2"
+                Grid.Column="3"
                 Width="290"
                 Margin="6 0 6 0"
                 VerticalAlignment="Center"
@@ -105,8 +118,12 @@
                 </AutoSuggestBox.QueryIcon>
             </AutoSuggestBox>
 
-        </Grid>
+            <ContentPresenter
+                Grid.Row="1"
+                Grid.Column="4"
+                Content="{x:Bind TitleRightContent, Mode=OneWay}" />
 
+        </Grid>
 
         <!--  Main UI Grid  -->
         <Grid
@@ -145,6 +162,7 @@
                     Stretch="UniformToFill"
                     StrokeThickness="0" />
 
+                <!--  Character Grid  -->
                 <Grid x:Name="MapContainer" x:FieldModifier="public">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -503,8 +521,6 @@
                         Glyph="&#xE784;"
                         IsHitTestVisible="False" />
                 </Grid>
-
-
 
                 <!--  Preview Grid  -->
                 <Grid
@@ -1005,6 +1021,7 @@
             </Grid>
         </Grid>
 
+        <!--  Notification Presenter  -->
         <Grid
             x:Name="NotificationRoot"
             x:Load="False"
@@ -1013,7 +1030,7 @@
             <toolkit:InAppNotification x:Name="DefaultNotification" />
         </Grid>
 
-        <!--  Loading Root  -->
+        <!--  Standalone Loading Root  -->
         <ProgressRing
             x:Name="LoadingRing"
             Grid.Row="2"
@@ -1021,13 +1038,11 @@
             Width="50"
             Height="50" />
 
+        <!--  Status Bar  -->
         <Grid
             x:Name="StatusBar"
-            x:Load="{x:Bind IsStandalone}"
             Grid.Row="3"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Height="26"
+            Height="{StaticResource StatusBarHeight}"
             Background="{StaticResource AltHostBrush}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -1036,22 +1051,33 @@
             </Grid.ColumnDefinitions>
 
             <Grid.Resources>
-                <Style TargetType="TextBlock">
-                    <Setter Property="FontSize" Value="12" />
-                    <Setter Property="VerticalAlignment" Value="Center" />
-                </Style>
+                <Style BasedOn="{StaticResource StatusBarTextStyle}" TargetType="TextBlock" />
             </Grid.Resources>
 
-            <TextBlock Margin="12,0" Text="{x:Bind UpdateStatusBarLabel(ViewModel.SelectedVariant), Mode=OneWay}" />
+            <ContentPresenter Content="{x:Bind StatusBarLeftContent, Mode=OneWay}" />
+
+            <TextBlock
+                Grid.Column="1"
+                Margin="12,0"
+                Text="{x:Bind UpdateStatusBarLabel(ViewModel.SelectedVariant), Mode=OneWay}" />
 
             <TextBlock
                 Grid.Column="2"
-                Margin="12,0"
                 Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
                 Text="{x:Bind ViewModel.GetCharDescription(ViewModel.SelectedChar), Mode=OneWay}" />
 
         </Grid>
 
+        <Rectangle
+            Grid.Row="3"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Height="{StaticResource StatusBarHeight}"
+            VerticalAlignment="Bottom"
+            Canvas.ZIndex="-1"
+            Fill="{x:Bind StatusBar.Background, Mode=OneWay}" />
+
+        <!--  Print Preview Container  -->
         <Border
             x:Name="PrintPresenter"
             x:DeferLoadStrategy="Lazy"
@@ -1059,6 +1085,7 @@
             Grid.ColumnSpan="10"
             Canvas.ZIndex="100" />
 
+        <!--  Off-screen printer render container  -->
         <Canvas x:Name="PrintCanvas" Margin="-10000, -10000, 0, 0" />
 
         <VisualStateManager.VisualStateGroups>
@@ -1085,11 +1112,18 @@
             </VisualStateGroup>
             <VisualStateGroup x:Name="SearchStatesGroup">
                 <VisualState x:Name="InstantSearchState">
+                    <VisualState.StateTriggers>
+                        <StateTrigger IsActive="{x:Bind ViewModel.Settings.UseInstantSearch, Mode=OneWay}" />
+                    </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SearchBox.QueryIcon" Value="{x:Null}" />
                     </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="ManualSearchState" />
+                <VisualState x:Name="ManualSearchState">
+                    <VisualState.StateTriggers>
+                        <StateTrigger IsActive="{x:Bind core:Converters.False(ViewModel.Settings.UseInstantSearch), Mode=OneWay}" />
+                    </VisualState.StateTriggers>
+                </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
     </Grid>

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -40,10 +40,15 @@
                 <RowDefinition Height="{StaticResource TitleRowGridHeight}" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
+                <!--  Left Content  -->
                 <ColumnDefinition Width="Auto" />
+                <!--  Font Name  -->
                 <ColumnDefinition Width="*" />
+                <!--  Font Import Button (Standalone Window)  -->
                 <ColumnDefinition Width="Auto" />
+                <!--  Search Box  -->
                 <ColumnDefinition Width="Auto" />
+                <!--  Right Content  -->
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
@@ -180,10 +185,11 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <StackPanel
+                        <toolkit:WrapPanel
                             x:Name="OptionsPanel"
                             Orientation="Horizontal"
-                            Spacing="12">
+                            HorizontalSpacing="12"
+                            ChildrenTransitions="{StaticResource RepositionTransitions}">
 
                             <ComboBox
                                 x:Name="WeightSelector"
@@ -429,7 +435,7 @@
                                 </Button.Flyout>
                             </Button>
 
-                        </StackPanel>
+                        </toolkit:WrapPanel>
 
                         <Button
                             x:Name="MoreOptionsButton"
@@ -445,7 +451,6 @@
                                 <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
                                     <MenuFlyout.MenuFlyoutPresenterStyle>
                                         <Style TargetType="MenuFlyoutPresenter">
-                                            <Setter Property="RequestedTheme" Value="Default" />
                                             <Setter Property="FontSize" Value="16" />
                                         </Style>
                                     </MenuFlyout.MenuFlyoutPresenterStyle>
@@ -522,18 +527,18 @@
                         IsHitTestVisible="False" />
                 </Grid>
 
-                <!--  Preview Grid  -->
+                <!--  Preview Column  -->
                 <Grid
                     x:Name="PreviewGrid"
                     x:FieldModifier="public"
                     Grid.RowSpan="2"
-                    Grid.Column="2"
-                    SizeChanged="PreviewGrid_SizeChanged">
+                    Grid.Column="2">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
+                    <!--  Character Preview  -->
                     <Grid>
                         <Viewbox
                             Margin="24 12 24 4"
@@ -608,33 +613,22 @@
                         </Border>
                     </Grid>
 
-
-
-                    <Grid Grid.Row="1" Loaded="DetailsGrid_Loaded">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="2" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="2" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
+                    <!--  Character Actions Panel  -->
+                    <StackPanel Grid.Row="1" Loaded="DetailsGrid_Loaded">
 
                         <Rectangle
-                            Height="2"
-                            Margin="15,0"
+                            Height="1"
+                            Margin="0 0 0 1"
                             HorizontalAlignment="Stretch"
                             Fill="{ThemeResource ApplicationForegroundThemeBrush}"
                             Opacity="0.15" />
 
+                        <!--  Copy Button  -->
                         <Button
                             Grid.Row="1"
                             Height="54"
-                            BorderThickness="0 1"
+                            Padding="0 4 0 5"
+                            BorderThickness="1"
                             Click="{x:Bind TryCopyInternal}"
                             Style="{ThemeResource TransparentButton}">
                             <Grid>
@@ -653,54 +647,14 @@
                             </Grid>
                         </Button>
 
-                        <CommandBar
-                            x:Name="SaveAsCommandBar"
-                            Grid.Row="2"
-                            Grid.RowSpan="6"
-                            Height="54"
-                            VerticalAlignment="Top"
-                            Style="{ThemeResource SaveAsPNGCommandBar}">
-                            <CommandBar.SecondaryCommands>
-                                <AppBarButton
-                                    Command="{Binding CommandSavePng}"
-                                    CommandParameter="{x:Bind ViewModel.GlyphColor}"
-                                    Style="{ThemeResource TransparentButton}"
-                                    Visibility="{x:Bind ViewModel.SelectedCharAnalysis.HasColorGlyphs, Mode=OneWay}">
-                                    <AppBarButton.Content>
-                                        <TextBlock x:Uid="ColoredGlyphLabel" Margin="12,10" />
-                                    </AppBarButton.Content>
-                                </AppBarButton>
-                                <AppBarButton
-                                    Background="Transparent"
-                                    Command="{Binding CommandSavePng}"
-                                    CommandParameter="{x:Bind ViewModel.BlackColor}"
-                                    Style="{ThemeResource TransparentButton}"
-                                    Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}">
-                                    <AppBarButton.Content>
-                                        <TextBlock x:Uid="BlackFill" Margin="12,10" />
-                                    </AppBarButton.Content>
-                                </AppBarButton>
-                                <AppBarButton
-                                    VerticalContentAlignment="Stretch"
-                                    Background="Transparent"
-                                    Command="{Binding CommandSavePng}"
-                                    CommandParameter="{x:Bind ViewModel.WhiteColor}"
-                                    Style="{ThemeResource TransparentButton}"
-                                    Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}">
-                                    <AppBarButton.Content>
-                                        <TextBlock x:Uid="WhiteFill" Margin="12,10" />
-                                    </AppBarButton.Content>
-                                </AppBarButton>
-                            </CommandBar.SecondaryCommands>
-                        </CommandBar>
-
+                        <!--  Save As Button  -->
                         <Button
                             Grid.Row="2"
                             Height="54"
-                            Padding="8 4 0 5"
-                            BorderThickness="0 1"
-                            Click="BtnSaveAs_OnClick"
+                            Padding="0 4 0 5"
+                            BorderThickness="1"
                             Style="{StaticResource TransparentButton}">
+                            <Button.Resources />
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="50" />
@@ -710,313 +664,271 @@
 
                                 <FontIcon Foreground="{ThemeResource SystemControlForegroundAccentBrush}" Glyph="&#xEB9F;" />
                                 <TextBlock
-                                    x:Uid="BtnSavePng"
                                     Grid.Column="1"
                                     Margin="0,0,5,0"
                                     VerticalAlignment="Center"
-                                    Text="#BtnSavePng"
+                                    Text="Save As"
                                     TextTrimming="CharacterEllipsis" />
-                                <FontIcon
+                                <!--<FontIcon
                                     Grid.Column="2"
                                     FontSize="13"
-                                    Glyph="&#xE972;" />
+                                    Glyph="" />-->
                             </Grid>
+                            <Button.Flyout>
+                                <MenuFlyout x:Name="SaveAsFlyout" Opened="SaveAsFlyout_Opened" Opening="MenuFlyout_Opening_1" Placement="Top">
+                                    <MenuFlyoutItem Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}" Text="PNG" />
+                                    <MenuFlyoutItem
+                                        Command="{Binding CommandSavePng}"
+                                        CommandParameter="{x:Bind ViewModel.GlyphColor}"
+                                        Style="{StaticResource Mfi}"
+                                        Text="Colored Glyph"
+                                        Visibility="{x:Bind ViewModel.SelectedCharAnalysis.HasColorGlyphs, Mode=OneWay}" />
+                                    <MenuFlyoutItem
+                                        Command="{Binding CommandSavePng}"
+                                        CommandParameter="{x:Bind ViewModel.BlackColor}"
+                                        Style="{StaticResource Mfi}"
+                                        Text="Black"
+                                        Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}" />
+                                    <MenuFlyoutItem
+                                        Command="{Binding CommandSavePng}"
+                                        CommandParameter="{x:Bind ViewModel.WhiteColor}"
+                                        Style="{StaticResource Mfi}"
+                                        Text="White"
+                                        Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}" />
+
+                                    <!--<MenuFlyoutSubItem Style="{StaticResource Mfsi}" Text="PNG Image"></MenuFlyoutSubItem>-->
+
+                                    <MenuFlyoutItem
+                                        Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}"
+                                        Text="SVG"
+                                        Visibility="{x:Bind ViewModel.SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}" />
+                                    <MenuFlyoutItem
+                                        Command="{Binding CommandSaveSvg}"
+                                        CommandParameter="{x:Bind ViewModel.GlyphColor}"
+                                        Style="{StaticResource Mfi}"
+                                        Text="SVG Glyph"
+                                        Visibility="{x:Bind ViewModel.IsSvgChar, Mode=OneWay}" />
+                                    <MenuFlyoutItem
+                                        Command="{Binding CommandSaveSvg}"
+                                        CommandParameter="{x:Bind ViewModel.GlyphColor}"
+                                        Style="{StaticResource Mfi}"
+                                        Text="Colored Glyph"
+                                        Visibility="{x:Bind core:Converters.TrueAndTrueAndFalseToVis(ViewModel.SelectedCharAnalysis.HasColorGlyphs, ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
+                                    <MenuFlyoutItem
+                                        Command="{Binding CommandSaveSvg}"
+                                        CommandParameter="{x:Bind ViewModel.BlackColor}"
+                                        Style="{StaticResource Mfi}"
+                                        Text="Black"
+                                        Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
+                                    <MenuFlyoutItem
+                                        Command="{Binding CommandSaveSvg}"
+                                        CommandParameter="{x:Bind ViewModel.WhiteColor}"
+                                        Style="{StaticResource Mfi}"
+                                        Text="White"
+                                        Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
+                                </MenuFlyout>
+                            </Button.Flyout>
                         </Button>
 
-                        <CommandBar
-                            x:Name="SaveAsSvgCommandBar"
-                            Grid.Row="3"
-                            Grid.RowSpan="6"
-                            Height="54"
-                            VerticalAlignment="Top"
-                            Style="{StaticResource SaveAsPNGCommandBar}">
-                            <CommandBar.SecondaryCommands>
-                                <AppBarButton
-                                    Command="{Binding CommandSaveSvg}"
-                                    CommandParameter="{x:Bind ViewModel.GlyphColor}"
-                                    Style="{ThemeResource TransparentButton}"
-                                    Visibility="{x:Bind ViewModel.SelectedCharAnalysis.HasColorGlyphs, Mode=OneWay}">
-                                    <AppBarButton.Content>
-                                        <TextBlock x:Uid="ColoredGlyphLabel" Margin="12,10" />
-                                    </AppBarButton.Content>
-                                </AppBarButton>
-                                <AppBarButton
-                                    Background="Transparent"
-                                    Command="{Binding CommandSaveSvg}"
-                                    CommandParameter="{x:Bind ViewModel.BlackColor}"
-                                    Style="{ThemeResource TransparentButton}">
-                                    <AppBarButton.Content>
-                                        <TextBlock x:Uid="BlackFill" Margin="12,10" />
-                                    </AppBarButton.Content>
-                                </AppBarButton>
-                                <AppBarButton
-                                    VerticalContentAlignment="Stretch"
-                                    Background="Transparent"
-                                    Command="{Binding CommandSaveSvg}"
-                                    CommandParameter="{x:Bind ViewModel.WhiteColor}"
-                                    Style="{ThemeResource TransparentButton}">
-                                    <AppBarButton.Content>
-                                        <TextBlock x:Uid="WhiteFill" Margin="12,10" />
-                                    </AppBarButton.Content>
-                                </AppBarButton>
-                            </CommandBar.SecondaryCommands>
-                        </CommandBar>
+                        <!--  Dev Utils  -->
+                        <StackPanel Grid.Row="3" Visibility="{x:Bind ViewModel.Settings.ShowDevUtils, Mode=OneWay}">
 
-                        <Button
-                            x:Name="SaveAsSvgButton"
-                            x:Load="{x:Bind core:Converters.False(ViewModel.IsSvgChar), Mode=OneWay, FallbackValue=False}"
-                            Grid.Row="3"
-                            Height="54"
-                            Padding="8 4 0 5"
-                            BorderThickness="0 1"
-                            Click="BtnSaveAsSvg_OnClick"
-                            IsEnabled="{Binding SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}"
-                            Style="{StaticResource TransparentButton}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="50" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="50" />
-                                </Grid.ColumnDefinitions>
-                                <FontIcon Foreground="{ThemeResource SystemControlForegroundAccentBrush}" Glyph="&#xEB9F;" />
-                                <TextBlock
-                                    x:Uid="BtnSaveSvgRaw"
-                                    Grid.Column="1"
-                                    Margin="0,0,5,0"
-                                    VerticalAlignment="Center"
-                                    Text="#BtnSaveSvg"
-                                    TextTrimming="CharacterEllipsis" />
-                                <FontIcon
-                                    Grid.Column="2"
-                                    HorizontalAlignment="Center"
-                                    FontSize="13"
-                                    Glyph="&#xE972;" />
-                            </Grid>
-                        </Button>
+                            <Rectangle
+                                Height="1"
+                                HorizontalAlignment="Stretch"
+                                Fill="{ThemeResource ApplicationForegroundThemeBrush}"
+                                Opacity="0.15" />
 
-                        <Button
-                            x:Name="SaveAsRawSvgButton"
-                            x:Load="{x:Bind ViewModel.IsSvgChar, Mode=OneWay, FallbackValue=False}"
-                            Grid.Row="3"
-                            Height="54"
-                            Padding="8 4 0 5"
-                            BorderThickness="0 1"
-                            Command="{x:Bind ViewModel.CommandSaveSvg}"
-                            CommandParameter="{x:Bind ViewModel.GlyphColor}"
-                            IsEnabled="{Binding SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}"
-                            Style="{StaticResource TransparentButton}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="50" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <FontIcon Foreground="{ThemeResource SystemControlForegroundAccentBrush}" Glyph="&#xEB9F;" />
-                                <TextBlock
-                                    x:Uid="BtnSaveSvgRaw"
-                                    Grid.Column="1"
-                                    Margin="0,0,5,0"
-                                    VerticalAlignment="Center"
-                                    TextTrimming="CharacterEllipsis" />
-                            </Grid>
-                        </Button>
-
-                        <Rectangle
-                            Grid.Row="5"
-                            Height="2"
-                            Margin="15,0"
-                            HorizontalAlignment="Stretch"
-                            Fill="{ThemeResource ApplicationForegroundThemeBrush}"
-                            Opacity="0.15"
-                            Visibility="{x:Bind ViewModel.Settings.ShowDevUtils, Mode=OneWay}" />
-
-
-                        <Grid
-                            Grid.Row="6"
-                            ColumnSpacing="8"
-                            Height="50"
-                            Margin="0,15,0,0"
-                            Visibility="{x:Bind ViewModel.Settings.ShowDevUtils, Mode=OneWay}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="50" />
-                            </Grid.ColumnDefinitions>
-
-                            <TextBox
-                                x:Name="TxtXamlCode"
-                                x:Uid="TxtXamlCode"
-                                GotFocus="OnCopyGotFocus"
-                                Header="#TxtXamlCode"
-                                Style="{StaticResource CopyTextBox}"
-                                Text="{Binding XamlCode}" />
-                            <AppBarButton
-                                x:Name="BtnCopyXamlCode"
-                                x:Uid="BtnCopyDev"
-                                Grid.Column="1"
-                                Width="50"
+                            <Grid
+                                Grid.Row="6"
+                                ColumnSpacing="8"
                                 Height="50"
-                                VerticalAlignment="Bottom"
-                                Click="BtnCopyXamlCode_OnClick">
-                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                            </AppBarButton>
-                        </Grid>
-
-                        <Grid
-                            Grid.Row="7"
-                            ColumnSpacing="8"
-                            Height="50"
-                            Visibility="{x:Bind ViewModel.Settings.ShowDevUtils, Mode=OneWay}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="50" />
-                            </Grid.ColumnDefinitions>
-
-                            <TextBox
-                                x:Name="TxtFontIcon"
-                                x:Uid="TxtFontIcon"
-                                Margin="0 0 0 -8"
-                                GotFocus="OnCopyGotFocus"
-                                Header="#TxtFontIcon"
-                                Style="{StaticResource CopyTextBox}"
-                                Text="{Binding FontIcon}" />
-
-                            <AppBarButton
-                                x:Name="BtnCopyFontIcon"
-                                x:Uid="BtnCopyDev"
-                                Grid.Column="1"
-                                Width="50"
-                                Height="50"
-                                VerticalAlignment="Bottom"
-                                Click="BtnCopyFontIcon_OnClick">
-                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                            </AppBarButton>
-                        </Grid>
-
-                        <Grid
-                            Grid.Row="8"
-                            ColumnSpacing="8"
-                            Height="50">
-
-                            <Grid x:Name="XAMLGeometryDefaultRoot" VerticalAlignment="Stretch">
+                                Margin="0,15,0,0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="50" />
                                 </Grid.ColumnDefinitions>
 
-                                <StackPanel Margin="0 0 0 0">
-                                    <TextBlock
-                                        x:Uid="TxtPathGeometry"
-                                        Margin="14 0 0 0"
-                                        FontSize="12"
-                                        Foreground="{ThemeResource TextControlHeaderForeground}"
-                                        Opacity="0.5" />
-
-                                    <!--
-                                        XAML Path Geometry can easily be too long to display in
-                                        a normal TextBlock and will cause it to fail to render.
-                                        So we switch to Flyout if needed.
-                                    -->
-
-                                    <TextBox
-                                        x:Name="GeometryTextbox"
-                                        x:Load="{x:Bind core:Converters.False(ViewModel.IsLongGeometry), Mode=OneWay}"
-                                        Margin="0 -8 0 0"
-                                        GotFocus="OnCopyGotFocus"
-                                        Style="{StaticResource CopyTextBox}"
-                                        Text="{Binding XamlPathGeom}" />
-
-                                    <Button
-                                        x:Name="BtnXAMLGeometry"
-                                        x:Uid="BtnXAMLGeometry"
-                                        x:Load="{x:Bind ViewModel.IsLongGeometry, Mode=OneWay}"
-                                        Margin="6 0 0 0"
-                                        FontSize="13.333"
-                                        Style="{StaticResource TextBlockButtonStyle}">
-                                        <Button.Flyout>
-                                            <Flyout x:Name="GeometryFlyout" ScrollViewer.VerticalScrollMode="Disabled">
-                                                <Grid>
-                                                    <Grid.RowDefinitions>
-                                                        <RowDefinition Height="Auto" />
-                                                        <RowDefinition Height="Auto" />
-                                                    </Grid.RowDefinitions>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*" />
-                                                        <ColumnDefinition Width="Auto" />
-                                                    </Grid.ColumnDefinitions>
-
-                                                    <TextBlock x:Uid="TxtPathGeometry" VerticalAlignment="Center" />
-
-                                                    <AppBarButton
-                                                        x:Uid="BtnCopyDev"
-                                                        Grid.Column="1"
-                                                        Width="50"
-                                                        Height="50"
-                                                        VerticalAlignment="Bottom"
-                                                        Click="BtnCopyXamlPath_OnClick">
-                                                        <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                                    </AppBarButton>
-
-                                                    <TextBox
-                                                        Grid.Row="1"
-                                                        Grid.ColumnSpan="2"
-                                                        Width="400"
-                                                        MaxHeight="400"
-                                                        FontFamily="Consolas"
-                                                        IsReadOnly="True"
-                                                        ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                                        Text="{x:Bind ViewModel.XamlPathGeom, Mode=OneWay}"
-                                                        TextWrapping="Wrap" />
-
-                                                </Grid>
-                                            </Flyout>
-                                        </Button.Flyout>
-                                    </Button>
-
-                                </StackPanel>
-
-
+                                <TextBox
+                                    x:Name="TxtXamlCode"
+                                    x:Uid="TxtXamlCode"
+                                    GotFocus="OnCopyGotFocus"
+                                    Header="#TxtXamlCode"
+                                    Style="{StaticResource CopyTextBox}"
+                                    Text="{Binding XamlCode}" />
                                 <AppBarButton
+                                    x:Name="BtnCopyXamlCode"
                                     x:Uid="BtnCopyDev"
                                     Grid.Column="1"
                                     Width="50"
                                     Height="50"
                                     VerticalAlignment="Bottom"
-                                    Click="BtnCopyXamlPath_OnClick">
+                                    Click="BtnCopyXamlCode_OnClick">
                                     <FontIcon FontSize="16" Glyph="&#xE16F;" />
                                 </AppBarButton>
-
                             </Grid>
-                        </Grid>
 
-                        <Grid
-                            x:Name="SymbolIconGrid"
-                            x:Load="{x:Bind core:Converters.IsNotNull(ViewModel.SymbolIcon), Mode=OneWay, FallbackValue=False}"
-                            Grid.Row="9"
-                            ColumnSpacing="8"
-                            Height="50">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="50" />
-                            </Grid.ColumnDefinitions>
-                            <TextBox
-                                x:Name="TxtSymbolIcon"
-                                x:Uid="TxtSymbolIcon"
-                                GotFocus="OnCopyGotFocus"
-                                Header="#TxtSymbolIcon"
-                                Style="{StaticResource CopyTextBox}"
-                                Text="{Binding SymbolIcon}" />
-                            <AppBarButton
-                                x:Name="BtnCopySymbolIcon"
-                                x:Uid="BtnCopyDev"
-                                Grid.Column="1"
-                                Width="50"
-                                Height="50"
-                                VerticalAlignment="Bottom"
-                                Click="BtnCopySymbolIcon_OnClick">
-                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                            </AppBarButton>
-                        </Grid>
+                            <Grid
+                                Grid.Row="7"
+                                ColumnSpacing="8"
+                                Height="50">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="50" />
+                                </Grid.ColumnDefinitions>
 
-                    </Grid>
+                                <TextBox
+                                    x:Name="TxtFontIcon"
+                                    x:Uid="TxtFontIcon"
+                                    Margin="0 0 0 -8"
+                                    GotFocus="OnCopyGotFocus"
+                                    Header="#TxtFontIcon"
+                                    Style="{StaticResource CopyTextBox}"
+                                    Text="{Binding FontIcon}" />
+
+                                <AppBarButton
+                                    x:Name="BtnCopyFontIcon"
+                                    x:Uid="BtnCopyDev"
+                                    Grid.Column="1"
+                                    Width="50"
+                                    Height="50"
+                                    VerticalAlignment="Bottom"
+                                    Click="BtnCopyFontIcon_OnClick">
+                                    <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                                </AppBarButton>
+                            </Grid>
+
+                            <Grid
+                                Grid.Row="8"
+                                ColumnSpacing="8"
+                                Height="50">
+
+                                <Grid x:Name="XAMLGeometryDefaultRoot" VerticalAlignment="Stretch">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="50" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <StackPanel Margin="0 0 0 0">
+                                        <TextBlock
+                                            x:Uid="TxtPathGeometry"
+                                            Margin="14 0 0 0"
+                                            FontSize="12"
+                                            Foreground="{ThemeResource TextControlHeaderForeground}"
+                                            Opacity="0.5" />
+
+                                        <!--
+                                            XAML Path Geometry can easily be too long to display in
+                                            a normal TextBlock and will cause it to fail to render.
+                                            So we switch to Flyout if needed.
+                                        -->
+
+                                        <TextBox
+                                            x:Name="GeometryTextbox"
+                                            x:Load="{x:Bind core:Converters.False(ViewModel.IsLongGeometry), Mode=OneWay}"
+                                            Margin="0 -8 0 0"
+                                            GotFocus="OnCopyGotFocus"
+                                            Style="{StaticResource CopyTextBox}"
+                                            Text="{Binding XamlPathGeom}" />
+
+                                        <Button
+                                            x:Name="BtnXAMLGeometry"
+                                            x:Uid="BtnXAMLGeometry"
+                                            x:Load="{x:Bind ViewModel.IsLongGeometry, Mode=OneWay}"
+                                            Margin="6 0 0 0"
+                                            FontSize="13.333"
+                                            Style="{StaticResource TextBlockButtonStyle}">
+                                            <Button.Flyout>
+                                                <Flyout x:Name="GeometryFlyout" ScrollViewer.VerticalScrollMode="Disabled">
+                                                    <Grid>
+                                                        <Grid.RowDefinitions>
+                                                            <RowDefinition Height="Auto" />
+                                                            <RowDefinition Height="Auto" />
+                                                        </Grid.RowDefinitions>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                        </Grid.ColumnDefinitions>
+
+                                                        <TextBlock x:Uid="TxtPathGeometry" VerticalAlignment="Center" />
+
+                                                        <AppBarButton
+                                                            x:Uid="BtnCopyDev"
+                                                            Grid.Column="1"
+                                                            Width="50"
+                                                            Height="50"
+                                                            VerticalAlignment="Bottom"
+                                                            Click="BtnCopyXamlPath_OnClick">
+                                                            <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                                                        </AppBarButton>
+
+                                                        <TextBox
+                                                            Grid.Row="1"
+                                                            Grid.ColumnSpan="2"
+                                                            Width="400"
+                                                            MaxHeight="400"
+                                                            FontFamily="Consolas"
+                                                            IsReadOnly="True"
+                                                            ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                                            Text="{x:Bind ViewModel.XamlPathGeom, Mode=OneWay}"
+                                                            TextWrapping="Wrap" />
+
+                                                    </Grid>
+                                                </Flyout>
+                                            </Button.Flyout>
+                                        </Button>
+
+                                    </StackPanel>
+
+
+                                    <AppBarButton
+                                        x:Uid="BtnCopyDev"
+                                        Grid.Column="1"
+                                        Width="50"
+                                        Height="50"
+                                        VerticalAlignment="Bottom"
+                                        Click="BtnCopyXamlPath_OnClick">
+                                        <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                                    </AppBarButton>
+
+                                </Grid>
+                            </Grid>
+
+                            <Border x:Name="SymbolIconContainer" Grid.Row="9">
+                                <Grid
+                                    x:Name="SymbolIconGrid"
+                                    x:Load="{x:Bind core:Converters.IsNotNull(ViewModel.SymbolIcon), Mode=OneWay, FallbackValue=False}"
+                                    ColumnSpacing="8"
+                                    Height="50">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="50" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox
+                                        x:Name="TxtSymbolIcon"
+                                        x:Uid="TxtSymbolIcon"
+                                        GotFocus="OnCopyGotFocus"
+                                        Header="#TxtSymbolIcon"
+                                        Style="{StaticResource CopyTextBox}"
+                                        Text="{Binding SymbolIcon}" />
+                                    <AppBarButton
+                                        x:Name="BtnCopySymbolIcon"
+                                        x:Uid="BtnCopyDev"
+                                        Grid.Column="1"
+                                        Width="50"
+                                        Height="50"
+                                        VerticalAlignment="Bottom"
+                                        Click="BtnCopySymbolIcon_OnClick">
+                                        <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                                    </AppBarButton>
+                                </Grid>
+
+                            </Border>
+
+                        </StackPanel>
+
+                    </StackPanel>
+
                 </Grid>
             </Grid>
         </Grid>
@@ -1043,7 +955,7 @@
             x:Name="StatusBar"
             Grid.Row="3"
             Height="{StaticResource StatusBarHeight}"
-            Background="{StaticResource AltHostBrush}">
+            Background="{StaticResource StatusBarBrush}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -153,7 +153,7 @@
                 <ColumnDefinition Width="10" />
                 <ColumnDefinition
                     x:Name="PreviewColumn"
-                    Width="328"
+                    Width="326"
                     MinWidth="150" />
             </Grid.ColumnDefinitions>
 
@@ -525,23 +525,24 @@
                 Grid.Column="1">
                 <toolkit:GridSplitter
                     x:Name="Splitter"
-                    Width="10"
+                    Width="12"
                     Background="Transparent"
                     CursorBehavior="ChangeOnSplitterHover"
                     GripperCursor="SizeWestEast"
                     GripperForeground="Transparent"
-                    Loading="GridSplitter_Loading"
                     ParentLevel="1"
                     ResizeBehavior="BasedOnAlignment"
                     ResizeDirection="Columns" />
 
-                <FontIcon
-                    Grid.RowSpan="2"
-                    Grid.Column="1"
-                    Margin="-5,0,0,0"
+                <TextBlock
+                    Margin="3 0 0 0"
                     VerticalAlignment="Center"
-                    Glyph="&#xE784;"
-                    IsHitTestVisible="False" />
+                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                    FontSize="18"
+                    Foreground="{ThemeResource ListViewItemPlaceholderBackgroundThemeBrush}"
+                    IsHitTestVisible="False"
+                    OpticalMarginAlignment="TrimSideBearings"
+                    Text="&#xE784;" />
             </Grid>
 
             <!--  Preview Column  -->
@@ -557,6 +558,11 @@
 
                 <!--  Character Preview  -->
                 <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
                     <Viewbox
                         x:Name="TxtPreviewViewBox"
                         x:FieldModifier="public"
@@ -581,27 +587,30 @@
                             TextAlignment="Center" />
                     </Viewbox>
 
-
+                    <!--  Character Description  -->
                     <StackPanel
+                        x:Name="CharacterInfo"
+                        Grid.Row="1"
+                        Margin="12 0 12 4"
+                        VerticalAlignment="Bottom"
+                        Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
+                        <TextBlock
+                            FontSize="12"
+                            Text="{x:Bind ViewModel.GetCharName(ViewModel.SelectedChar), Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource TextBoxPlaceholderTextThemeBrush}"
+                            Text="{x:Bind ViewModel.GetCharDescription(ViewModel.SelectedChar), Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+
+                    <!--  Copy / Save / Fit Row  -->
+                    <StackPanel
+                        Grid.Row="2"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Bottom"
                         Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
-
-                        <StackPanel
-                            x:Name="CharacterInfo"
-                            Margin="12 0 12 4"
-                            VerticalAlignment="Bottom">
-                            <TextBlock
-                                FontSize="12"
-                                Text="{x:Bind ViewModel.GetCharName(ViewModel.SelectedChar), Mode=OneWay}"
-                                TextWrapping="Wrap" />
-                            <TextBlock
-                                FontSize="12"
-                                Foreground="{ThemeResource TextBoxPlaceholderTextThemeBrush}"
-                                Text="{x:Bind ViewModel.GetCharDescription(ViewModel.SelectedChar), Mode=OneWay}"
-                                TextWrapping="Wrap" />
-                        </StackPanel>
-
 
                         <Rectangle
                             Height="1"
@@ -621,76 +630,75 @@
                                 HorizontalAlignment="Right"
                                 Orientation="Horizontal">
                                 <AppBarButton
+                                    x:Uid="BtnSaveGlyph"
                                     Width="50"
-                                    Height="50"
-                                    Label="Save As">
-                                    <FontIcon Glyph="&#xE105;" />
+                                    Height="50">
+                                    <FontIcon FontSize="18" Glyph="&#xE105;" />
                                     <Button.Flyout>
                                         <MenuFlyout x:Name="SaveAsFlyout" Placement="Top">
-                                            <MenuFlyoutItem Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}" Text="Save as PNG" />
+                                            <MenuFlyoutItem x:Uid="ExportPNGLabel" Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}" />
                                             <MenuFlyoutItem
+                                                x:Uid="ColoredGlyphLabel"
                                                 Command="{Binding CommandSavePng}"
                                                 CommandParameter="{x:Bind ViewModel.GlyphColor}"
                                                 Style="{StaticResource Mfi}"
-                                                Text="Colored Glyph"
                                                 Visibility="{x:Bind ViewModel.SelectedCharAnalysis.HasColorGlyphs, Mode=OneWay}" />
                                             <MenuFlyoutItem
+                                                x:Uid="BlackFill"
                                                 Command="{Binding CommandSavePng}"
                                                 CommandParameter="{x:Bind ViewModel.BlackColor}"
                                                 Style="{StaticResource Mfi}"
-                                                Text="Black"
                                                 Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}" />
                                             <MenuFlyoutItem
+                                                x:Uid="WhiteFill"
                                                 Command="{Binding CommandSavePng}"
                                                 CommandParameter="{x:Bind ViewModel.WhiteColor}"
                                                 Style="{StaticResource Mfi}"
-                                                Text="White"
                                                 Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}" />
 
-                                            <!--<MenuFlyoutSubItem Style="{StaticResource Mfsi}" Text="PNG Image"></MenuFlyoutSubItem>-->
-
                                             <MenuFlyoutItem
+                                                x:Uid="ExportSVGLabel"
                                                 Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}"
-                                                Text="Save as SVG"
                                                 Visibility="{x:Bind ViewModel.SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}" />
                                             <MenuFlyoutItem
+                                                x:Uid="ExportSVGGlyphLabel"
                                                 Command="{Binding CommandSaveSvg}"
                                                 CommandParameter="{x:Bind ViewModel.GlyphColor}"
                                                 Style="{StaticResource Mfi}"
-                                                Text="SVG Glyph"
                                                 Visibility="{x:Bind ViewModel.IsSvgChar, Mode=OneWay}" />
                                             <MenuFlyoutItem
+                                                x:Uid="ColoredGlyphLabel"
                                                 Command="{Binding CommandSaveSvg}"
                                                 CommandParameter="{x:Bind ViewModel.GlyphColor}"
                                                 Style="{StaticResource Mfi}"
-                                                Text="Colored Glyph"
                                                 Visibility="{x:Bind core:Converters.TrueAndTrueAndFalseToVis(ViewModel.SelectedCharAnalysis.HasColorGlyphs, ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
                                             <MenuFlyoutItem
+                                                x:Uid="BlackFill"
                                                 Command="{Binding CommandSaveSvg}"
                                                 CommandParameter="{x:Bind ViewModel.BlackColor}"
                                                 Style="{StaticResource Mfi}"
-                                                Text="Black"
                                                 Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
                                             <MenuFlyoutItem
+                                                x:Uid="WhiteFill"
                                                 Command="{Binding CommandSaveSvg}"
                                                 CommandParameter="{x:Bind ViewModel.WhiteColor}"
                                                 Style="{StaticResource Mfi}"
-                                                Text="White"
                                                 Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
                                         </MenuFlyout>
                                     </Button.Flyout>
                                 </AppBarButton>
                                 <AppBarButton
+                                    x:Uid="BtnCopyGlyph"
                                     Width="50"
                                     Height="50"
-                                    Click="{x:Bind TryCopyInternal}"
-                                    Label="Copy">
-                                    <FontIcon Glyph="&#xE16F;" />
+                                    Click="{x:Bind TryCopyInternal}">
+                                    <FontIcon FontSize="18" Glyph="&#xE16F;" />
                                 </AppBarButton>
                             </StackPanel>
 
                             <AppBarButton
                                 x:Name="BtnFit"
+                                x:Uid="BtnFit"
                                 Width="50"
                                 Height="50"
                                 HorizontalAlignment="Right"
@@ -712,16 +720,8 @@
                                         Loaded="{x:Bind helpers:Composition.SetStandardFadeInOut}"
                                         Stretch="Uniform"
                                         Visibility="{x:Bind ViewModel.Settings.FitCharacter, Mode=OneTime}" />
-                                    <!--<FontIcon
-
-                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                        FontSize="16"
-                                        Glyph="&#xE9A7;"
-                                        />-->
                                 </Grid>
                             </AppBarButton>
-
-
                         </Grid>
 
                     </StackPanel>
@@ -730,6 +730,7 @@
                         x:Name="BorderCopiedMessage"
                         x:Load="False"
                         Grid.Row="0"
+                        Grid.RowSpan="3"
                         Margin="12 12 12 60"
                         Padding="12"
                         VerticalAlignment="Bottom"
@@ -751,207 +752,206 @@
                     </Border>
                 </Grid>
 
-                <!--  Character Actions Panel  -->
-                <StackPanel Grid.Row="2" Loaded="DetailsGrid_Loaded">
+                <!--  Dev Utils  -->
+                <StackPanel
+                    Grid.Row="1"
+                    Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
+                    Visibility="{x:Bind ViewModel.Settings.ShowDevUtils, Mode=OneWay}">
 
-                    <!--  Dev Utils  -->
-                    <StackPanel Grid.Row="3" Visibility="{x:Bind ViewModel.Settings.ShowDevUtils, Mode=OneWay}">
+                    <Rectangle
+                        Height="1"
+                        HorizontalAlignment="Stretch"
+                        Fill="{ThemeResource ApplicationForegroundThemeBrush}"
+                        Opacity="0.15" />
 
-                        <Rectangle
-                            Height="1"
-                            HorizontalAlignment="Stretch"
-                            Fill="{ThemeResource ApplicationForegroundThemeBrush}"
-                            Opacity="0.15" />
+                    <Grid
+                        Grid.Row="6"
+                        ColumnSpacing="8"
+                        Height="50"
+                        Margin="0,15,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="50" />
+                        </Grid.ColumnDefinitions>
 
-                        <Grid
-                            Grid.Row="6"
-                            ColumnSpacing="8"
+                        <TextBox
+                            x:Name="TxtXamlCode"
+                            x:Uid="TxtXamlCode"
+                            GotFocus="OnCopyGotFocus"
+                            Header="#TxtXamlCode"
+                            Style="{StaticResource CopyTextBox}"
+                            Text="{Binding XamlCode}" />
+                        <AppBarButton
+                            x:Name="BtnCopyXamlCode"
+                            x:Uid="BtnCopyDev"
+                            Grid.Column="1"
+                            Width="50"
                             Height="50"
-                            Margin="0,15,0,0">
+                            VerticalAlignment="Bottom"
+                            Click="BtnCopyXamlCode_OnClick">
+                            <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                        </AppBarButton>
+                    </Grid>
+
+                    <Grid
+                        Grid.Row="7"
+                        ColumnSpacing="8"
+                        Height="50">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="50" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBox
+                            x:Name="TxtFontIcon"
+                            x:Uid="TxtFontIcon"
+                            Margin="0 0 0 -8"
+                            GotFocus="OnCopyGotFocus"
+                            Header="#TxtFontIcon"
+                            Style="{StaticResource CopyTextBox}"
+                            Text="{Binding FontIcon}" />
+
+                        <AppBarButton
+                            x:Name="BtnCopyFontIcon"
+                            x:Uid="BtnCopyDev"
+                            Grid.Column="1"
+                            Width="50"
+                            Height="50"
+                            VerticalAlignment="Bottom"
+                            Click="BtnCopyFontIcon_OnClick">
+                            <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                        </AppBarButton>
+                    </Grid>
+
+                    <Grid
+                        Grid.Row="8"
+                        ColumnSpacing="8"
+                        Height="50">
+
+                        <Grid x:Name="XAMLGeometryDefaultRoot" VerticalAlignment="Stretch">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="50" />
                             </Grid.ColumnDefinitions>
 
-                            <TextBox
-                                x:Name="TxtXamlCode"
-                                x:Uid="TxtXamlCode"
-                                GotFocus="OnCopyGotFocus"
-                                Header="#TxtXamlCode"
-                                Style="{StaticResource CopyTextBox}"
-                                Text="{Binding XamlCode}" />
-                            <AppBarButton
-                                x:Name="BtnCopyXamlCode"
-                                x:Uid="BtnCopyDev"
-                                Grid.Column="1"
-                                Width="50"
-                                Height="50"
-                                VerticalAlignment="Bottom"
-                                Click="BtnCopyXamlCode_OnClick">
-                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                            </AppBarButton>
-                        </Grid>
+                            <StackPanel Margin="0 0 0 0">
+                                <TextBlock
+                                    x:Uid="TxtPathGeometry"
+                                    Margin="14 0 0 0"
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextControlHeaderForeground}"
+                                    Opacity="0.5" />
 
-                        <Grid
-                            Grid.Row="7"
-                            ColumnSpacing="8"
-                            Height="50">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="50" />
-                            </Grid.ColumnDefinitions>
+                                <!--
+                                    XAML Path Geometry can easily be too long to display in
+                                    a normal TextBlock and will cause it to fail to render.
+                                    So we switch to Flyout if needed.
+                                -->
 
-                            <TextBox
-                                x:Name="TxtFontIcon"
-                                x:Uid="TxtFontIcon"
-                                Margin="0 0 0 -8"
-                                GotFocus="OnCopyGotFocus"
-                                Header="#TxtFontIcon"
-                                Style="{StaticResource CopyTextBox}"
-                                Text="{Binding FontIcon}" />
-
-                            <AppBarButton
-                                x:Name="BtnCopyFontIcon"
-                                x:Uid="BtnCopyDev"
-                                Grid.Column="1"
-                                Width="50"
-                                Height="50"
-                                VerticalAlignment="Bottom"
-                                Click="BtnCopyFontIcon_OnClick">
-                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                            </AppBarButton>
-                        </Grid>
-
-                        <Grid
-                            Grid.Row="8"
-                            ColumnSpacing="8"
-                            Height="50">
-
-                            <Grid x:Name="XAMLGeometryDefaultRoot" VerticalAlignment="Stretch">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="50" />
-                                </Grid.ColumnDefinitions>
-
-                                <StackPanel Margin="0 0 0 0">
-                                    <TextBlock
-                                        x:Uid="TxtPathGeometry"
-                                        Margin="14 0 0 0"
-                                        FontSize="12"
-                                        Foreground="{ThemeResource TextControlHeaderForeground}"
-                                        Opacity="0.5" />
-
-                                    <!--
-                                        XAML Path Geometry can easily be too long to display in
-                                        a normal TextBlock and will cause it to fail to render.
-                                        So we switch to Flyout if needed.
-                                    -->
-
-                                    <TextBox
-                                        x:Name="GeometryTextbox"
-                                        x:Load="{x:Bind core:Converters.False(ViewModel.IsLongGeometry), Mode=OneWay}"
-                                        Margin="0 -8 0 0"
-                                        GotFocus="OnCopyGotFocus"
-                                        Style="{StaticResource CopyTextBox}"
-                                        Text="{Binding XamlPathGeom}" />
-
-                                    <Button
-                                        x:Name="BtnXAMLGeometry"
-                                        x:Uid="BtnXAMLGeometry"
-                                        x:Load="{x:Bind ViewModel.IsLongGeometry, Mode=OneWay}"
-                                        Margin="6 0 0 0"
-                                        FontSize="13.333"
-                                        Style="{StaticResource TextBlockButtonStyle}">
-                                        <Button.Flyout>
-                                            <Flyout x:Name="GeometryFlyout" ScrollViewer.VerticalScrollMode="Disabled">
-                                                <Grid>
-                                                    <Grid.RowDefinitions>
-                                                        <RowDefinition Height="Auto" />
-                                                        <RowDefinition Height="Auto" />
-                                                    </Grid.RowDefinitions>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*" />
-                                                        <ColumnDefinition Width="Auto" />
-                                                    </Grid.ColumnDefinitions>
-
-                                                    <TextBlock x:Uid="TxtPathGeometry" VerticalAlignment="Center" />
-
-                                                    <AppBarButton
-                                                        x:Uid="BtnCopyDev"
-                                                        Grid.Column="1"
-                                                        Width="50"
-                                                        Height="50"
-                                                        VerticalAlignment="Bottom"
-                                                        Click="BtnCopyXamlPath_OnClick">
-                                                        <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                                    </AppBarButton>
-
-                                                    <TextBox
-                                                        Grid.Row="1"
-                                                        Grid.ColumnSpan="2"
-                                                        Width="400"
-                                                        MaxHeight="400"
-                                                        FontFamily="Consolas"
-                                                        IsReadOnly="True"
-                                                        ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                                        Text="{x:Bind ViewModel.XamlPathGeom, Mode=OneWay}"
-                                                        TextWrapping="Wrap" />
-
-                                                </Grid>
-                                            </Flyout>
-                                        </Button.Flyout>
-                                    </Button>
-
-                                </StackPanel>
-
-
-                                <AppBarButton
-                                    x:Uid="BtnCopyDev"
-                                    Grid.Column="1"
-                                    Width="50"
-                                    Height="50"
-                                    VerticalAlignment="Bottom"
-                                    Click="BtnCopyXamlPath_OnClick">
-                                    <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                </AppBarButton>
-
-                            </Grid>
-                        </Grid>
-
-                        <Border x:Name="SymbolIconContainer" Grid.Row="9">
-                            <Grid
-                                x:Name="SymbolIconGrid"
-                                x:Load="{x:Bind core:Converters.IsNotNull(ViewModel.SymbolIcon), Mode=OneWay, FallbackValue=False}"
-                                ColumnSpacing="8"
-                                Height="50">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="50" />
-                                </Grid.ColumnDefinitions>
                                 <TextBox
-                                    x:Name="TxtSymbolIcon"
-                                    x:Uid="TxtSymbolIcon"
+                                    x:Name="GeometryTextbox"
+                                    x:Load="{x:Bind core:Converters.False(ViewModel.IsLongGeometry), Mode=OneWay}"
+                                    Margin="0 -8 0 0"
                                     GotFocus="OnCopyGotFocus"
-                                    Header="#TxtSymbolIcon"
                                     Style="{StaticResource CopyTextBox}"
-                                    Text="{Binding SymbolIcon}" />
-                                <AppBarButton
-                                    x:Name="BtnCopySymbolIcon"
-                                    x:Uid="BtnCopyDev"
-                                    Grid.Column="1"
-                                    Width="50"
-                                    Height="50"
-                                    VerticalAlignment="Bottom"
-                                    Click="BtnCopySymbolIcon_OnClick">
-                                    <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                </AppBarButton>
-                            </Grid>
+                                    Text="{Binding XamlPathGeom}" />
 
-                        </Border>
+                                <Button
+                                    x:Name="BtnXAMLGeometry"
+                                    x:Uid="BtnXAMLGeometry"
+                                    x:Load="{x:Bind ViewModel.IsLongGeometry, Mode=OneWay}"
+                                    Margin="6 0 0 0"
+                                    FontSize="13.333"
+                                    Style="{StaticResource TextBlockButtonStyle}">
+                                    <Button.Flyout>
+                                        <Flyout x:Name="GeometryFlyout" ScrollViewer.VerticalScrollMode="Disabled">
+                                            <Grid>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
 
-                    </StackPanel>
+                                                <TextBlock x:Uid="TxtPathGeometry" VerticalAlignment="Center" />
+
+                                                <AppBarButton
+                                                    x:Uid="BtnCopyDev"
+                                                    Grid.Column="1"
+                                                    Width="50"
+                                                    Height="50"
+                                                    VerticalAlignment="Bottom"
+                                                    Click="BtnCopyXamlPath_OnClick">
+                                                    <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                                                </AppBarButton>
+
+                                                <TextBox
+                                                    Grid.Row="1"
+                                                    Grid.ColumnSpan="2"
+                                                    Width="400"
+                                                    MaxHeight="400"
+                                                    FontFamily="Consolas"
+                                                    IsReadOnly="True"
+                                                    ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                                    Text="{x:Bind ViewModel.XamlPathGeom, Mode=OneWay}"
+                                                    TextWrapping="Wrap" />
+
+                                            </Grid>
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+
+                            </StackPanel>
+
+
+                            <AppBarButton
+                                x:Uid="BtnCopyDev"
+                                Grid.Column="1"
+                                Width="50"
+                                Height="50"
+                                VerticalAlignment="Bottom"
+                                Click="BtnCopyXamlPath_OnClick">
+                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                            </AppBarButton>
+
+                        </Grid>
+                    </Grid>
+
+                    <Border x:Name="SymbolIconContainer" Grid.Row="9">
+                        <Grid
+                            x:Name="SymbolIconGrid"
+                            x:Load="{x:Bind core:Converters.IsNotNull(ViewModel.SymbolIcon), Mode=OneWay, FallbackValue=False}"
+                            ColumnSpacing="8"
+                            Height="50">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="50" />
+                            </Grid.ColumnDefinitions>
+                            <TextBox
+                                x:Name="TxtSymbolIcon"
+                                x:Uid="TxtSymbolIcon"
+                                GotFocus="OnCopyGotFocus"
+                                Header="#TxtSymbolIcon"
+                                Style="{StaticResource CopyTextBox}"
+                                Text="{Binding SymbolIcon}" />
+                            <AppBarButton
+                                x:Name="BtnCopySymbolIcon"
+                                x:Uid="BtnCopyDev"
+                                Grid.Column="1"
+                                Width="50"
+                                Height="50"
+                                VerticalAlignment="Bottom"
+                                Click="BtnCopySymbolIcon_OnClick">
+                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                            </AppBarButton>
+                        </Grid>
+
+                    </Border>
 
                 </StackPanel>
+
 
             </Grid>
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -11,6 +11,7 @@
     xmlns:views="using:CharacterMap.Views"
     d:DesignHeight="800"
     d:DesignWidth="1280"
+    BorderThickness="0"
     SizeChanged="UserControl_SizeChanged"
     mc:Ignorable="d">
 
@@ -22,7 +23,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="{StaticResource TitleRowGridHeight}" />
             <RowDefinition Height="*" />
-            <RowDefinition Height="{StaticResource StatusBarGridHeight}" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <controls:XamlTitleBar
@@ -147,790 +148,813 @@
                 </Storyboard>
             </Grid.Resources>
 
-            <!--  Char Grid  Background="#141414"  -->
-            <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" MinWidth="250" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition
+                    x:Name="PreviewColumn"
+                    Width="328"
+                    MinWidth="150" />
+            </Grid.ColumnDefinitions>
 
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" MinWidth="250" />
-                    <ColumnDefinition Width="10" />
-                    <ColumnDefinition
-                        x:Name="PreviewColumn"
-                        Width="328"
-                        MinWidth="125" />
-                </Grid.ColumnDefinitions>
+            <Rectangle
+                x:Name="ShadowTarget"
+                Grid.RowSpan="2"
+                Grid.ColumnSpan="3"
+                Fill="Transparent"
+                Stretch="UniformToFill"
+                StrokeThickness="0" />
 
-                <Rectangle
-                    x:Name="ShadowTarget"
-                    Grid.RowSpan="2"
-                    Grid.ColumnSpan="3"
-                    Fill="Transparent"
-                    Stretch="UniformToFill"
-                    StrokeThickness="0" />
+            <!--  Main Column  -->
+            <Grid x:Name="MapContainer" x:FieldModifier="public">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
 
-                <!--  Character Grid  -->
-                <Grid x:Name="MapContainer" x:FieldModifier="public">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
+                <!--  Filters & Controls Panel  -->
+                <Grid
+                    x:Name="CharGridHeader"
+                    x:FieldModifier="public"
+                    ColumnSpacing="12"
+                    Margin="12 0 12 12"
+                    VerticalAlignment="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
 
-                    <Grid
-                        x:Name="CharGridHeader"
+                    <toolkit:WrapPanel
+                        x:Name="OptionsPanel"
                         x:FieldModifier="public"
-                        ColumnSpacing="12"
-                        Margin="12 0 12 12"
-                        VerticalAlignment="Top">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
+                        ChildrenTransitions="{StaticResource RepositionTransitions}"
+                        HorizontalSpacing="12"
+                        Orientation="Horizontal">
 
-                        <toolkit:WrapPanel
-                            x:Name="OptionsPanel"
-                            Orientation="Horizontal"
-                            HorizontalSpacing="12"
-                            ChildrenTransitions="{StaticResource RepositionTransitions}">
-
-                            <ComboBox
-                                x:Name="WeightSelector"
-                                MinWidth="160"
-                                IsEnabled="{Binding SelectedFont.HasVariants}"
-                                ItemsSource="{Binding SelectedFont.Variants}"
-                                SelectedItem="{Binding SelectedVariant, Mode=TwoWay}" />
-
-                            <Button
-                                x:Name="FontPropertiesButton"
-                                x:Uid="FontPropertiesButton"
-                                Height="44"
-                                VerticalAlignment="Bottom"
-                                Style="{ThemeResource TransparentHintButton}">
-                                <FontIcon
-                                    Margin="0,0,-2,0"
-                                    Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
-                                    Glyph="&#xE946;" />
-                                <Button.Flyout>
-                                    <Flyout Opened="InfoFlyout_Opened">
-                                        <StackPanel
-                                            MinWidth="300"
-                                            MaxWidth="400"
-                                            Padding="12"
-                                            Spacing="12">
-                                            <Panel.Resources>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="Opacity" Value="0.5" />
-                                                    <Setter Property="TextWrapping" Value="Wrap" />
-                                                    <Setter Property="VerticalAlignment" Value="Top" />
-                                                </Style>
-                                                <Style x:Key="Value" TargetType="TextBlock">
-                                                    <Setter Property="Opacity" Value="1" />
-                                                    <Setter Property="Grid.Column" Value="1" />
-                                                    <Setter Property="TextWrapping" Value="Wrap" />
-                                                    <Setter Property="VerticalAlignment" Value="Top" />
-                                                </Style>
-                                            </Panel.Resources>
-                                            <TextBlock x:Uid="FontPropTitle" FontWeight="Bold" />
-                                            <Grid RowSpacing="8">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition />
-                                                    <ColumnDefinition />
-                                                </Grid.ColumnDefinitions>
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                    <RowDefinition Height="Auto" />
-                                                </Grid.RowDefinitions>
-
-
-                                                <TextBlock x:Uid="FontPropFamily" Grid.Row="0" />
-                                                <TextBlock
-                                                    Grid.Row="0"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{Binding SelectedFont.Name}" />
-
-                                                <TextBlock x:Uid="FontPropFace" Grid.Row="1" />
-                                                <TextBlock
-                                                    Grid.Row="1"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{Binding SelectedVariant.PreferredName}" />
-
-                                                <TextBlock x:Uid="FontPropCharCount" Grid.Row="2" />
-                                                <TextBlock
-                                                    Grid.Row="2"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{x:Bind ViewModel.SelectedVariant.Characters.Count, Mode=OneWay}" />
-
-                                                <TextBlock x:Uid="FontPropCount" Grid.Row="3" />
-                                                <TextBlock
-                                                    Grid.Row="3"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{x:Bind ViewModel.SelectedVariant.FontFace.GlyphCount, Mode=OneWay}" />
-
-                                                <TextBlock x:Uid="FontPropType" Grid.Row="4" />
-                                                <TextBlock
-                                                    Grid.Row="4"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{Binding SelectedVariant.FontFace.FileFormatType}" />
-
-                                                <TextBlock x:Uid="FontPropSymbol" Grid.Row="5" />
-                                                <TextBlock
-                                                    Grid.Row="5"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{Binding SelectedVariant.FontFace.IsSymbolFont}" />
-
-                                                <TextBlock x:Uid="FontPropMonospaced" Grid.Row="6" />
-                                                <TextBlock
-                                                    Grid.Row="6"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{Binding SelectedVariant.FontFace.IsMonospaced}" />
-
-                                                <TextBlock x:Uid="FontPropStyle" Grid.Row="7" />
-                                                <TextBlock
-                                                    Grid.Row="7"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{Binding SelectedVariant.FontFace.Style}" />
-
-                                                <TextBlock x:Uid="FontPropStretch" Grid.Row="8" />
-                                                <TextBlock
-                                                    Grid.Row="8"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{Binding SelectedVariant.FontFace.Stretch}" />
-
-                                                <TextBlock x:Uid="FontPropWeight" Grid.Row="9" />
-                                                <TextBlock
-                                                    Grid.Row="9"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{x:Bind core:Converters.GetWeightName(ViewModel.SelectedVariant.FontFace.Weight), Mode=OneWay}" />
-
-                                                <TextBlock x:Uid="FontPropInstallType" Grid.Row="10" />
-                                                <TextBlock
-                                                    Grid.Row="10"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{x:Bind ViewModel.SelectedVariant.GetProviderName(), Mode=OneWay}" />
-
-                                                <TextBlock x:Uid="FontPropFileSize" Grid.Row="11" />
-                                                <TextBlock
-                                                    Grid.Row="11"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{x:Bind core:Converters.GetFileSize(ViewModel.SelectedVariantAnalysis.FileSize), Mode=OneWay}" />
-
-                                                <TextBlock
-                                                    x:Name="FontPropXaml"
-                                                    x:Uid="FontPropXaml"
-                                                    Grid.Row="12"
-                                                    Padding="0,4,0,0"
-                                                    Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
-                                                <TextBlock
-                                                    Grid.Row="13"
-                                                    Grid.Column="0"
-                                                    Grid.ColumnSpan="2"
-                                                    Margin="0,-4,0,0"
-                                                    IsTextSelectionEnabled="True"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{x:Bind ViewModel.XamlPath, Mode=OneWay}"
-                                                    Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
-
-                                                <TextBlock
-                                                    x:Uid="FontPropFilePath"
-                                                    Grid.Row="12"
-                                                    Visibility="{x:Bind ShowFilePath(ViewModel.SelectedVariantAnalysis.FilePath, ViewModel.SelectedVariant.IsImported), Mode=OneWay, FallbackValue=Collapsed}" />
-                                                <TextBlock
-                                                    Grid.Row="13"
-                                                    Grid.Column="0"
-                                                    Grid.ColumnSpan="2"
-                                                    Margin="0,-4,0,0"
-                                                    IsTextSelectionEnabled="True"
-                                                    Style="{StaticResource Value}"
-                                                    Text="{x:Bind ViewModel.SelectedVariantAnalysis.FilePath, Mode=OneWay}"
-                                                    Visibility="{x:Bind ShowFilePath(ViewModel.SelectedVariantAnalysis.FilePath, ViewModel.SelectedVariant.IsImported), Mode=OneWay, FallbackValue=Collapsed}" />
-
-                                            </Grid>
-
-                                            <ItemsControl ItemsSource="{Binding SelectedVariant.FontInformation}">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <StackPanel Spacing="12" />
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate>
-                                                        <StackPanel Spacing="4">
-                                                            <TextBlock Opacity="0.5" Text="{Binding Key}" />
-                                                            <TextBlock
-                                                                IsTextSelectionEnabled="True"
-                                                                Style="{StaticResource Value}"
-                                                                Text="{Binding Value}" />
-                                                        </StackPanel>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
-
-                                        </StackPanel>
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-
-                            <Button
-                                x:Uid="FontOptionsButton"
-                                Height="44"
-                                VerticalAlignment="Bottom"
-                                IsEnabled="{Binding HasFontOptions}"
-                                Style="{ThemeResource TransparentHintButton}">
-                                <FontIcon
-                                    Margin="0,0,-2,0"
-                                    Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
-                                    Glyph="&#xE890;" />
-                                <Button.Flyout>
-                                    <Flyout Placement="Bottom">
-                                        <ListView
-                                            Width="300"
-                                            Padding="0"
-                                            ItemsSource="{x:Bind ViewModel.SelectedVariant.XamlTypographyFeatures, Mode=OneWay}"
-                                            SelectedItem="{Binding SelectedTypography, Mode=TwoWay}"
-                                            SelectionMode="Single"
-                                            ShowsScrollingPlaceholders="False"
-                                            SingleSelectionFollowsFocus="True">
-                                            <ListView.ItemContainerTransitions>
-                                                <TransitionCollection />
-                                            </ListView.ItemContainerTransitions>
-                                            <ListView.Header>
-                                                <StackPanel Margin="12,4" Spacing="12">
-                                                    <TextBlock
-                                                        x:Name="ColorHeader"
-                                                        x:Uid="FontDisplayHeader"
-                                                        x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
-                                                        FontWeight="Bold"
-                                                        Opacity="0.5" />
-                                                    <ToggleSwitch
-                                                        x:Name="ColorGlyphToggle"
-                                                        x:Uid="ColorGlyphToggle"
-                                                        x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
-                                                        VerticalAlignment="Bottom"
-                                                        IsOn="{Binding ShowColorGlyphs, Mode=TwoWay}" />
-                                                    <TextBlock
-                                                        x:Uid="TypographyVariantsHeader"
-                                                        Margin="0,12,0,0"
-                                                        FontWeight="Bold"
-                                                        Opacity="0.5"
-                                                        Visibility="{x:Bind ViewModel.SelectedVariant.HasXamlTypographyFeatures, Mode=OneWay}" />
-                                                </StackPanel>
-                                            </ListView.Header>
-                                            <ListView.ItemTemplate>
-                                                <DataTemplate x:DataType="core:TypographyFeatureInfo">
-                                                    <TextBlock Text="{x:Bind DisplayName}" />
-                                                </DataTemplate>
-                                            </ListView.ItemTemplate>
-                                        </ListView>
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-
-                        </toolkit:WrapPanel>
+                        <ComboBox
+                            x:Name="WeightSelector"
+                            MinWidth="160"
+                            IsEnabled="{Binding SelectedFont.HasVariants}"
+                            ItemsSource="{Binding SelectedFont.Variants}"
+                            PlaceholderText="{x:Bind UpdateStatusBarLabel(ViewModel.SelectedVariant), Mode=OneWay}"
+                            SelectedItem="{Binding SelectedVariant, Mode=TwoWay}"
+                            Style="{StaticResource VariantComboBoxStyle}" />
 
                         <Button
-                            x:Name="MoreOptionsButton"
-                            x:Uid="BtnMoreIcon"
-                            x:Load="{x:Bind core:Converters.False(ViewModel.IsExternalFile)}"
-                            Grid.Column="1"
-                            Width="44"
-                            Height="44"
-                            VerticalAlignment="Bottom"
-                            DataContext="{x:Bind ViewModel.SelectedFont, Mode=OneWay}"
-                            Style="{ThemeResource TransparentButton}">
-                            <Button.Flyout>
-                                <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
-                                    <MenuFlyout.MenuFlyoutPresenterStyle>
-                                        <Style TargetType="MenuFlyoutPresenter">
-                                            <Setter Property="FontSize" Value="16" />
-                                        </Style>
-                                    </MenuFlyout.MenuFlyoutPresenterStyle>
-                                </MenuFlyout>
-                            </Button.Flyout>
+                            x:Name="FontPropertiesButton"
+                            x:Uid="FontPropertiesButton"
+                            MinHeight="47"
+                            VerticalAlignment="Stretch"
+                            Style="{ThemeResource TransparentHintButton}">
                             <FontIcon
                                 Margin="0,0,-2,0"
                                 Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
-                                Glyph="&#xE10C;" />
+                                Glyph="&#xE946;" />
+                            <Button.Flyout>
+                                <Flyout Opened="InfoFlyout_Opened">
+                                    <StackPanel
+                                        MinWidth="300"
+                                        MaxWidth="400"
+                                        Padding="12"
+                                        Spacing="12">
+                                        <Panel.Resources>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Opacity" Value="0.5" />
+                                                <Setter Property="TextWrapping" Value="Wrap" />
+                                                <Setter Property="VerticalAlignment" Value="Top" />
+                                            </Style>
+                                            <Style x:Key="Value" TargetType="TextBlock">
+                                                <Setter Property="Opacity" Value="1" />
+                                                <Setter Property="Grid.Column" Value="1" />
+                                                <Setter Property="TextWrapping" Value="Wrap" />
+                                                <Setter Property="VerticalAlignment" Value="Top" />
+                                            </Style>
+                                        </Panel.Resources>
+                                        <TextBlock x:Uid="FontPropTitle" FontWeight="Bold" />
+                                        <Grid RowSpacing="8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition />
+                                                <ColumnDefinition />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+
+
+                                            <TextBlock x:Uid="FontPropFamily" Grid.Row="0" />
+                                            <TextBlock
+                                                Grid.Row="0"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedFont.Name}" />
+
+                                            <TextBlock x:Uid="FontPropFace" Grid.Row="1" />
+                                            <TextBlock
+                                                Grid.Row="1"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.PreferredName}" />
+
+                                            <TextBlock x:Uid="FontPropCharCount" Grid.Row="2" />
+                                            <TextBlock
+                                                Grid.Row="2"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind ViewModel.SelectedVariant.Characters.Count, Mode=OneWay}" />
+
+                                            <TextBlock x:Uid="FontPropCount" Grid.Row="3" />
+                                            <TextBlock
+                                                Grid.Row="3"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind ViewModel.SelectedVariant.FontFace.GlyphCount, Mode=OneWay}" />
+
+                                            <TextBlock x:Uid="FontPropType" Grid.Row="4" />
+                                            <TextBlock
+                                                Grid.Row="4"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.FileFormatType}" />
+
+                                            <TextBlock x:Uid="FontPropSymbol" Grid.Row="5" />
+                                            <TextBlock
+                                                Grid.Row="5"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.IsSymbolFont}" />
+
+                                            <TextBlock x:Uid="FontPropMonospaced" Grid.Row="6" />
+                                            <TextBlock
+                                                Grid.Row="6"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.IsMonospaced}" />
+
+                                            <TextBlock x:Uid="FontPropStyle" Grid.Row="7" />
+                                            <TextBlock
+                                                Grid.Row="7"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.Style}" />
+
+                                            <TextBlock x:Uid="FontPropStretch" Grid.Row="8" />
+                                            <TextBlock
+                                                Grid.Row="8"
+                                                Style="{StaticResource Value}"
+                                                Text="{Binding SelectedVariant.FontFace.Stretch}" />
+
+                                            <TextBlock x:Uid="FontPropWeight" Grid.Row="9" />
+                                            <TextBlock
+                                                Grid.Row="9"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind core:Converters.GetWeightName(ViewModel.SelectedVariant.FontFace.Weight), Mode=OneWay}" />
+
+                                            <TextBlock x:Uid="FontPropInstallType" Grid.Row="10" />
+                                            <TextBlock
+                                                Grid.Row="10"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind ViewModel.SelectedVariant.GetProviderName(), Mode=OneWay}" />
+
+                                            <TextBlock x:Uid="FontPropFileSize" Grid.Row="11" />
+                                            <TextBlock
+                                                Grid.Row="11"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind core:Converters.GetFileSize(ViewModel.SelectedVariantAnalysis.FileSize), Mode=OneWay}" />
+
+                                            <TextBlock
+                                                x:Name="FontPropXaml"
+                                                x:Uid="FontPropXaml"
+                                                Grid.Row="12"
+                                                Padding="0,4,0,0"
+                                                Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
+                                            <TextBlock
+                                                Grid.Row="13"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="2"
+                                                Margin="0,-4,0,0"
+                                                IsTextSelectionEnabled="True"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind ViewModel.XamlPath, Mode=OneWay}"
+                                                Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
+
+                                            <TextBlock
+                                                x:Uid="FontPropFilePath"
+                                                Grid.Row="12"
+                                                Visibility="{x:Bind ShowFilePath(ViewModel.SelectedVariantAnalysis.FilePath, ViewModel.SelectedVariant.IsImported), Mode=OneWay, FallbackValue=Collapsed}" />
+                                            <TextBlock
+                                                Grid.Row="13"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="2"
+                                                Margin="0,-4,0,0"
+                                                IsTextSelectionEnabled="True"
+                                                Style="{StaticResource Value}"
+                                                Text="{x:Bind ViewModel.SelectedVariantAnalysis.FilePath, Mode=OneWay}"
+                                                Visibility="{x:Bind ShowFilePath(ViewModel.SelectedVariantAnalysis.FilePath, ViewModel.SelectedVariant.IsImported), Mode=OneWay, FallbackValue=Collapsed}" />
+
+                                        </Grid>
+
+                                        <ItemsControl ItemsSource="{Binding SelectedVariant.FontInformation}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <StackPanel Spacing="12" />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <StackPanel Spacing="4">
+                                                        <TextBlock Opacity="0.5" Text="{Binding Key}" />
+                                                        <TextBlock
+                                                            IsTextSelectionEnabled="True"
+                                                            Style="{StaticResource Value}"
+                                                            Text="{Binding Value}" />
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+
+                                    </StackPanel>
+                                </Flyout>
+                            </Button.Flyout>
                         </Button>
 
-                    </Grid>
-
-                    <controls:CharacterGridView
-                        x:Name="CharGrid"
-                        x:FieldModifier="public"
-                        Grid.Row="1"
-                        Grid.Column="0"
-                        Padding="10 10 6 10"
-                        EnableResizeAnimation="{x:Bind ViewModel.Settings.AllowExpensiveAnimations, Mode=OneTime}"
-                        IsItemClickEnabled="False"
-                        ItemAnnotation="{x:Bind ViewModel.Settings.GlyphAnnotation, Mode=OneTime}"
-                        ItemFontFace="{x:Bind ViewModel.SelectedVariant.FontFace, Mode=OneWay}"
-                        ItemFontFamily="{x:Bind ViewModel.FontFamily, Mode=OneWay}"
-                        ItemTypography="{x:Bind ViewModel.SelectedTypography, Mode=OneWay}"
-                        ItemsSource="{Binding Chars, Mode=OneWay}"
-                        SelectedItem="{Binding SelectedChar, Mode=TwoWay}"
-                        SelectionMode="Single"
-                        ShowColorGlyphs="{x:Bind ViewModel.ShowColorGlyphs, Mode=OneWay}"
-                        ShowsScrollingPlaceholders="False">
-                        <GridView.ItemContainerTransitions>
-                            <TransitionCollection />
-                        </GridView.ItemContainerTransitions>
-                        <GridView.ItemTemplate>
-                            <DataTemplate>
-                                <!--  For performance reasons, all bindings are done in C#  -->
-                                <Grid Padding="4">
-                                    <TextBlock
-                                        Margin="0 -2 0 0"
-                                        Padding="0,0,0,8"
-                                        IsTextScaleFactorEnabled="False"
-                                        TextAlignment="Center" />
-                                    <TextBlock Style="{StaticResource CharItemUnicodeStyle}" />
-                                </Grid>
-                            </DataTemplate>
-                        </GridView.ItemTemplate>
-                    </controls:CharacterGridView>
-                </Grid>
-
-                <!--  Column Grid Splitter  -->
-                <Grid
-                    x:Name="SplitterContainer"
-                    x:FieldModifier="public"
-                    Grid.RowSpan="2"
-                    Grid.Column="1">
-                    <toolkit:GridSplitter
-                        x:Name="Splitter"
-                        Width="10"
-                        Background="Transparent"
-                        CursorBehavior="ChangeOnSplitterHover"
-                        GripperCursor="SizeWestEast"
-                        GripperForeground="Transparent"
-                        Loading="GridSplitter_Loading"
-                        ParentLevel="1"
-                        ResizeBehavior="BasedOnAlignment"
-                        ResizeDirection="Columns" />
-
-                    <FontIcon
-                        Grid.RowSpan="2"
-                        Grid.Column="1"
-                        Margin="-5,0,0,0"
-                        VerticalAlignment="Center"
-                        Glyph="&#xE784;"
-                        IsHitTestVisible="False" />
-                </Grid>
-
-                <!--  Preview Column  -->
-                <Grid
-                    x:Name="PreviewGrid"
-                    x:FieldModifier="public"
-                    Grid.RowSpan="2"
-                    Grid.Column="2">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-
-                    <!--  Character Preview  -->
-                    <Grid>
-                        <Viewbox
-                            Margin="24 12 24 4"
-                            HorizontalAlignment="Stretch"
+                        <Button
+                            x:Uid="FontOptionsButton"
+                            MinHeight="47"
+                            Margin="0 0 -12 0"
                             VerticalAlignment="Stretch"
-                            IsHitTestVisible="False"
-                            Stretch="Uniform"
-                            StretchDirection="Both">
-                            <TextBlock
-                                x:Name="TxtPreview"
+                            IsEnabled="{Binding HasFontOptions}"
+                            Style="{ThemeResource TransparentHintButton}">
+                            <FontIcon
+                                Margin="0,0,-2,0"
+                                Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                                Glyph="&#xE890;" />
+                            <Button.Flyout>
+                                <Flyout Placement="Bottom">
+                                    <ListView
+                                        Width="300"
+                                        Padding="0"
+                                        ItemsSource="{x:Bind ViewModel.SelectedVariant.XamlTypographyFeatures, Mode=OneWay}"
+                                        SelectedItem="{Binding SelectedTypography, Mode=TwoWay}"
+                                        SelectionMode="Single"
+                                        ShowsScrollingPlaceholders="False"
+                                        SingleSelectionFollowsFocus="True">
+                                        <ListView.ItemContainerTransitions>
+                                            <TransitionCollection />
+                                        </ListView.ItemContainerTransitions>
+                                        <ListView.Header>
+                                            <StackPanel Margin="12,4" Spacing="12">
+                                                <TextBlock
+                                                    x:Name="ColorHeader"
+                                                    x:Uid="FontDisplayHeader"
+                                                    x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
+                                                    FontWeight="Bold"
+                                                    Opacity="0.5" />
+                                                <ToggleSwitch
+                                                    x:Name="ColorGlyphToggle"
+                                                    x:Uid="ColorGlyphToggle"
+                                                    x:Load="{x:Bind ViewModel.SelectedVariantAnalysis.ContainsVectorColorGlyphs, Mode=OneWay}"
+                                                    VerticalAlignment="Bottom"
+                                                    IsOn="{Binding ShowColorGlyphs, Mode=TwoWay}" />
+                                                <TextBlock
+                                                    x:Uid="TypographyVariantsHeader"
+                                                    Margin="0,12,0,0"
+                                                    FontWeight="Bold"
+                                                    Opacity="0.5"
+                                                    Visibility="{x:Bind ViewModel.SelectedVariant.HasXamlTypographyFeatures, Mode=OneWay}" />
+                                            </StackPanel>
+                                        </ListView.Header>
+                                        <ListView.ItemTemplate>
+                                            <DataTemplate x:DataType="core:TypographyFeatureInfo">
+                                                <TextBlock Text="{x:Bind DisplayName}" />
+                                            </DataTemplate>
+                                        </ListView.ItemTemplate>
+                                    </ListView>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
+
+                        <!--<TextBlock
+                                Grid.Row="1"
+                                Margin="12 12 0 0"
                                 VerticalAlignment="Center"
-                                FontFamily="{Binding FontFamily}"
-                                FontSize="{x:Bind core:Converters.GetFontSize(ViewModel.Settings.GridSize), Mode=OneTime}"
-                                FontStretch="{Binding SelectedVariant.FontFace.Stretch}"
-                                FontStyle="{Binding SelectedVariant.FontFace.Style}"
-                                FontWeight="{Binding SelectedVariant.FontFace.Weight}"
-                                Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                                IsColorFontEnabled="{Binding ShowColorGlyphs}"
-                                IsTextScaleFactorEnabled="False"
-                                Text="{Binding SelectedChar.Char}"
-                                TextAlignment="Center" />
-                        </Viewbox>
+                                FontSize="12"
+                                Opacity="0.6"
 
-                        <AppBarButton
-                            x:Name="BtnFit"
-                            Width="50"
-                            Height="50"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Bottom"
-                            Click="BtnFit_Click">
-                            <Grid>
-                                <FontIcon
-                                    x:Name="ZoomGlyph"
-                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                    FontSize="16"
-                                    Glyph="&#xE73F;"
-                                    Loaded="{x:Bind helpers:Composition.SetStandardFadeInOut}"
-                                    Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.Settings.FitCharacter), Mode=OneTime}" />
-                                <FontIcon
-                                    x:Name="ZoomOutGlyph"
-                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                    FontSize="16"
-                                    Glyph="&#xE740;"
-                                    Loaded="{x:Bind helpers:Composition.SetStandardFadeInOut}"
-                                    Visibility="{x:Bind ViewModel.Settings.FitCharacter, Mode=OneTime}" />
-                            </Grid>
-                        </AppBarButton>
+                                Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.Settings.UseStatusBar), Mode=OneWay}" />-->
 
-                        <Border
-                            x:Name="BorderCopiedMessage"
-                            x:Load="False"
-                            Grid.Row="0"
-                            Margin="15"
-                            Padding="12"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Bottom"
-                            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
-                            IsHitTestVisible="False"
-                            Opacity="0">
-                            <StackPanel Orientation="Horizontal">
-                                <FontIcon
-                                    FontSize="21"
-                                    Foreground="White"
-                                    Glyph="&#xEC61;" />
+                    </toolkit:WrapPanel>
+
+                    <Button
+                        x:Name="MoreOptionsButton"
+                        x:Uid="BtnMoreIcon"
+                        x:Load="{x:Bind core:Converters.False(ViewModel.IsExternalFile)}"
+                        Grid.Column="1"
+                        Width="44"
+                        Height="44"
+                        VerticalAlignment="Bottom"
+                        DataContext="{x:Bind ViewModel.SelectedFont, Mode=OneWay}"
+                        Style="{ThemeResource TransparentButton}">
+                        <Button.Flyout>
+                            <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
+                                <MenuFlyout.MenuFlyoutPresenterStyle>
+                                    <Style TargetType="MenuFlyoutPresenter">
+                                        <Setter Property="FontSize" Value="16" />
+                                    </Style>
+                                </MenuFlyout.MenuFlyoutPresenterStyle>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                        <FontIcon
+                            Margin="0,0,-2,0"
+                            Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                            Glyph="&#xE10C;" />
+                    </Button>
+
+
+
+                </Grid>
+
+                <!--  The One And Only, The Character Map  -->
+                <controls:CharacterGridView
+                    x:Name="CharGrid"
+                    x:FieldModifier="public"
+                    Grid.Row="2"
+                    Grid.Column="0"
+                    Margin="0"
+                    Padding="10 10 6 10"
+                    EnableResizeAnimation="{x:Bind ViewModel.Settings.AllowExpensiveAnimations, Mode=OneTime}"
+                    IsItemClickEnabled="False"
+                    ItemAnnotation="{x:Bind ViewModel.Settings.GlyphAnnotation, Mode=OneTime}"
+                    ItemFontFace="{x:Bind ViewModel.SelectedVariant.FontFace, Mode=OneWay}"
+                    ItemFontFamily="{x:Bind ViewModel.FontFamily, Mode=OneWay}"
+                    ItemTypography="{x:Bind ViewModel.SelectedTypography, Mode=OneWay}"
+                    ItemsSource="{Binding Chars, Mode=OneWay}"
+                    SelectedItem="{Binding SelectedChar, Mode=TwoWay}"
+                    SelectionMode="Single"
+                    ShowColorGlyphs="{x:Bind ViewModel.ShowColorGlyphs, Mode=OneWay}"
+                    ShowsScrollingPlaceholders="False">
+                    <GridView.ItemContainerTransitions>
+                        <TransitionCollection />
+                    </GridView.ItemContainerTransitions>
+                    <GridView.ItemTemplate>
+                        <DataTemplate>
+                            <!--  For performance reasons, all bindings are done in C#  -->
+                            <Grid Padding="4">
                                 <TextBlock
-                                    x:Name="TxtCopiedMessage"
-                                    x:Uid="TxtCopiedMessage"
-                                    Margin="8,0,0,0"
-                                    Foreground="White"
-                                    Text="#TxtCopiedMessage" />
-                            </StackPanel>
-                        </Border>
-                    </Grid>
+                                    Margin="0 -2 0 0"
+                                    Padding="0,0,0,8"
+                                    IsTextScaleFactorEnabled="False"
+                                    TextAlignment="Center" />
+                                <TextBlock Style="{StaticResource CharItemUnicodeStyle}" />
+                            </Grid>
+                        </DataTemplate>
+                    </GridView.ItemTemplate>
+                </controls:CharacterGridView>
+            </Grid>
 
-                    <!--  Character Actions Panel  -->
-                    <StackPanel Grid.Row="1" Loaded="DetailsGrid_Loaded">
+            <!--  Column Grid Splitter  -->
+            <Grid
+                x:Name="SplitterContainer"
+                x:FieldModifier="public"
+                Grid.RowSpan="2"
+                Grid.Column="1">
+                <toolkit:GridSplitter
+                    x:Name="Splitter"
+                    Width="10"
+                    Background="Transparent"
+                    CursorBehavior="ChangeOnSplitterHover"
+                    GripperCursor="SizeWestEast"
+                    GripperForeground="Transparent"
+                    Loading="GridSplitter_Loading"
+                    ParentLevel="1"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Columns" />
+
+                <FontIcon
+                    Grid.RowSpan="2"
+                    Grid.Column="1"
+                    Margin="-5,0,0,0"
+                    VerticalAlignment="Center"
+                    Glyph="&#xE784;"
+                    IsHitTestVisible="False" />
+            </Grid>
+
+            <!--  Preview Column  -->
+            <Grid
+                x:Name="PreviewGrid"
+                x:FieldModifier="public"
+                Grid.RowSpan="2"
+                Grid.Column="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <!--  Character Preview  -->
+                <Grid>
+                    <Viewbox
+                        x:Name="TxtPreviewViewBox"
+                        x:FieldModifier="public"
+                        Margin="24 12 24 4"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        IsHitTestVisible="False"
+                        Stretch="Uniform"
+                        StretchDirection="Both">
+                        <TextBlock
+                            x:Name="TxtPreview"
+                            VerticalAlignment="Center"
+                            FontFamily="{Binding FontFamily}"
+                            FontSize="{x:Bind core:Converters.GetFontSize(ViewModel.Settings.GridSize), Mode=OneTime}"
+                            FontStretch="{Binding SelectedVariant.FontFace.Stretch}"
+                            FontStyle="{Binding SelectedVariant.FontFace.Style}"
+                            FontWeight="{Binding SelectedVariant.FontFace.Weight}"
+                            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                            IsColorFontEnabled="{Binding ShowColorGlyphs}"
+                            IsTextScaleFactorEnabled="False"
+                            Text="{Binding SelectedChar.Char}"
+                            TextAlignment="Center" />
+                    </Viewbox>
+
+
+                    <StackPanel
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Bottom"
+                        Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
+
+                        <StackPanel
+                            x:Name="CharacterInfo"
+                            Margin="12 0 12 4"
+                            VerticalAlignment="Bottom">
+                            <TextBlock
+                                FontSize="12"
+                                Text="{x:Bind ViewModel.GetCharName(ViewModel.SelectedChar), Mode=OneWay}"
+                                TextWrapping="Wrap" />
+                            <TextBlock
+                                FontSize="12"
+                                Foreground="{ThemeResource TextBoxPlaceholderTextThemeBrush}"
+                                Text="{x:Bind ViewModel.GetCharDescription(ViewModel.SelectedChar), Mode=OneWay}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+
 
                         <Rectangle
                             Height="1"
-                            Margin="0 0 0 1"
                             HorizontalAlignment="Stretch"
                             Fill="{ThemeResource ApplicationForegroundThemeBrush}"
                             Opacity="0.15" />
 
-                        <!--  Copy Button  -->
-                        <Button
-                            Grid.Row="1"
-                            Height="54"
-                            Padding="0 4 0 5"
-                            BorderThickness="1"
-                            Click="{x:Bind TryCopyInternal}"
-                            Style="{ThemeResource TransparentButton}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="50" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
+                        <Grid MinHeight="50">
 
-                                <FontIcon Foreground="{ThemeResource SystemControlForegroundAccentBrush}" Glyph="&#xE16F;" />
-                                <TextBlock
-                                    x:Uid="BtnCopy"
-                                    Grid.Column="1"
-                                    Margin="0,0,5,0"
-                                    Text="#BtnCopy"
-                                    TextTrimming="CharacterEllipsis" />
-                            </Grid>
-                        </Button>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
 
-                        <!--  Save As Button  -->
-                        <Button
-                            Grid.Row="2"
-                            Height="54"
-                            Padding="0 4 0 5"
-                            BorderThickness="1"
-                            Style="{StaticResource TransparentButton}">
-                            <Button.Resources />
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="50" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="50" />
-                                </Grid.ColumnDefinitions>
+                            <StackPanel
+                                Grid.Column="1"
+                                HorizontalAlignment="Right"
+                                Orientation="Horizontal">
+                                <AppBarButton
+                                    Width="50"
+                                    Height="50"
+                                    Label="Save As">
+                                    <FontIcon Glyph="&#xE105;" />
+                                    <Button.Flyout>
+                                        <MenuFlyout x:Name="SaveAsFlyout" Placement="Top">
+                                            <MenuFlyoutItem Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}" Text="Save as PNG" />
+                                            <MenuFlyoutItem
+                                                Command="{Binding CommandSavePng}"
+                                                CommandParameter="{x:Bind ViewModel.GlyphColor}"
+                                                Style="{StaticResource Mfi}"
+                                                Text="Colored Glyph"
+                                                Visibility="{x:Bind ViewModel.SelectedCharAnalysis.HasColorGlyphs, Mode=OneWay}" />
+                                            <MenuFlyoutItem
+                                                Command="{Binding CommandSavePng}"
+                                                CommandParameter="{x:Bind ViewModel.BlackColor}"
+                                                Style="{StaticResource Mfi}"
+                                                Text="Black"
+                                                Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}" />
+                                            <MenuFlyoutItem
+                                                Command="{Binding CommandSavePng}"
+                                                CommandParameter="{x:Bind ViewModel.WhiteColor}"
+                                                Style="{StaticResource Mfi}"
+                                                Text="White"
+                                                Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}" />
 
-                                <FontIcon Foreground="{ThemeResource SystemControlForegroundAccentBrush}" Glyph="&#xEB9F;" />
-                                <TextBlock
-                                    Grid.Column="1"
-                                    Margin="0,0,5,0"
-                                    VerticalAlignment="Center"
-                                    Text="Save As"
-                                    TextTrimming="CharacterEllipsis" />
-                                <!--<FontIcon
-                                    Grid.Column="2"
-                                    FontSize="13"
-                                    Glyph="" />-->
-                            </Grid>
-                            <Button.Flyout>
-                                <MenuFlyout x:Name="SaveAsFlyout" Opened="SaveAsFlyout_Opened" Opening="MenuFlyout_Opening_1" Placement="Top">
-                                    <MenuFlyoutItem Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}" Text="PNG" />
-                                    <MenuFlyoutItem
-                                        Command="{Binding CommandSavePng}"
-                                        CommandParameter="{x:Bind ViewModel.GlyphColor}"
-                                        Style="{StaticResource Mfi}"
-                                        Text="Colored Glyph"
-                                        Visibility="{x:Bind ViewModel.SelectedCharAnalysis.HasColorGlyphs, Mode=OneWay}" />
-                                    <MenuFlyoutItem
-                                        Command="{Binding CommandSavePng}"
-                                        CommandParameter="{x:Bind ViewModel.BlackColor}"
-                                        Style="{StaticResource Mfi}"
-                                        Text="Black"
-                                        Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}" />
-                                    <MenuFlyoutItem
-                                        Command="{Binding CommandSavePng}"
-                                        CommandParameter="{x:Bind ViewModel.WhiteColor}"
-                                        Style="{StaticResource Mfi}"
-                                        Text="White"
-                                        Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}" />
+                                            <!--<MenuFlyoutSubItem Style="{StaticResource Mfsi}" Text="PNG Image"></MenuFlyoutSubItem>-->
 
-                                    <!--<MenuFlyoutSubItem Style="{StaticResource Mfsi}" Text="PNG Image"></MenuFlyoutSubItem>-->
+                                            <MenuFlyoutItem
+                                                Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}"
+                                                Text="Save as SVG"
+                                                Visibility="{x:Bind ViewModel.SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}" />
+                                            <MenuFlyoutItem
+                                                Command="{Binding CommandSaveSvg}"
+                                                CommandParameter="{x:Bind ViewModel.GlyphColor}"
+                                                Style="{StaticResource Mfi}"
+                                                Text="SVG Glyph"
+                                                Visibility="{x:Bind ViewModel.IsSvgChar, Mode=OneWay}" />
+                                            <MenuFlyoutItem
+                                                Command="{Binding CommandSaveSvg}"
+                                                CommandParameter="{x:Bind ViewModel.GlyphColor}"
+                                                Style="{StaticResource Mfi}"
+                                                Text="Colored Glyph"
+                                                Visibility="{x:Bind core:Converters.TrueAndTrueAndFalseToVis(ViewModel.SelectedCharAnalysis.HasColorGlyphs, ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
+                                            <MenuFlyoutItem
+                                                Command="{Binding CommandSaveSvg}"
+                                                CommandParameter="{x:Bind ViewModel.BlackColor}"
+                                                Style="{StaticResource Mfi}"
+                                                Text="Black"
+                                                Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
+                                            <MenuFlyoutItem
+                                                Command="{Binding CommandSaveSvg}"
+                                                CommandParameter="{x:Bind ViewModel.WhiteColor}"
+                                                Style="{StaticResource Mfi}"
+                                                Text="White"
+                                                Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
+                                        </MenuFlyout>
+                                    </Button.Flyout>
+                                </AppBarButton>
+                                <AppBarButton
+                                    Width="50"
+                                    Height="50"
+                                    Click="{x:Bind TryCopyInternal}"
+                                    Label="Copy">
+                                    <FontIcon Glyph="&#xE16F;" />
+                                </AppBarButton>
+                            </StackPanel>
 
-                                    <MenuFlyoutItem
-                                        Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}"
-                                        Text="SVG"
-                                        Visibility="{x:Bind ViewModel.SelectedCharAnalysis.IsFullVectorBased, Mode=OneWay}" />
-                                    <MenuFlyoutItem
-                                        Command="{Binding CommandSaveSvg}"
-                                        CommandParameter="{x:Bind ViewModel.GlyphColor}"
-                                        Style="{StaticResource Mfi}"
-                                        Text="SVG Glyph"
-                                        Visibility="{x:Bind ViewModel.IsSvgChar, Mode=OneWay}" />
-                                    <MenuFlyoutItem
-                                        Command="{Binding CommandSaveSvg}"
-                                        CommandParameter="{x:Bind ViewModel.GlyphColor}"
-                                        Style="{StaticResource Mfi}"
-                                        Text="Colored Glyph"
-                                        Visibility="{x:Bind core:Converters.TrueAndTrueAndFalseToVis(ViewModel.SelectedCharAnalysis.HasColorGlyphs, ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
-                                    <MenuFlyoutItem
-                                        Command="{Binding CommandSaveSvg}"
-                                        CommandParameter="{x:Bind ViewModel.BlackColor}"
-                                        Style="{StaticResource Mfi}"
-                                        Text="Black"
-                                        Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
-                                    <MenuFlyoutItem
-                                        Command="{Binding CommandSaveSvg}"
-                                        CommandParameter="{x:Bind ViewModel.WhiteColor}"
-                                        Style="{StaticResource Mfi}"
-                                        Text="White"
-                                        Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}" />
-                                </MenuFlyout>
-                            </Button.Flyout>
-                        </Button>
-
-                        <!--  Dev Utils  -->
-                        <StackPanel Grid.Row="3" Visibility="{x:Bind ViewModel.Settings.ShowDevUtils, Mode=OneWay}">
-
-                            <Rectangle
-                                Height="1"
-                                HorizontalAlignment="Stretch"
-                                Fill="{ThemeResource ApplicationForegroundThemeBrush}"
-                                Opacity="0.15" />
-
-                            <Grid
-                                Grid.Row="6"
-                                ColumnSpacing="8"
+                            <AppBarButton
+                                x:Name="BtnFit"
+                                Width="50"
                                 Height="50"
-                                Margin="0,15,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="50" />
-                                </Grid.ColumnDefinitions>
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Bottom"
+                                Click="BtnFit_Click">
+                                <Grid>
+                                    <FontIcon
+                                        x:Name="ZoomGlyph"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        FontSize="16"
+                                        Glyph="&#xE9A6;"
+                                        Loaded="{x:Bind helpers:Composition.SetStandardFadeInOut}"
+                                        Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.Settings.FitCharacter), Mode=OneTime}" />
+                                    <Path
+                                        x:Name="ZoomOutGlyph"
+                                        Height="12"
+                                        Data="F1 M 0.000000 -105.000000 L 120.000000 -105.000000 L 120.000000 -15.000000 L 0.000000 -15.000000 Z M 112.500000 -22.500000 L 112.500000 -97.500000 L 7.500000 -97.500000 L 7.500000 -22.500000 Z M 32.519531 -55.019531 L 27.480469 -49.980469 L 13.652344 -63.750000 L 27.480469 -77.519531 L 32.519531 -72.480469 L 27.539063 -67.500000 L 52.500000 -67.500000 L 52.500000 -60.000000 L 27.539063 -60.000000 Z M 87.480469 -55.019531 L 92.460938 -60.000000 L 67.500000 -60.000000 L 67.500000 -67.500000 L 92.460938 -67.500000 L 87.480469 -72.480469 L 92.519531 -77.519531 L 106.347656 -63.750000 L 92.519531 -49.980469 Z "
+                                        Fill="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                                        Loaded="{x:Bind helpers:Composition.SetStandardFadeInOut}"
+                                        Stretch="Uniform"
+                                        Visibility="{x:Bind ViewModel.Settings.FitCharacter, Mode=OneTime}" />
+                                    <!--<FontIcon
 
-                                <TextBox
-                                    x:Name="TxtXamlCode"
-                                    x:Uid="TxtXamlCode"
-                                    GotFocus="OnCopyGotFocus"
-                                    Header="#TxtXamlCode"
-                                    Style="{StaticResource CopyTextBox}"
-                                    Text="{Binding XamlCode}" />
-                                <AppBarButton
-                                    x:Name="BtnCopyXamlCode"
-                                    x:Uid="BtnCopyDev"
-                                    Grid.Column="1"
-                                    Width="50"
-                                    Height="50"
-                                    VerticalAlignment="Bottom"
-                                    Click="BtnCopyXamlCode_OnClick">
-                                    <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                </AppBarButton>
-                            </Grid>
-
-                            <Grid
-                                Grid.Row="7"
-                                ColumnSpacing="8"
-                                Height="50">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="50" />
-                                </Grid.ColumnDefinitions>
-
-                                <TextBox
-                                    x:Name="TxtFontIcon"
-                                    x:Uid="TxtFontIcon"
-                                    Margin="0 0 0 -8"
-                                    GotFocus="OnCopyGotFocus"
-                                    Header="#TxtFontIcon"
-                                    Style="{StaticResource CopyTextBox}"
-                                    Text="{Binding FontIcon}" />
-
-                                <AppBarButton
-                                    x:Name="BtnCopyFontIcon"
-                                    x:Uid="BtnCopyDev"
-                                    Grid.Column="1"
-                                    Width="50"
-                                    Height="50"
-                                    VerticalAlignment="Bottom"
-                                    Click="BtnCopyFontIcon_OnClick">
-                                    <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                </AppBarButton>
-                            </Grid>
-
-                            <Grid
-                                Grid.Row="8"
-                                ColumnSpacing="8"
-                                Height="50">
-
-                                <Grid x:Name="XAMLGeometryDefaultRoot" VerticalAlignment="Stretch">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="50" />
-                                    </Grid.ColumnDefinitions>
-
-                                    <StackPanel Margin="0 0 0 0">
-                                        <TextBlock
-                                            x:Uid="TxtPathGeometry"
-                                            Margin="14 0 0 0"
-                                            FontSize="12"
-                                            Foreground="{ThemeResource TextControlHeaderForeground}"
-                                            Opacity="0.5" />
-
-                                        <!--
-                                            XAML Path Geometry can easily be too long to display in
-                                            a normal TextBlock and will cause it to fail to render.
-                                            So we switch to Flyout if needed.
-                                        -->
-
-                                        <TextBox
-                                            x:Name="GeometryTextbox"
-                                            x:Load="{x:Bind core:Converters.False(ViewModel.IsLongGeometry), Mode=OneWay}"
-                                            Margin="0 -8 0 0"
-                                            GotFocus="OnCopyGotFocus"
-                                            Style="{StaticResource CopyTextBox}"
-                                            Text="{Binding XamlPathGeom}" />
-
-                                        <Button
-                                            x:Name="BtnXAMLGeometry"
-                                            x:Uid="BtnXAMLGeometry"
-                                            x:Load="{x:Bind ViewModel.IsLongGeometry, Mode=OneWay}"
-                                            Margin="6 0 0 0"
-                                            FontSize="13.333"
-                                            Style="{StaticResource TextBlockButtonStyle}">
-                                            <Button.Flyout>
-                                                <Flyout x:Name="GeometryFlyout" ScrollViewer.VerticalScrollMode="Disabled">
-                                                    <Grid>
-                                                        <Grid.RowDefinitions>
-                                                            <RowDefinition Height="Auto" />
-                                                            <RowDefinition Height="Auto" />
-                                                        </Grid.RowDefinitions>
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition Width="*" />
-                                                            <ColumnDefinition Width="Auto" />
-                                                        </Grid.ColumnDefinitions>
-
-                                                        <TextBlock x:Uid="TxtPathGeometry" VerticalAlignment="Center" />
-
-                                                        <AppBarButton
-                                                            x:Uid="BtnCopyDev"
-                                                            Grid.Column="1"
-                                                            Width="50"
-                                                            Height="50"
-                                                            VerticalAlignment="Bottom"
-                                                            Click="BtnCopyXamlPath_OnClick">
-                                                            <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                                        </AppBarButton>
-
-                                                        <TextBox
-                                                            Grid.Row="1"
-                                                            Grid.ColumnSpan="2"
-                                                            Width="400"
-                                                            MaxHeight="400"
-                                                            FontFamily="Consolas"
-                                                            IsReadOnly="True"
-                                                            ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                                            Text="{x:Bind ViewModel.XamlPathGeom, Mode=OneWay}"
-                                                            TextWrapping="Wrap" />
-
-                                                    </Grid>
-                                                </Flyout>
-                                            </Button.Flyout>
-                                        </Button>
-
-                                    </StackPanel>
-
-
-                                    <AppBarButton
-                                        x:Uid="BtnCopyDev"
-                                        Grid.Column="1"
-                                        Width="50"
-                                        Height="50"
-                                        VerticalAlignment="Bottom"
-                                        Click="BtnCopyXamlPath_OnClick">
-                                        <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                    </AppBarButton>
-
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        FontSize="16"
+                                        Glyph="&#xE9A7;"
+                                        />-->
                                 </Grid>
-                            </Grid>
+                            </AppBarButton>
 
-                            <Border x:Name="SymbolIconContainer" Grid.Row="9">
-                                <Grid
-                                    x:Name="SymbolIconGrid"
-                                    x:Load="{x:Bind core:Converters.IsNotNull(ViewModel.SymbolIcon), Mode=OneWay, FallbackValue=False}"
-                                    ColumnSpacing="8"
-                                    Height="50">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="50" />
-                                    </Grid.ColumnDefinitions>
-                                    <TextBox
-                                        x:Name="TxtSymbolIcon"
-                                        x:Uid="TxtSymbolIcon"
-                                        GotFocus="OnCopyGotFocus"
-                                        Header="#TxtSymbolIcon"
-                                        Style="{StaticResource CopyTextBox}"
-                                        Text="{Binding SymbolIcon}" />
-                                    <AppBarButton
-                                        x:Name="BtnCopySymbolIcon"
-                                        x:Uid="BtnCopyDev"
-                                        Grid.Column="1"
-                                        Width="50"
-                                        Height="50"
-                                        VerticalAlignment="Bottom"
-                                        Click="BtnCopySymbolIcon_OnClick">
-                                        <FontIcon FontSize="16" Glyph="&#xE16F;" />
-                                    </AppBarButton>
-                                </Grid>
 
-                            </Border>
-
-                        </StackPanel>
+                        </Grid>
 
                     </StackPanel>
 
+                    <Border
+                        x:Name="BorderCopiedMessage"
+                        x:Load="False"
+                        Grid.Row="0"
+                        Margin="12 12 12 60"
+                        Padding="12"
+                        VerticalAlignment="Bottom"
+                        Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+                        IsHitTestVisible="False"
+                        Opacity="0">
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon
+                                FontSize="21"
+                                Foreground="White"
+                                Glyph="&#xEC61;" />
+                            <TextBlock
+                                x:Name="TxtCopiedMessage"
+                                x:Uid="TxtCopiedMessage"
+                                Margin="8,0,0,0"
+                                Foreground="White"
+                                Text="#TxtCopiedMessage" />
+                        </StackPanel>
+                    </Border>
                 </Grid>
+
+                <!--  Character Actions Panel  -->
+                <StackPanel Grid.Row="2" Loaded="DetailsGrid_Loaded">
+
+                    <!--  Dev Utils  -->
+                    <StackPanel Grid.Row="3" Visibility="{x:Bind ViewModel.Settings.ShowDevUtils, Mode=OneWay}">
+
+                        <Rectangle
+                            Height="1"
+                            HorizontalAlignment="Stretch"
+                            Fill="{ThemeResource ApplicationForegroundThemeBrush}"
+                            Opacity="0.15" />
+
+                        <Grid
+                            Grid.Row="6"
+                            ColumnSpacing="8"
+                            Height="50"
+                            Margin="0,15,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="50" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBox
+                                x:Name="TxtXamlCode"
+                                x:Uid="TxtXamlCode"
+                                GotFocus="OnCopyGotFocus"
+                                Header="#TxtXamlCode"
+                                Style="{StaticResource CopyTextBox}"
+                                Text="{Binding XamlCode}" />
+                            <AppBarButton
+                                x:Name="BtnCopyXamlCode"
+                                x:Uid="BtnCopyDev"
+                                Grid.Column="1"
+                                Width="50"
+                                Height="50"
+                                VerticalAlignment="Bottom"
+                                Click="BtnCopyXamlCode_OnClick">
+                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                            </AppBarButton>
+                        </Grid>
+
+                        <Grid
+                            Grid.Row="7"
+                            ColumnSpacing="8"
+                            Height="50">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="50" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBox
+                                x:Name="TxtFontIcon"
+                                x:Uid="TxtFontIcon"
+                                Margin="0 0 0 -8"
+                                GotFocus="OnCopyGotFocus"
+                                Header="#TxtFontIcon"
+                                Style="{StaticResource CopyTextBox}"
+                                Text="{Binding FontIcon}" />
+
+                            <AppBarButton
+                                x:Name="BtnCopyFontIcon"
+                                x:Uid="BtnCopyDev"
+                                Grid.Column="1"
+                                Width="50"
+                                Height="50"
+                                VerticalAlignment="Bottom"
+                                Click="BtnCopyFontIcon_OnClick">
+                                <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                            </AppBarButton>
+                        </Grid>
+
+                        <Grid
+                            Grid.Row="8"
+                            ColumnSpacing="8"
+                            Height="50">
+
+                            <Grid x:Name="XAMLGeometryDefaultRoot" VerticalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="50" />
+                                </Grid.ColumnDefinitions>
+
+                                <StackPanel Margin="0 0 0 0">
+                                    <TextBlock
+                                        x:Uid="TxtPathGeometry"
+                                        Margin="14 0 0 0"
+                                        FontSize="12"
+                                        Foreground="{ThemeResource TextControlHeaderForeground}"
+                                        Opacity="0.5" />
+
+                                    <!--
+                                        XAML Path Geometry can easily be too long to display in
+                                        a normal TextBlock and will cause it to fail to render.
+                                        So we switch to Flyout if needed.
+                                    -->
+
+                                    <TextBox
+                                        x:Name="GeometryTextbox"
+                                        x:Load="{x:Bind core:Converters.False(ViewModel.IsLongGeometry), Mode=OneWay}"
+                                        Margin="0 -8 0 0"
+                                        GotFocus="OnCopyGotFocus"
+                                        Style="{StaticResource CopyTextBox}"
+                                        Text="{Binding XamlPathGeom}" />
+
+                                    <Button
+                                        x:Name="BtnXAMLGeometry"
+                                        x:Uid="BtnXAMLGeometry"
+                                        x:Load="{x:Bind ViewModel.IsLongGeometry, Mode=OneWay}"
+                                        Margin="6 0 0 0"
+                                        FontSize="13.333"
+                                        Style="{StaticResource TextBlockButtonStyle}">
+                                        <Button.Flyout>
+                                            <Flyout x:Name="GeometryFlyout" ScrollViewer.VerticalScrollMode="Disabled">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto" />
+                                                        <RowDefinition Height="Auto" />
+                                                    </Grid.RowDefinitions>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <TextBlock x:Uid="TxtPathGeometry" VerticalAlignment="Center" />
+
+                                                    <AppBarButton
+                                                        x:Uid="BtnCopyDev"
+                                                        Grid.Column="1"
+                                                        Width="50"
+                                                        Height="50"
+                                                        VerticalAlignment="Bottom"
+                                                        Click="BtnCopyXamlPath_OnClick">
+                                                        <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                                                    </AppBarButton>
+
+                                                    <TextBox
+                                                        Grid.Row="1"
+                                                        Grid.ColumnSpan="2"
+                                                        Width="400"
+                                                        MaxHeight="400"
+                                                        FontFamily="Consolas"
+                                                        IsReadOnly="True"
+                                                        ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                                        Text="{x:Bind ViewModel.XamlPathGeom, Mode=OneWay}"
+                                                        TextWrapping="Wrap" />
+
+                                                </Grid>
+                                            </Flyout>
+                                        </Button.Flyout>
+                                    </Button>
+
+                                </StackPanel>
+
+
+                                <AppBarButton
+                                    x:Uid="BtnCopyDev"
+                                    Grid.Column="1"
+                                    Width="50"
+                                    Height="50"
+                                    VerticalAlignment="Bottom"
+                                    Click="BtnCopyXamlPath_OnClick">
+                                    <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                                </AppBarButton>
+
+                            </Grid>
+                        </Grid>
+
+                        <Border x:Name="SymbolIconContainer" Grid.Row="9">
+                            <Grid
+                                x:Name="SymbolIconGrid"
+                                x:Load="{x:Bind core:Converters.IsNotNull(ViewModel.SymbolIcon), Mode=OneWay, FallbackValue=False}"
+                                ColumnSpacing="8"
+                                Height="50">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="50" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox
+                                    x:Name="TxtSymbolIcon"
+                                    x:Uid="TxtSymbolIcon"
+                                    GotFocus="OnCopyGotFocus"
+                                    Header="#TxtSymbolIcon"
+                                    Style="{StaticResource CopyTextBox}"
+                                    Text="{Binding SymbolIcon}" />
+                                <AppBarButton
+                                    x:Name="BtnCopySymbolIcon"
+                                    x:Uid="BtnCopyDev"
+                                    Grid.Column="1"
+                                    Width="50"
+                                    Height="50"
+                                    VerticalAlignment="Bottom"
+                                    Click="BtnCopySymbolIcon_OnClick">
+                                    <FontIcon FontSize="16" Glyph="&#xE16F;" />
+                                </AppBarButton>
+                            </Grid>
+
+                        </Border>
+
+                    </StackPanel>
+
+                </StackPanel>
+
             </Grid>
+
         </Grid>
 
         <!--  Notification Presenter  -->
@@ -949,45 +973,6 @@
             Grid.ColumnSpan="2"
             Width="50"
             Height="50" />
-
-        <!--  Status Bar  -->
-        <Grid
-            x:Name="StatusBar"
-            Grid.Row="3"
-            Height="{StaticResource StatusBarHeight}"
-            Background="{StaticResource StatusBarBrush}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-
-            <Grid.Resources>
-                <Style BasedOn="{StaticResource StatusBarTextStyle}" TargetType="TextBlock" />
-            </Grid.Resources>
-
-            <ContentPresenter Content="{x:Bind StatusBarLeftContent, Mode=OneWay}" />
-
-            <TextBlock
-                Grid.Column="1"
-                Margin="12,0"
-                Text="{x:Bind UpdateStatusBarLabel(ViewModel.SelectedVariant), Mode=OneWay}" />
-
-            <TextBlock
-                Grid.Column="2"
-                Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
-                Text="{x:Bind ViewModel.GetCharDescription(ViewModel.SelectedChar), Mode=OneWay}" />
-
-        </Grid>
-
-        <Rectangle
-            Grid.Row="3"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Height="{StaticResource StatusBarHeight}"
-            VerticalAlignment="Bottom"
-            Canvas.ZIndex="-1"
-            Fill="{x:Bind StatusBar.Background, Mode=OneWay}" />
 
         <!--  Print Preview Container  -->
         <Border

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -25,26 +25,20 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <controls:XamlTitleBar x:Name="TitleBar" x:Load="{x:Bind IsStandalone}">
-            <TextBlock
-                Margin="12,0,0,0"
-                VerticalAlignment="Center"
-                FontSize="12"
-                IsHitTestVisible="False">
-                <Run Text="{Binding TitlePrefix}" />
-                <Run x:Uid="TxtTitle" />
-            </TextBlock>
-        </controls:XamlTitleBar>
+        <controls:XamlTitleBar
+            x:Name="TitleBar"
+            x:Load="{x:Bind IsStandalone}"
+            Canvas.ZIndex="101" />
 
         <Grid
             x:Name="TitleGrid"
             x:Load="{x:Bind IsStandalone}"
-            Grid.Row="1"
-            Height="45"
-            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
-            Canvas.ZIndex="1"
-            Loading="TitleGrid_Loading"
-            RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(ThemeLock), Mode=OneWay}">
+            Grid.RowSpan="2"
+            Canvas.ZIndex="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, FallbackValue=Auto}" />
+                <RowDefinition Height="45" />
+            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
@@ -53,23 +47,23 @@
             </Grid.ColumnDefinitions>
             <TextBlock
                 x:Name="FontTitleBlock"
+                Grid.Row="1"
                 Grid.Column="0"
-                Margin="12,0"
+                Margin="24,0"
                 VerticalAlignment="Center"
                 FontSize="22"
-                FontWeight="SemiLight"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
+                FontWeight="Bold"
                 Text="{Binding SelectedFont.Name}"
                 TextTrimming="CharacterEllipsis"
                 ToolTipService.ToolTip="{Binding SelectedFont.Name}" />
 
             <Button
+                Grid.Row="1"
                 Grid.Column="1"
                 Height="45"
                 Padding="12,0"
                 HorizontalAlignment="Right"
                 Click="{x:Bind ViewModel.ImportFile}"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                 IsEnabled="{Binding ImportButtonEnabled}"
                 Style="{ThemeResource TransparentButton}"
                 Visibility="{x:Bind ViewModel.IsExternalFile}">
@@ -89,6 +83,7 @@
             <AutoSuggestBox
                 x:Name="SearchBox"
                 x:Uid="SearchBox"
+                Grid.Row="1"
                 Grid.Column="2"
                 Width="290"
                 Margin="6 0 6 0"
@@ -135,10 +130,10 @@
 
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" MinWidth="250" />
-                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="10" />
                     <ColumnDefinition
                         x:Name="PreviewColumn"
-                        Width="330"
+                        Width="328"
                         MinWidth="125" />
                 </Grid.ColumnDefinitions>
 
@@ -160,7 +155,7 @@
                         x:Name="CharGridHeader"
                         x:FieldModifier="public"
                         ColumnSpacing="12"
-                        Margin="12"
+                        Margin="12 0 12 12"
                         VerticalAlignment="Top">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
@@ -174,7 +169,6 @@
 
                             <ComboBox
                                 x:Name="WeightSelector"
-                                x:Uid="WeightSelector"
                                 MinWidth="160"
                                 IsEnabled="{Binding SelectedFont.HasVariants}"
                                 ItemsSource="{Binding SelectedFont.Variants}"
@@ -491,8 +485,8 @@
                     Grid.Column="1">
                     <toolkit:GridSplitter
                         x:Name="Splitter"
-                        Width="8"
-                        Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
+                        Width="10"
+                        Background="Transparent"
                         CursorBehavior="ChangeOnSplitterHover"
                         GripperCursor="SizeWestEast"
                         GripperForeground="Transparent"
@@ -504,7 +498,7 @@
                     <FontIcon
                         Grid.RowSpan="2"
                         Grid.Column="1"
-                        Margin="-6,0,0,0"
+                        Margin="-5,0,0,0"
                         VerticalAlignment="Center"
                         Glyph="&#xE784;"
                         IsHitTestVisible="False" />
@@ -1034,7 +1028,7 @@
             Grid.Column="0"
             Grid.ColumnSpan="2"
             Height="26"
-            Background="{ThemeResource SystemControlBackgroundAccentBrush}">
+            Background="{StaticResource AltHostBrush}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
@@ -1048,15 +1042,11 @@
                 </Style>
             </Grid.Resources>
 
-            <TextBlock
-                Margin="12,0"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                Text="{x:Bind UpdateStatusBarLabel(ViewModel.SelectedVariant), Mode=OneWay}" />
+            <TextBlock Margin="12,0" Text="{x:Bind UpdateStatusBarLabel(ViewModel.SelectedVariant), Mode=OneWay}" />
 
             <TextBlock
                 Grid.Column="2"
                 Margin="12,0"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                 Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
                 Text="{x:Bind ViewModel.GetCharDescription(ViewModel.SelectedChar), Mode=OneWay}" />
 
@@ -1065,7 +1055,6 @@
         <Border
             x:Name="PrintPresenter"
             x:DeferLoadStrategy="Lazy"
-            Grid.Row="1"
             Grid.RowSpan="10"
             Grid.ColumnSpan="10"
             Canvas.ZIndex="100" />

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -73,8 +73,6 @@ namespace CharacterMap.Views
 
         public object ThemeLock { get; } = new object();
 
-        private bool _isCtrlKeyPressed = false;
-
         private Debouncer _sizeDebouncer { get; } = new Debouncer();
 
         private XamlDirect _xamlDirect { get; }
@@ -539,6 +537,8 @@ namespace CharacterMap.Views
             return PrintPresenter;
         }
 
+        public GridLength GetTitleBarHeight() => TitleBar.TemplateSettings.GridHeight;
+
         private void TryPrint()
         {
             if (this.GetFirstAncestorOfType<MainPage>() is null)
@@ -630,13 +630,14 @@ namespace CharacterMap.Views
 
         private void TitleGrid_Loading(FrameworkElement sender, object args)
         {
-            Composition.SetThemeShadow(sender, 20, MainUIGrid);
+            //Composition.SetThemeShadow(sender, 20, MainUIGrid);
         }
 
         private void GridSplitter_Loading(FrameworkElement sender, object args)
         {
-            Composition.SetThemeShadow(sender, 20, ShadowTarget);
+            //Composition.SetThemeShadow(sender, 20, ShadowTarget);
         }
+
     }
 
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -35,7 +35,48 @@ namespace CharacterMap.Views
 {
     public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter, IPrintPresenter
     {
-        #region Dependency Properties
+        #region Dependency Properties 
+
+        #region TitleLeftContent
+
+        public object TitleLeftContent
+        {
+            get { return (object)GetValue(TitleLeftContentProperty); }
+            set { SetValue(TitleLeftContentProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for TitleLeftContent.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty TitleLeftContentProperty =
+            DependencyProperty.Register(nameof(TitleLeftContent), typeof(object), typeof(FontMapView), new PropertyMetadata(null));
+
+        #endregion
+
+        #region TitleRightContent
+
+        public object TitleRightContent
+        {
+            get { return (object)GetValue(TitleRightContentProperty); }
+            set { SetValue(TitleRightContentProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for TitleRightContent.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty TitleRightContentProperty =
+            DependencyProperty.Register(nameof(TitleRightContent), typeof(object), typeof(FontMapView), new PropertyMetadata(null));
+
+        #endregion
+
+        #region StatusBarLeftContent
+
+        public object StatusBarLeftContent
+        {
+            get { return (object)GetValue(StatusBarLeftContentProperty); }
+            set { SetValue(StatusBarLeftContentProperty, value); }
+        }
+
+        public static readonly DependencyProperty StatusBarLeftContentProperty =
+            DependencyProperty.Register(nameof(StatusBarLeftContent), typeof(object), typeof(FontMapView), new PropertyMetadata(null));
+
+        #endregion
 
         #region Font
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -65,19 +65,6 @@ namespace CharacterMap.Views
 
         #endregion
 
-        #region StatusBarLeftContent
-
-        public object StatusBarLeftContent
-        {
-            get { return (object)GetValue(StatusBarLeftContentProperty); }
-            set { SetValue(StatusBarLeftContentProperty, value); }
-        }
-
-        public static readonly DependencyProperty StatusBarLeftContentProperty =
-            DependencyProperty.Register(nameof(StatusBarLeftContent), typeof(object), typeof(FontMapView), new PropertyMetadata(null));
-
-        #endregion
-
         #region Font
 
         public InstalledFont Font
@@ -215,7 +202,10 @@ namespace CharacterMap.Views
             else if (e.PropertyName == nameof(ViewModel.SelectedChar))
             {
                 if (ViewModel.Settings.UseSelectionAnimations)
+                {
                     Composition.PlayScaleEntrance(TxtPreview, .85f, 1f);
+                    Composition.PlayEntrance(CharacterInfo.Children.ToList(), 0, 0, 40);
+                }
 
                 UpdateTypography(ViewModel.SelectedTypography);
             }
@@ -224,7 +214,7 @@ namespace CharacterMap.Views
                 CharGrid.ItemsSource = ViewModel.Chars;
 
                 if (ViewModel.Settings.UseSelectionAnimations)
-                    Composition.PlayEntrance(CharGrid);
+                    Composition.PlayEntrance(CharGrid, 166);
             }
         }
 
@@ -241,6 +231,7 @@ namespace CharacterMap.Views
                         CharGrid.ItemAnnotation = ViewModel.Settings.GlyphAnnotation;
                         break;
                     case nameof(AppSettings.DevToolsLanguage):
+                    case nameof(AppSettings.ShowDevUtils):
                         ViewModel.UpdateDevValues();
                         break;
                     case nameof(AppSettings.GridSize):

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -632,44 +632,7 @@ namespace CharacterMap.Views
 
         /* Composition */
 
-        private async void DetailsGrid_Loaded(object sender, RoutedEventArgs e)
-        {
-            // This avoids strange animation on secondary window
-            await Task.Delay(500);
-            if (this.IsLoaded)
-                Composition.SetStandardReposition(sender, e);
-        }
-
-        private void TitleGrid_Loading(FrameworkElement sender, object args)
-        {
-            //Composition.SetThemeShadow(sender, 20, MainUIGrid);
-        }
-
-        private void GridSplitter_Loading(FrameworkElement sender, object args)
-        {
-            //Composition.SetThemeShadow(sender, 20, ShadowTarget);
-        }
-
-        private void MenuFlyout_Opening_1(object sender, object e)
-        {
-            if (sender is MenuFlyout flyout
-                && flyout.GetPresenter() is MenuFlyoutPresenter p)
-            {
-                //flyout.GetPresenter().Width = flyout.Target.ActualWidth;
-                //foreach (var item in flyout.Items)
-                //    item.Width = flyout.Target.ActualWidth;
-            }
-        }
-
-        private void SaveAsFlyout_Opened(object sender, object e)
-        {
-            if (sender is MenuFlyout flyout)
-            {
-                flyout.GetPresenter().Width = flyout.Target.ActualWidth;
-                //foreach (var item in flyout.Items)
-                //    item.Width = flyout.Target.ActualWidth;
-            }
-        }
+        
     }
 
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -396,16 +396,6 @@ namespace CharacterMap.Views
             ViewModel.Settings.FitCharacter = !ViewModel.Settings.FitCharacter;
         }
 
-        private void BtnSaveAs_OnClick(object sender, RoutedEventArgs e)
-        {
-            SaveAsCommandBar.IsOpen = !SaveAsCommandBar.IsOpen;
-        }
-
-        private void BtnSaveAsSvg_OnClick(object sender, RoutedEventArgs e)
-        {
-            SaveAsSvgCommandBar.IsOpen = !SaveAsSvgCommandBar.IsOpen;
-        }
-
         private void OnCopyGotFocus(object sender, RoutedEventArgs e)
         {
             ((TextBox)sender).SelectAll();
@@ -454,16 +444,6 @@ namespace CharacterMap.Views
                     PreviewColumn.Width = new GridLength((int)(this.ActualWidth - CharGrid.ActualWidth - Splitter.ActualWidth));
                 }
             });
-        }
-
-        private void PreviewGrid_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            var newSize = e.NewSize.Width - 2;
-
-            foreach (AppBarButton item in SaveAsCommandBar.SecondaryCommands.Concat(SaveAsSvgCommandBar.SecondaryCommands))
-            {
-                item.Width = newSize;
-            }
         }
 
         private void OnSearchBoxGotFocus(AutoSuggestBox searchBox)
@@ -679,6 +659,26 @@ namespace CharacterMap.Views
             //Composition.SetThemeShadow(sender, 20, ShadowTarget);
         }
 
+        private void MenuFlyout_Opening_1(object sender, object e)
+        {
+            if (sender is MenuFlyout flyout
+                && flyout.GetPresenter() is MenuFlyoutPresenter p)
+            {
+                //flyout.GetPresenter().Width = flyout.Target.ActualWidth;
+                //foreach (var item in flyout.Items)
+                //    item.Width = flyout.Target.ActualWidth;
+            }
+        }
+
+        private void SaveAsFlyout_Opened(object sender, object e)
+        {
+            if (sender is MenuFlyout flyout)
+            {
+                flyout.GetPresenter().Width = flyout.Target.ActualWidth;
+                //foreach (var item in flyout.Items)
+                //    item.Width = flyout.Target.ActualWidth;
+            }
+        }
     }
 
 

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -16,7 +16,7 @@
     <Page.Resources>
         <!--  Ensure both of these are equal  -->
         <x:Double x:Key="SplitViewPaneWidth">256</x:Double>
-        <GridLength x:Key="StatusBarPaneWidth">256</GridLength>
+        <GridLength x:Key="PaneGridWidth">256</GridLength>
 
         <CollectionViewSource
             x:Key="GroupedFontList"
@@ -42,7 +42,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="256" />
+            <ColumnDefinition Width="{StaticResource PaneGridWidth}" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
@@ -80,13 +80,13 @@
 
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
-                        <RowDefinition x:Name="StatusBarRow" Height="26" />
+                        <RowDefinition x:Name="StatusBarRow" Height="{StaticResource StatusBarGridHeight}" />
                     </Grid.RowDefinitions>
 
                     <Grid x:Name="PaneContentRoot">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}" />
-                            <RowDefinition Height="{x:Bind TitleBarRow.Height}" />
+                            <RowDefinition Height="{StaticResource TitleRowGridHeight}" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
@@ -102,8 +102,8 @@
                                 x:Name="OpenFontButton"
                                 x:Uid="OpenFontButton"
                                 Grid.Column="0"
-                                Width="45"
-                                Height="45"
+                                Width="{StaticResource TitleRowHeight}"
+                                Height="{StaticResource TitleRowHeight}"
                                 VerticalAlignment="Bottom"
                                 Click="{x:Bind OpenFont}">
                                 <Path
@@ -118,7 +118,7 @@
                                 x:Name="FontListFilter"
                                 x:Uid="FontListFilter"
                                 Grid.Column="1"
-                                Height="45"
+                                Height="{StaticResource TitleRowHeight}"
                                 Margin="0,0,0,0"
                                 Padding="12,6"
                                 HorizontalAlignment="Stretch"
@@ -207,22 +207,6 @@
                                     </MenuFlyout>
                                 </Button.Flyout>
                             </Button>
-
-                            <!--<AppBarButton
-                                x:Name="ImportFontsButton"
-                                x:Uid="ImportFontsButton"
-                                Grid.Column="1"
-                                Width="45"
-                                Height="45"
-                                VerticalAlignment="Bottom"
-                                Click="{x:Bind PickFonts}"
-                                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                                Visibility="Collapsed">
-                                <FontIcon
-                                    FontSize="16"
-                                    Glyph="&#xE109;"
-                                    Opacity="0.8" />
-                            </AppBarButton>-->
 
                         </Grid>
 
@@ -353,15 +337,10 @@
                     <!--  Pane Status Bar  -->
                     <Grid
                         x:Name="PaneStatusBar"
-                        Grid.Row="3"
-                        Background="{x:Bind StatusBar.Background}">
+                        Grid.Row="1"
+                        Background="{StaticResource AltHostBrush}">
                         <Grid.Resources>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="FontSize" Value="12" />
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="12 0" />
-                                <Setter Property="TextLineBounds" Value="Tight" />
-                            </Style>
+                            <Style BasedOn="{StaticResource StatusBarTextStyle}" TargetType="TextBlock" />
                         </Grid.Resources>
 
                         <Grid.ColumnDefinitions>
@@ -407,78 +386,34 @@
             </SplitView.Pane>
 
             <!--  FontMap Grid  -->
-            <Grid>
+            <Grid x:Name="SplitViewContentRoot" Loading="Grid_Loading">
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}" />
                     <RowDefinition Height="*" />
-                    <RowDefinition Height="{x:Bind StatusBarRow.Height}" />
                 </Grid.RowDefinitions>
 
-                <Grid x:Name="SplitViewContentRoot" Loading="Grid_Loading">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}" />
-                        <RowDefinition x:Name="TitleBarRow" Height="45" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-
-                    <!--  Commands Grid  -->
-                    <Grid x:Name="CommandsGrid" Grid.Row="1">
-
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-
-
+                <!--  Character Map  -->
+                <views:FontMapView
+                    x:Name="FontMap"
+                    Grid.Row="1"
+                    Font="{x:Bind ViewModel.SelectedFont, Mode=OneWay}">
+                    <views:FontMapView.TitleLeftContent>
                         <AppBarButton
                             x:Name="OpenFontPaneButton"
                             Width="45"
                             Height="45"
+                            Margin="0 0 -16 0"
                             Click="OpenFontPaneButton_Click"
                             Visibility="Collapsed">
                             <SymbolIcon Symbol="GlobalNavigationButton" />
                         </AppBarButton>
-
-                        <TextBlock
-                            x:Name="FontTitleBlock"
-                            Grid.Column="1"
-                            Margin="24,0,5,0"
-                            VerticalAlignment="Center"
-                            FontSize="22"
-                            FontWeight="Bold"
-                            Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
-                            Text="{Binding SelectedFont.Name, Mode=OneWay}"
-                            TextTrimming="CharacterEllipsis" />
-
-                        <AutoSuggestBox
-                            x:Name="SearchBox"
-                            x:Uid="SearchBox"
-                            Grid.Column="2"
-                            Width="290"
-                            VerticalAlignment="Center"
-                            GotFocus="{x:Bind FontMap.SearchBox_GotFocus}"
-                            ItemTemplate="{StaticResource SearchResultTemplate}"
-                            ItemsSource="{x:Bind FontMap.ViewModel.SearchResults, Mode=OneWay}"
-                            PlaceholderText="#SearchBox"
-                            PreviewKeyDown="{x:Bind FontMap.SearchBox_PreviewKeyDown}"
-                            QuerySubmitted="{x:Bind FontMap.SearchBox_QuerySubmitted}"
-                            SuggestionChosen="{x:Bind FontMap.SearchBox_SuggestionChosen}"
-                            Tag="{Binding ElementName=FontMap, Path=ViewModel.FontFamily}"
-                            Text="{Binding ElementName=FontMap, Path=ViewModel.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                            TextChanged="{x:Bind FontMap.SearchBox_TextChanged}"
-                            TextMemberPath="Description"
-                            UpdateTextOnSelect="False">
-                            <AutoSuggestBox.QueryIcon>
-                                <SymbolIcon Symbol="Find" />
-                            </AutoSuggestBox.QueryIcon>
-                        </AutoSuggestBox>
-
+                    </views:FontMapView.TitleLeftContent>
+                    <views:FontMapView.TitleRightContent>
                         <AppBarButton
                             x:Name="BtnSettings"
-                            Grid.Column="3"
                             Width="45"
                             Height="45"
+                            Margin="-6 0 0 0"
                             Click="BtnSettings_OnClick">
                             <FontIcon
                                 HorizontalAlignment="Center"
@@ -486,67 +421,28 @@
                                 FontSize="16"
                                 Glyph="&#xE115;" />
                         </AppBarButton>
-                    </Grid>
-
-                    <views:FontMapView
-                        x:Name="FontMap"
-                        Grid.Row="2"
-                        Font="{x:Bind ViewModel.SelectedFont, Mode=OneWay}" />
-
-                </Grid>
-
-                <!--  Status Bar  -->
-                <Grid
-                    x:Name="StatusBar"
-                    Grid.Row="1"
-                    Grid.Column="0"
-                    Background="{StaticResource AltHostBrush}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.Resources>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="FontSize" Value="12" />
-                            <Setter Property="VerticalAlignment" Value="Center" />
-                            <Setter Property="Margin" Value="12 0" />
-                            <Setter Property="TextLineBounds" Value="Tight" />
-                        </Style>
-                    </Grid.Resources>
-                    <AppBarButton
-                        x:Name="ShowPaneButton"
-                        x:Uid="BtnShowPane"
-                        Width="32"
-                        Margin="0 0 -6 0"
-                        VerticalAlignment="Stretch"
-                        Click="TogglePane_Click"
-                        Visibility="Collapsed">
-                        <FontIcon
-                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                            FontSize="16"
-                            Glyph="&#xE126;" />
-                    </AppBarButton>
-
-                    <TextBlock Grid.Column="1" Text="{x:Bind UpdateCharacterCountLabel(FontMap.ViewModel.SelectedVariant), Mode=OneWay}" />
-
-                    <TextBlock
-                        Grid.Column="2"
-                        Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
-                        Text="{x:Bind FontMap.ViewModel.GetCharDescription(FontMap.ViewModel.SelectedChar), Mode=OneWay}" />
-                </Grid>
+                    </views:FontMapView.TitleRightContent>
+                    <views:FontMapView.StatusBarLeftContent>
+                        <AppBarButton
+                            x:Name="ShowPaneButton"
+                            x:Uid="BtnShowPane"
+                            Width="32"
+                            Margin="0 0 -6 0"
+                            VerticalAlignment="Stretch"
+                            Click="TogglePane_Click"
+                            Visibility="Collapsed">
+                            <FontIcon
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                FontSize="16"
+                                Glyph="&#xE126;" />
+                        </AppBarButton>
+                    </views:FontMapView.StatusBarLeftContent>
+                </views:FontMapView>
             </Grid>
+
         </SplitView>
 
-        <!--  Status Bar Background (for content resize)  -->
-        <Rectangle
-            Grid.Row="1"
-            Grid.ColumnSpan="10"
-            Height="26"
-            VerticalAlignment="Bottom"
-            Canvas.ZIndex="-1"
-            Fill="{x:Bind StatusBar.Background, Mode=OneWay}" />
-
+        <!--  Settings  -->
         <views:SettingsView
             x:Name="SettingsView"
             x:Load="False"
@@ -568,23 +464,20 @@
                 VerticalAlignment="Center"
                 Spacing="8">
                 <TextBlock
+                    x:Uid="StartupFailedHeader"
                     Style="{StaticResource TitleTextBlockStyle}"
-                    Text="Uh Oh"
                     TextAlignment="Center" />
                 <TextBlock
+                    x:Uid="StartupFailedMessage"
                     Style="{StaticResource BodyTextBlockStyle}"
                     TextAlignment="Center"
-                    TextWrapping="Wrap">
-                    <Run Text="Something went wrong and we couldn't start the app right now." />
-                    <LineBreak />
-                    <LineBreak /><Run Text="Please consider posting details about this error to GitHub so we can help you fix it." />
-                </TextBlock>
+                    TextWrapping="Wrap" />
                 <Button
+                    x:Uid="StartupFailedButton"
                     MinWidth="200"
                     Margin="0 8 0 0"
                     HorizontalAlignment="Center"
-                    Click="{x:Bind ViewModel.ShowStartUpException}"
-                    Content="Show Details" />
+                    Click="{x:Bind ViewModel.ShowStartUpException}" />
             </StackPanel>
         </Grid>
 
@@ -631,7 +524,6 @@
 
         </Grid>
 
-
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="ViewStates">
                 <VisualState x:Name="CompactViewState">
@@ -639,11 +531,6 @@
                         <Setter Target="SplitView.IsPaneOpen" Value="False" />
                         <Setter Target="SplitView.DisplayMode" Value="Overlay" />
                         <Setter Target="OpenFontPaneButton.Visibility" Value="Visible" />
-                        <Setter Target="FontTitleBlock.Margin" Value="8 0 5 0" />
-                        <!--<Setter Target="PaneHeaderGrid.Background" Value="{ThemeResource SystemAccentColorDark1}" />
-                        <Setter Target="PaneStatusBar.Background" Value="{ThemeResource SystemAccentColorDark1}" />
-                        <Setter Target="FontListGrid.Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />-->
-
                         <Setter Target="ShowPaneButton.Visibility" Value="Collapsed" />
                         <Setter Target="ShowPaneButton2.Visibility" Value="Collapsed" />
                         <Setter Target="HidePaneButton.Visibility" Value="Collapsed" />
@@ -654,11 +541,6 @@
                         <Setter Target="SplitView.IsPaneOpen" Value="False" />
                         <Setter Target="SplitView.DisplayMode" Value="Overlay" />
                         <Setter Target="OpenFontPaneButton.Visibility" Value="Visible" />
-                        <Setter Target="FontTitleBlock.Margin" Value="8 0 5 0" />
-                        <!--<Setter Target="PaneHeaderGrid.Background" Value="{ThemeResource SystemAccentColorDark1}" />
-                        <Setter Target="PaneStatusBar.Background" Value="{ThemeResource SystemAccentColorDark1}" />
-                        <Setter Target="FontListGrid.Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />-->
-
                         <Setter Target="ShowPaneButton.Visibility" Value="Visible" />
                         <Setter Target="ShowPaneButton2.Visibility" Value="Visible" />
                         <Setter Target="HidePaneButton.Visibility" Value="Collapsed" />
@@ -674,28 +556,13 @@
             <VisualStateGroup x:Name="LoadingStates">
                 <VisualState x:Name="FontsLoadingState">
                     <VisualState.Setters>
-                        <Setter Target="CommandsGrid.Opacity" Value="0" />
                         <Setter Target="SplitView.Opacity" Value="0" />
-                        <Setter Target="SplitView.IsHitTestVisible" Value="False" />
-                        <Setter Target="SearchBox.IsEnabled" Value="False" />
-                        <Setter Target="SearchBox.Opacity" Value="0" />
-                        <Setter Target="OpenFontButton.IsEnabled" Value="False" />
-                        <Setter Target="OpenFontButton.Opacity" Value="0.4" />
-                        <Setter Target="HidePaneButton.IsEnabled" Value="False" />
-                        <Setter Target="ShowPaneButton.IsEnabled" Value="False" />
-                        <Setter Target="OpenFontPaneButton.IsEnabled" Value="False" />
-                        <Setter Target="BtnSettings.IsEnabled" Value="False" />
-                        <Setter Target="BtnSettings.Opacity" Value="0" />
+                        <Setter Target="SplitView.IsEnabled" Value="False" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FontsFailedState">
                     <VisualState.Setters>
                         <Setter Target="SplitView.Visibility" Value="Collapsed" />
-                        <Setter Target="SearchBox.IsEnabled" Value="False" />
-                        <Setter Target="HidePaneButton.IsEnabled" Value="False" />
-                        <Setter Target="ShowPaneButton.IsEnabled" Value="False" />
-                        <Setter Target="OpenFontPaneButton.IsEnabled" Value="False" />
-                        <Setter Target="BtnSettings.IsEnabled" Value="False" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FontsLoadedState" />
@@ -710,21 +577,6 @@
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="HasFontsState" />
-            </VisualStateGroup>
-            <VisualStateGroup x:Name="SearchStatesGroup">
-                <VisualState x:Name="InstantSearchState">
-                    <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind ViewModel.Settings.UseInstantSearch, Mode=OneWay}" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SearchBox.QueryIcon" Value="{x:Null}" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState x:Name="ManualSearchState">
-                    <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind core:Converters.False(ViewModel.Settings.UseInstantSearch), Mode=OneWay}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
     </Grid>

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -39,8 +39,6 @@
         Drop="Grid_Drop"
         KeyDown="LayoutRoot_KeyDown">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition x:Name="TitleBarRow" Height="45" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -51,122 +49,26 @@
         <!--  Title Bar Grid  -->
         <controls:XamlTitleBar
             x:Name="TitleBar"
-            Grid.Row="0"
             Grid.ColumnSpan="2"
+            VerticalAlignment="Top"
             Canvas.ZIndex="1">
-            <Grid ColumnSpacing="7">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
+            <Grid>
+
                 <ToggleButton
                     x:Uid="ToggleFullScreenModeButton"
                     Command="{Binding CommandToggleFullScreen}"
-                    Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
+                    Foreground="{ThemeResource AppBarItemForegroundThemeBrush}"
                     Style="{StaticResource IconToggleButtonStyle}"
                     ToolTipService.Placement="Right">
                     <FontIcon FontSize="14" Glyph="&#xE740;" />
                 </ToggleButton>
-                <TextBlock
-                    Grid.Column="1"
-                    VerticalAlignment="Center"
-                    FontSize="12"
-                    Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                    IsHitTestVisible="False">
-                    <Run Text="{Binding TitlePrefix}" />
-                    <Run x:Uid="TxtTitle" />
-                </TextBlock>
+
             </Grid>
         </controls:XamlTitleBar>
-
-        <!--  Commands Grid  -->
-        <Grid
-            x:Name="CommandsGrid"
-            Grid.Row="1"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Loading="CommandsGrid_Loading"
-            RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(ThemeLock), Mode=OneWay}">
-
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition x:Name="SplitViewPaneColumn" Width="{StaticResource StatusBarPaneWidth}" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="0" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-
-            <!--  Required to work around error with hit-testing and shadowing  -->
-            <Border
-                x:Name="CommandsGridBackground"
-                Grid.ColumnSpan="5"
-                Background="{ThemeResource SystemControlBackgroundAccentBrush}" />
-
-            <AppBarButton
-                x:Name="OpenFontPaneButton"
-                Width="45"
-                Height="45"
-                Click="OpenFontPaneButton_Click"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                Visibility="Collapsed">
-                <SymbolIcon Symbol="GlobalNavigationButton" />
-            </AppBarButton>
-
-            <TextBlock
-                x:Name="FontTitleBlock"
-                Grid.Column="1"
-                Margin="24,0,5,0"
-                VerticalAlignment="Center"
-                FontSize="22"
-                FontWeight="SemiLight"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
-                Text="{Binding SelectedFont.Name, Mode=OneWay}"
-                TextTrimming="CharacterEllipsis" />
-
-            <AutoSuggestBox
-                x:Name="SearchBox"
-                x:Uid="SearchBox"
-                Grid.Column="2"
-                Width="290"
-                VerticalAlignment="Center"
-                GotFocus="{x:Bind FontMap.SearchBox_GotFocus}"
-                ItemTemplate="{StaticResource SearchResultTemplate}"
-                ItemsSource="{x:Bind FontMap.ViewModel.SearchResults, Mode=OneWay}"
-                PlaceholderText="#SearchBox"
-                PreviewKeyDown="{x:Bind FontMap.SearchBox_PreviewKeyDown}"
-                QuerySubmitted="{x:Bind FontMap.SearchBox_QuerySubmitted}"
-                SuggestionChosen="{x:Bind FontMap.SearchBox_SuggestionChosen}"
-                Tag="{Binding ElementName=FontMap, Path=ViewModel.FontFamily}"
-                Text="{Binding ElementName=FontMap, Path=ViewModel.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                TextChanged="{x:Bind FontMap.SearchBox_TextChanged}"
-                TextMemberPath="Description"
-                UpdateTextOnSelect="False">
-                <AutoSuggestBox.QueryIcon>
-                    <SymbolIcon Symbol="Find" />
-                </AutoSuggestBox.QueryIcon>
-            </AutoSuggestBox>
-
-            <AppBarButton
-                x:Name="BtnSettings"
-                Grid.Column="4"
-                Width="45"
-                Height="45"
-                Click="BtnSettings_OnClick"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}">
-                <FontIcon
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    FontSize="16"
-                    Glyph="&#xE115;" />
-            </AppBarButton>
-        </Grid>
-
 
         <!--  Main Content  -->
         <SplitView
             x:Name="SplitView"
-            Grid.Row="1"
             Grid.RowSpan="3"
             Grid.ColumnSpan="3"
             DisplayMode="Inline"
@@ -174,294 +76,285 @@
             OpenPaneLength="{StaticResource SplitViewPaneWidth}"
             PaneBackground="Transparent">
             <SplitView.Pane>
-                <Grid x:Name="PaneRoot" Loading="PaneRoot_Loading">
+                <Grid x:Name="PaneRoot" Background="{StaticResource DefaultHostBrush}">
 
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="{x:Bind TitleBarRow.Height}" />
                         <RowDefinition Height="*" />
                         <RowDefinition x:Name="StatusBarRow" Height="26" />
                     </Grid.RowDefinitions>
 
-                    <!--  Pane Header Commands  -->
-                    <Grid
-                        x:Name="PaneHeaderGrid"
-                        Loading="PaneHeaderGrid_Loading"
-                        RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(ThemeLock), Mode=OneWay}">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-
-                        <Button
-                            x:Name="FontListFilter"
-                            x:Uid="FontListFilter"
-                            Height="45"
-                            Margin="0,0,0,0"
-                            Padding="12,6"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch"
-                            HorizontalContentAlignment="Left"
-                            Background="Transparent"
-                            Content="{x:Bind ViewModel.FilterTitle, Mode=OneWay}"
-                            FontSize="16"
-                            Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                            Style="{StaticResource TransparentHintButton}"
-                            ToolTipService.Placement="Bottom">
-                            <Button.Flyout>
-                                <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
-                                    <MenuFlyout.MenuFlyoutPresenterStyle>
-                                        <Style TargetType="MenuFlyoutPresenter">
-                                            <Setter Property="RequestedTheme" Value="Default" />
-                                            <Setter Property="FontSize" Value="16" />
-                                        </Style>
-                                    </MenuFlyout.MenuFlyoutPresenterStyle>
-                                    <MenuFlyoutItem
-                                        x:Uid="OptionAllFonts"
-                                        Click="Filter_Click"
-                                        FontSize="16"
-                                        Tag="0" />
-                                    <MenuFlyoutItem
-                                        x:Uid="OptionSerifFonts"
-                                        Click="Filter_Click"
-                                        FontSize="16"
-                                        Tag="4" />
-                                    <MenuFlyoutItem
-                                        x:Uid="OptionSansSerifFonts"
-                                        Click="Filter_Click"
-                                        FontSize="16"
-                                        Tag="5" />
-                                    <MenuFlyoutItem
-                                        x:Uid="OptionSymbolFonts"
-                                        Click="Filter_Click"
-                                        FontSize="16"
-                                        Tag="1" />
-                                    <MenuFlyoutSubItem x:Uid="OptionMoreFilters" FontSize="16">
-                                        <MenuFlyoutItem
-                                            x:Uid="OptionColorFonts"
-                                            Click="Filter_Click"
-                                            FontSize="16"
-                                            Tag="10" />
-                                        <MenuFlyoutItem
-                                            x:Uid="OptionDecorativeFonts"
-                                            Click="Filter_Click"
-                                            FontSize="16"
-                                            Tag="8" />
-                                        <MenuFlyoutItem
-                                            x:Uid="OptionScriptFonts"
-                                            Click="Filter_Click"
-                                            FontSize="16"
-                                            Tag="9" />
-                                        <MenuFlyoutItem
-                                            x:Uid="OptionMonospacedFonts"
-                                            Click="Filter_Click"
-                                            FontSize="16"
-                                            Tag="3" />
-                                        <!--<MenuFlyoutSeparator />
-                                <MenuFlyoutItem
-                                    Text="Normal Fonts"
-                                    Click="Filter_Click"
-                                    Tag="11" />
-                                <MenuFlyoutItem
-                                    Text="Italic Fonts"
-                                    Click="Filter_Click"
-                                    Tag="12" />
-                                <MenuFlyoutItem
-                                    Text="Oblique Fonts"
-                                    Click="Filter_Click"
-                                    Tag="13" />-->
-                                        <MenuFlyoutSeparator x:Name="FontSourceSeperator" />
-                                        <MenuFlyoutItem
-                                            x:Name="CloudFontsOption"
-                                            x:Uid="OptionCloudFonts"
-                                            Click="Filter_Click"
-                                            FontSize="16"
-                                            Tag="7" />
-                                        <MenuFlyoutItem
-                                            x:Name="AppxOption"
-                                            x:Uid="OptionAppxFonts"
-                                            Click="Filter_Click"
-                                            FontSize="16"
-                                            Tag="6" />
-                                    </MenuFlyoutSubItem>
-                                    <MenuFlyoutSeparator />
-                                    <MenuFlyoutItem
-                                        x:Uid="OptionImportedFonts"
-                                        Click="Filter_Click"
-                                        FontSize="16"
-                                        Tag="2" />
-                                </MenuFlyout>
-                            </Button.Flyout>
-                        </Button>
-
-                        <AppBarButton
-                            x:Name="ImportFontsButton"
-                            x:Uid="ImportFontsButton"
-                            Grid.Column="1"
-                            Width="45"
-                            Height="45"
-                            VerticalAlignment="Bottom"
-                            Click="{x:Bind PickFonts}"
-                            Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                            Visibility="Collapsed">
-                            <FontIcon
-                                FontSize="16"
-                                Glyph="&#xE109;"
-                                Opacity="0.8" />
-                        </AppBarButton>
-
-                        <AppBarButton
-                            x:Name="OpenFontButton"
-                            x:Uid="OpenFontButton"
-                            Grid.Column="2"
-                            Width="45"
-                            Height="45"
-                            VerticalAlignment="Bottom"
-                            Click="{x:Bind OpenFont}"
-                            Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}">
-                            <Path
-                                Height="16"
-                                Data="M896,320L1012,320L788,768L0,768L0,128L338.5,128L466.5,0L896,0ZM64,192L64,632.5L220.5,320L832,320L832,64L493.5,64L365.5,192ZM748,704L908,384L260,384L99.5,704Z"
-                                Fill="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                                Opacity="0.8"
-                                Stretch="Uniform" />
-                        </AppBarButton>
-                    </Grid>
-
-                    <!--  Font List Grid  -->
-                    <Grid
-                        x:Name="FontListGrid"
-                        Grid.Row="1"
-                        Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
-                        Loading="FontListGrid_Loading">
-
+                    <Grid x:Name="PaneContentRoot">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}" />
+                            <RowDefinition Height="{x:Bind TitleBarRow.Height}" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
-                        <Grid x:Name="CollectionControlRow" Visibility="{x:Bind core:Converters.IsNotNullToVis(ViewModel.SelectedCollection), Mode=OneWay, FallbackValue=Collapsed}">
-                            <Border x:Name="CollectionControlBackground">
-                                <Border.Background>
-                                    <SolidColorBrush Opacity="0.4" Color="{ThemeResource SystemAccentColor}" />
-                                </Border.Background>
-                            </Border>
-                            <StackPanel
-                                x:Name="CollectionControlItems"
-                                Padding="0,0"
-                                HorizontalAlignment="Center"
-                                Orientation="Horizontal"
-                                Spacing="12">
-                                <AppBarButton
-                                    x:Uid="RenameCollectionButton"
-                                    Height="48"
-                                    Click="RenameFontCollection_Click"
-                                    Icon="Rename"
-                                    ToolTipService.Placement="Bottom" />
-                                <AppBarButton
-                                    x:Uid="DeleteCollectionButton"
-                                    Height="48"
-                                    Click="DeleteCollection_Click"
-                                    Icon="Delete"
-                                    ToolTipService.Placement="Bottom" />
-                            </StackPanel>
+                        <!--  Pane Header Commands  -->
+                        <Grid x:Name="PaneHeaderGrid" Grid.Row="1">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <AppBarButton
+                                x:Name="OpenFontButton"
+                                x:Uid="OpenFontButton"
+                                Grid.Column="0"
+                                Width="45"
+                                Height="45"
+                                VerticalAlignment="Bottom"
+                                Click="{x:Bind OpenFont}">
+                                <Path
+                                    Height="16"
+                                    Data="M896,320L1012,320L788,768L0,768L0,128L338.5,128L466.5,0L896,0ZM64,192L64,632.5L220.5,320L832,320L832,64L493.5,64L365.5,192ZM748,704L908,384L260,384L99.5,704Z"
+                                    Fill="{ThemeResource ApplicationForegroundThemeBrush}"
+                                    Opacity="0.8"
+                                    Stretch="Uniform" />
+                            </AppBarButton>
+
+                            <Button
+                                x:Name="FontListFilter"
+                                x:Uid="FontListFilter"
+                                Grid.Column="1"
+                                Height="45"
+                                Margin="0,0,0,0"
+                                Padding="12,6"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                HorizontalContentAlignment="Left"
+                                Background="Transparent"
+                                Content="{x:Bind ViewModel.FilterTitle, Mode=OneWay}"
+                                FontSize="16"
+                                FontWeight="Bold"
+                                Style="{StaticResource TransparentHintButton}"
+                                ToolTipService.Placement="Bottom">
+                                <Button.Flyout>
+                                    <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
+                                        <MenuFlyout.MenuFlyoutPresenterStyle>
+                                            <Style TargetType="MenuFlyoutPresenter">
+                                                <Setter Property="RequestedTheme" Value="Default" />
+                                                <Setter Property="FontSize" Value="16" />
+                                                <Setter Property="CornerRadius" Value="0" />
+                                                <Setter Property="Margin" Value="0 -4 0 0" />
+                                                <Setter Property="Padding" Value="0" />
+                                                <!--<Setter Property="BorderBrush" Value="{ThemeResource SystemAccentColor}" />-->
+                                                <Setter Property="BorderThickness" Value="1 0 1 1" />
+                                            </Style>
+                                        </MenuFlyout.MenuFlyoutPresenterStyle>
+                                        <MenuFlyoutItem
+                                            x:Uid="OptionAllFonts"
+                                            Click="Filter_Click"
+                                            FontSize="16"
+                                            Tag="0" />
+                                        <MenuFlyoutItem
+                                            x:Uid="OptionSerifFonts"
+                                            Click="Filter_Click"
+                                            FontSize="16"
+                                            Tag="4" />
+                                        <MenuFlyoutItem
+                                            x:Uid="OptionSansSerifFonts"
+                                            Click="Filter_Click"
+                                            FontSize="16"
+                                            Tag="5" />
+                                        <MenuFlyoutItem
+                                            x:Uid="OptionSymbolFonts"
+                                            Click="Filter_Click"
+                                            FontSize="16"
+                                            Tag="1" />
+                                        <MenuFlyoutSubItem x:Uid="OptionMoreFilters" FontSize="16">
+                                            <MenuFlyoutItem
+                                                x:Uid="OptionColorFonts"
+                                                Click="Filter_Click"
+                                                FontSize="16"
+                                                Tag="10" />
+                                            <MenuFlyoutItem
+                                                x:Uid="OptionDecorativeFonts"
+                                                Click="Filter_Click"
+                                                FontSize="16"
+                                                Tag="8" />
+                                            <MenuFlyoutItem
+                                                x:Uid="OptionScriptFonts"
+                                                Click="Filter_Click"
+                                                FontSize="16"
+                                                Tag="9" />
+                                            <MenuFlyoutItem
+                                                x:Uid="OptionMonospacedFonts"
+                                                Click="Filter_Click"
+                                                FontSize="16"
+                                                Tag="3" />
+                                            <MenuFlyoutSeparator x:Name="FontSourceSeperator" />
+                                            <MenuFlyoutItem
+                                                x:Name="CloudFontsOption"
+                                                x:Uid="OptionCloudFonts"
+                                                Click="Filter_Click"
+                                                FontSize="16"
+                                                Tag="7" />
+                                            <MenuFlyoutItem
+                                                x:Name="AppxOption"
+                                                x:Uid="OptionAppxFonts"
+                                                Click="Filter_Click"
+                                                FontSize="16"
+                                                Tag="6" />
+                                        </MenuFlyoutSubItem>
+                                        <MenuFlyoutSeparator />
+                                        <MenuFlyoutItem
+                                            x:Uid="OptionImportedFonts"
+                                            Click="Filter_Click"
+                                            FontSize="16"
+                                            Tag="2" />
+                                    </MenuFlyout>
+                                </Button.Flyout>
+                            </Button>
+
+                            <!--<AppBarButton
+                                x:Name="ImportFontsButton"
+                                x:Uid="ImportFontsButton"
+                                Grid.Column="1"
+                                Width="45"
+                                Height="45"
+                                VerticalAlignment="Bottom"
+                                Click="{x:Bind PickFonts}"
+                                Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
+                                Visibility="Collapsed">
+                                <FontIcon
+                                    FontSize="16"
+                                    Glyph="&#xE109;"
+                                    Opacity="0.8" />
+                            </AppBarButton>-->
+
                         </Grid>
 
-                        <TextBlock
-                            x:Name="ImportFontHelpBlock"
-                            x:Uid="ImportFontHelpBlock"
-                            Grid.Row="1"
-                            Margin="12"
-                            FontSize="13"
-                            Opacity="0.7"
-                            Style="{StaticResource CaptionTextBlockStyle}"
-                            Visibility="Collapsed" />
+                        <!--  Font List Grid  -->
+                        <Grid
+                            x:Name="FontListGrid"
+                            Grid.Row="2"
+                            Loading="FontListGrid_Loading">
 
-                        <SemanticZoom x:Name="FontsSemanticZoom" Grid.Row="1">
-                            <SemanticZoom.ZoomedInView>
-                                <ListView
-                                    x:Name="LstFontFamily"
-                                    IsItemClickEnabled="False"
-                                    IsSwipeEnabled="False"
-                                    ItemTemplate="{StaticResource FontListItemTemplate}"
-                                    ItemsSource="{Binding Source={StaticResource GroupedFontList}}"
-                                    SelectedValuePath="Name"
-                                    SelectionChanged="LstFontFamily_SelectionChanged"
-                                    SelectionMode="Single"
-                                    ShowsScrollingPlaceholders="False">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
 
-                                    <ListView.ItemContainerTransitions>
-                                        <TransitionCollection />
-                                    </ListView.ItemContainerTransitions>
-
-                                    <ListView.Resources>
-                                        <Style BasedOn="{StaticResource ListViewItemRevealStyle}" TargetType="ListViewItem">
-                                            <Setter Property="HorizontalAlignment" Value="Stretch" />
-                                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                                        </Style>
-                                    </ListView.Resources>
-
-                                    <ListView.GroupStyle>
-                                        <GroupStyle HeaderContainerStyle="{ThemeResource FontListHeaderItem}" HidesIfEmpty="True">
-                                            <GroupStyle.HeaderTemplate>
-                                                <DataTemplate>
-                                                    <GridViewItem
-                                                        x:Name="Root"
-                                                        Margin="0"
-                                                        Padding="0"
-                                                        HorizontalAlignment="Stretch"
-                                                        HorizontalContentAlignment="Stretch"
-                                                        IsHitTestVisible="True">
-                                                        <Border
-                                                            Margin="15,0"
-                                                            BorderBrush="#CCC"
-                                                            BorderThickness="0,0,0,1">
-                                                            <TextBlock
-                                                                Padding="0,8,0,10"
-                                                                HorizontalAlignment="Stretch"
-                                                                VerticalAlignment="Stretch"
-                                                                FontSize="30"
-                                                                FontWeight="SemiLight"
-                                                                Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
-                                                                Text="{Binding Key}" />
-                                                        </Border>
-                                                    </GridViewItem>
-                                                </DataTemplate>
-                                            </GroupStyle.HeaderTemplate>
-                                        </GroupStyle>
-                                    </ListView.GroupStyle>
-                                </ListView>
-                            </SemanticZoom.ZoomedInView>
-                            <SemanticZoom.ZoomedOutView>
-                                <GridView
-                                    x:Name="ZoomGridView"
+                            <Grid x:Name="CollectionControlRow" Visibility="{x:Bind core:Converters.IsNotNullToVis(ViewModel.SelectedCollection), Mode=OneWay, FallbackValue=Collapsed}">
+                                <Border x:Name="CollectionControlBackground" Background="{ThemeResource DefaultAcrylicBrush}" />
+                                <StackPanel
+                                    x:Name="CollectionControlItems"
+                                    Padding="0,0"
                                     HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    ItemsSource="{Binding CollectionGroups, Source={StaticResource GroupedFontList}}">
-                                    <GridView.ItemTemplate>
-                                        <DataTemplate>
-                                            <Border Width="64" Height="64">
-                                                <TextBlock
-                                                    HorizontalAlignment="Center"
-                                                    VerticalAlignment="Center"
-                                                    FontSize="32"
-                                                    FontWeight="SemiLight"
-                                                    Foreground="{Binding Group.Count, Converter={StaticResource ZoomBackgroundConverter}}"
-                                                    Text="{Binding Group.Key}" />
-                                            </Border>
-                                        </DataTemplate>
-                                    </GridView.ItemTemplate>
-                                </GridView>
-                            </SemanticZoom.ZoomedOutView>
-                        </SemanticZoom>
+                                    Orientation="Horizontal"
+                                    Spacing="12">
+                                    <AppBarButton
+                                        x:Uid="RenameCollectionButton"
+                                        Height="48"
+                                        Click="RenameFontCollection_Click"
+                                        Icon="Rename"
+                                        ToolTipService.Placement="Bottom" />
+                                    <AppBarButton
+                                        x:Uid="DeleteCollectionButton"
+                                        Height="48"
+                                        Click="DeleteCollection_Click"
+                                        Icon="Delete"
+                                        ToolTipService.Placement="Bottom" />
+                                </StackPanel>
+                            </Grid>
+
+                            <TextBlock
+                                x:Name="ImportFontHelpBlock"
+                                x:Uid="ImportFontHelpBlock"
+                                Grid.Row="1"
+                                Margin="12"
+                                FontSize="13"
+                                Opacity="0.7"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Visibility="Collapsed" />
+
+                            <SemanticZoom x:Name="FontsSemanticZoom" Grid.Row="1">
+                                <SemanticZoom.ZoomedInView>
+                                    <ListView
+                                        x:Name="LstFontFamily"
+                                        IsItemClickEnabled="False"
+                                        IsSwipeEnabled="False"
+                                        ItemTemplate="{StaticResource FontListItemTemplate}"
+                                        ItemsSource="{Binding Source={StaticResource GroupedFontList}}"
+                                        SelectedValuePath="Name"
+                                        SelectionChanged="LstFontFamily_SelectionChanged"
+                                        SelectionMode="Single"
+                                        ShowsScrollingPlaceholders="False">
+
+                                        <ListView.ItemContainerTransitions>
+                                            <TransitionCollection />
+                                        </ListView.ItemContainerTransitions>
+
+                                        <ListView.Resources>
+                                            <Style BasedOn="{StaticResource ListViewItemRevealStyle}" TargetType="ListViewItem">
+                                                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                            </Style>
+                                        </ListView.Resources>
+
+                                        <ListView.GroupStyle>
+                                            <GroupStyle HeaderContainerStyle="{ThemeResource FontListHeaderItem}" HidesIfEmpty="True">
+                                                <GroupStyle.HeaderTemplate>
+                                                    <DataTemplate>
+                                                        <GridViewItem
+                                                            x:Name="Root"
+                                                            Margin="0"
+                                                            Padding="0"
+                                                            HorizontalAlignment="Stretch"
+                                                            HorizontalContentAlignment="Stretch"
+                                                            IsHitTestVisible="True">
+                                                            <Border
+                                                                Margin="15,0"
+                                                                BorderBrush="#CCC"
+                                                                BorderThickness="0,0,0,1">
+                                                                <TextBlock
+                                                                    Padding="0,8,0,10"
+                                                                    HorizontalAlignment="Stretch"
+                                                                    VerticalAlignment="Stretch"
+                                                                    FontSize="30"
+                                                                    FontWeight="SemiBold"
+                                                                    Text="{Binding Key}" />
+                                                            </Border>
+                                                        </GridViewItem>
+                                                    </DataTemplate>
+                                                </GroupStyle.HeaderTemplate>
+                                            </GroupStyle>
+                                        </ListView.GroupStyle>
+                                    </ListView>
+                                </SemanticZoom.ZoomedInView>
+                                <SemanticZoom.ZoomedOutView>
+                                    <GridView
+                                        x:Name="ZoomGridView"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        ItemsSource="{Binding CollectionGroups, Source={StaticResource GroupedFontList}}">
+                                        <GridView.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Width="64" Height="64">
+                                                    <TextBlock
+                                                        HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center"
+                                                        FontSize="32"
+                                                        FontWeight="Bold"
+                                                        Foreground="{Binding Group.Count, Converter={StaticResource ZoomBackgroundConverter}}"
+                                                        Text="{Binding Group.Key}" />
+                                                </Border>
+                                            </DataTemplate>
+                                        </GridView.ItemTemplate>
+                                    </GridView>
+                                </SemanticZoom.ZoomedOutView>
+                            </SemanticZoom>
+                        </Grid>
+
                     </Grid>
 
                     <!--  Pane Status Bar  -->
                     <Grid
                         x:Name="PaneStatusBar"
-                        Grid.Row="2"
-                        Background="{ThemeResource SystemControlBackgroundAccentBrush}"
-                        RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(ThemeLock), Mode=OneWay}">
+                        Grid.Row="3"
+                        Background="{x:Bind StatusBar.Background}">
                         <Grid.Resources>
                             <Style TargetType="TextBlock">
                                 <Setter Property="FontSize" Value="12" />
@@ -482,8 +375,7 @@
                             Width="32"
                             Margin="0 0 -6 0"
                             VerticalAlignment="Stretch"
-                            Click="TogglePane_Click"
-                            Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}">
+                            Click="TogglePane_Click">
                             <FontIcon
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="16"
@@ -497,7 +389,6 @@
                             Margin="0 0 -6 0"
                             VerticalAlignment="Stretch"
                             Click="TogglePane_Click"
-                            Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                             Visibility="Collapsed">
                             <FontIcon
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
@@ -508,7 +399,6 @@
                         <TextBlock
                             x:Name="FontFamilyCountLabel"
                             Grid.Column="1"
-                            Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                             Text="{x:Bind UpdateFontCountLabel(ViewModel.FontList), Mode=OneWay}" />
 
                     </Grid>
@@ -519,23 +409,98 @@
             <!--  FontMap Grid  -->
             <Grid>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="{x:Bind TitleBarRow.Height}" />
                     <RowDefinition Height="*" />
                     <RowDefinition Height="{x:Bind StatusBarRow.Height}" />
                 </Grid.RowDefinitions>
 
-                <views:FontMapView
-                    x:Name="FontMap"
-                    Grid.Row="1"
-                    Font="{x:Bind ViewModel.SelectedFont, Mode=OneWay}" />
+                <Grid x:Name="SplitViewContentRoot" Loading="Grid_Loading">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}" />
+                        <RowDefinition x:Name="TitleBarRow" Height="45" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <!--  Commands Grid  -->
+                    <Grid x:Name="CommandsGrid" Grid.Row="1">
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+
+                        <AppBarButton
+                            x:Name="OpenFontPaneButton"
+                            Width="45"
+                            Height="45"
+                            Click="OpenFontPaneButton_Click"
+                            Visibility="Collapsed">
+                            <SymbolIcon Symbol="GlobalNavigationButton" />
+                        </AppBarButton>
+
+                        <TextBlock
+                            x:Name="FontTitleBlock"
+                            Grid.Column="1"
+                            Margin="24,0,5,0"
+                            VerticalAlignment="Center"
+                            FontSize="22"
+                            FontWeight="Bold"
+                            Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
+                            Text="{Binding SelectedFont.Name, Mode=OneWay}"
+                            TextTrimming="CharacterEllipsis" />
+
+                        <AutoSuggestBox
+                            x:Name="SearchBox"
+                            x:Uid="SearchBox"
+                            Grid.Column="2"
+                            Width="290"
+                            VerticalAlignment="Center"
+                            GotFocus="{x:Bind FontMap.SearchBox_GotFocus}"
+                            ItemTemplate="{StaticResource SearchResultTemplate}"
+                            ItemsSource="{x:Bind FontMap.ViewModel.SearchResults, Mode=OneWay}"
+                            PlaceholderText="#SearchBox"
+                            PreviewKeyDown="{x:Bind FontMap.SearchBox_PreviewKeyDown}"
+                            QuerySubmitted="{x:Bind FontMap.SearchBox_QuerySubmitted}"
+                            SuggestionChosen="{x:Bind FontMap.SearchBox_SuggestionChosen}"
+                            Tag="{Binding ElementName=FontMap, Path=ViewModel.FontFamily}"
+                            Text="{Binding ElementName=FontMap, Path=ViewModel.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            TextChanged="{x:Bind FontMap.SearchBox_TextChanged}"
+                            TextMemberPath="Description"
+                            UpdateTextOnSelect="False">
+                            <AutoSuggestBox.QueryIcon>
+                                <SymbolIcon Symbol="Find" />
+                            </AutoSuggestBox.QueryIcon>
+                        </AutoSuggestBox>
+
+                        <AppBarButton
+                            x:Name="BtnSettings"
+                            Grid.Column="3"
+                            Width="45"
+                            Height="45"
+                            Click="BtnSettings_OnClick">
+                            <FontIcon
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                FontSize="16"
+                                Glyph="&#xE115;" />
+                        </AppBarButton>
+                    </Grid>
+
+                    <views:FontMapView
+                        x:Name="FontMap"
+                        Grid.Row="2"
+                        Font="{x:Bind ViewModel.SelectedFont, Mode=OneWay}" />
+
+                </Grid>
 
                 <!--  Status Bar  -->
                 <Grid
                     x:Name="StatusBar"
-                    Grid.Row="2"
+                    Grid.Row="1"
                     Grid.Column="0"
-                    Background="{ThemeResource SystemControlBackgroundAccentBrush}"
-                    RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(ThemeLock), Mode=OneWay}">
+                    Background="{StaticResource AltHostBrush}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
@@ -549,7 +514,6 @@
                             <Setter Property="TextLineBounds" Value="Tight" />
                         </Style>
                     </Grid.Resources>
-
                     <AppBarButton
                         x:Name="ShowPaneButton"
                         x:Uid="BtnShowPane"
@@ -557,7 +521,6 @@
                         Margin="0 0 -6 0"
                         VerticalAlignment="Stretch"
                         Click="TogglePane_Click"
-                        Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                         Visibility="Collapsed">
                         <FontIcon
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
@@ -565,14 +528,10 @@
                             Glyph="&#xE126;" />
                     </AppBarButton>
 
-                    <TextBlock
-                        Grid.Column="1"
-                        Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
-                        Text="{x:Bind UpdateCharacterCountLabel(FontMap.ViewModel.SelectedVariant), Mode=OneWay}" />
+                    <TextBlock Grid.Column="1" Text="{x:Bind UpdateCharacterCountLabel(FontMap.ViewModel.SelectedVariant), Mode=OneWay}" />
 
                     <TextBlock
                         Grid.Column="2"
-                        Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock), Mode=OneWay}"
                         Loaded="{x:Bind helpers:Composition.SetStandardReposition}"
                         Text="{x:Bind FontMap.ViewModel.GetCharDescription(FontMap.ViewModel.SelectedChar), Mode=OneWay}" />
                 </Grid>
@@ -581,28 +540,27 @@
 
         <!--  Status Bar Background (for content resize)  -->
         <Rectangle
-            Grid.Row="3"
+            Grid.Row="1"
             Grid.ColumnSpan="10"
             Height="26"
             VerticalAlignment="Bottom"
             Canvas.ZIndex="-1"
             Fill="{x:Bind StatusBar.Background, Mode=OneWay}" />
 
-
-
         <views:SettingsView
             x:Name="SettingsView"
             x:Load="False"
-            Grid.Row="1"
+            Grid.Row="0"
             Grid.RowSpan="3"
             Grid.ColumnSpan="10"
+            TitleBarHeight="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}"
             Visibility="Collapsed" />
 
         <!--  Startup Exception Root  -->
         <Grid
             x:Name="StartupFailedRoot"
             x:Load="{x:Bind ViewModel.IsLoadingFontsFailed, Mode=OneWay}"
-            Grid.Row="2"
+            Grid.Row="1"
             Grid.ColumnSpan="10">
             <StackPanel
                 Margin="40"
@@ -643,7 +601,6 @@
         <Border
             x:Name="PrintPresenter"
             x:DeferLoadStrategy="Lazy"
-            Grid.Row="1"
             Grid.RowSpan="3"
             Grid.ColumnSpan="10" />
 
@@ -653,7 +610,7 @@
             x:Load="{x:Bind ViewModel.IsLoadingFonts, Mode=OneWay}"
             Grid.RowSpan="20"
             Grid.ColumnSpan="20"
-            Background="{ThemeResource SystemAccentColor}"
+            Background="{StaticResource DefaultHostBrush}"
             Loading="LoadingRoot_Loading">
 
             <StackPanel
@@ -663,14 +620,13 @@
                 <ProgressRing
                     Width="75"
                     Height="75"
-                    Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock)}"
+                    Foreground="{ThemeResource ApplicationForegroundThemeBrush}"
                     IsActive="True" />
                 <TextBlock
                     x:Uid="TxtLoadingFonts"
                     HorizontalAlignment="Center"
-                    FontSize="18"
-                    FontWeight="SemiLight"
-                    Foreground="{x:Bind core:Converters.GetForegroundBrush(ThemeLock)}" />
+                    FontSize="24"
+                    FontWeight="Bold" />
             </StackPanel>
 
         </Grid>
@@ -682,12 +638,11 @@
                     <VisualState.Setters>
                         <Setter Target="SplitView.IsPaneOpen" Value="False" />
                         <Setter Target="SplitView.DisplayMode" Value="Overlay" />
-                        <Setter Target="SplitViewPaneColumn.Width" Value="Auto" />
                         <Setter Target="OpenFontPaneButton.Visibility" Value="Visible" />
                         <Setter Target="FontTitleBlock.Margin" Value="8 0 5 0" />
-                        <Setter Target="PaneHeaderGrid.Background" Value="{ThemeResource SystemAccentColorDark1}" />
+                        <!--<Setter Target="PaneHeaderGrid.Background" Value="{ThemeResource SystemAccentColorDark1}" />
                         <Setter Target="PaneStatusBar.Background" Value="{ThemeResource SystemAccentColorDark1}" />
-                        <Setter Target="FontListGrid.Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />
+                        <Setter Target="FontListGrid.Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />-->
 
                         <Setter Target="ShowPaneButton.Visibility" Value="Collapsed" />
                         <Setter Target="ShowPaneButton2.Visibility" Value="Collapsed" />
@@ -698,12 +653,11 @@
                     <VisualState.Setters>
                         <Setter Target="SplitView.IsPaneOpen" Value="False" />
                         <Setter Target="SplitView.DisplayMode" Value="Overlay" />
-                        <Setter Target="SplitViewPaneColumn.Width" Value="Auto" />
                         <Setter Target="OpenFontPaneButton.Visibility" Value="Visible" />
                         <Setter Target="FontTitleBlock.Margin" Value="8 0 5 0" />
-                        <Setter Target="PaneHeaderGrid.Background" Value="{ThemeResource SystemAccentColorDark1}" />
+                        <!--<Setter Target="PaneHeaderGrid.Background" Value="{ThemeResource SystemAccentColorDark1}" />
                         <Setter Target="PaneStatusBar.Background" Value="{ThemeResource SystemAccentColorDark1}" />
-                        <Setter Target="FontListGrid.Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />
+                        <Setter Target="FontListGrid.Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />-->
 
                         <Setter Target="ShowPaneButton.Visibility" Value="Visible" />
                         <Setter Target="ShowPaneButton2.Visibility" Value="Visible" />
@@ -725,7 +679,6 @@
                         <Setter Target="SplitView.IsHitTestVisible" Value="False" />
                         <Setter Target="SearchBox.IsEnabled" Value="False" />
                         <Setter Target="SearchBox.Opacity" Value="0" />
-                        <Setter Target="ImportFontsButton.IsEnabled" Value="False" />
                         <Setter Target="OpenFontButton.IsEnabled" Value="False" />
                         <Setter Target="OpenFontButton.Opacity" Value="0.4" />
                         <Setter Target="HidePaneButton.IsEnabled" Value="False" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -3,12 +3,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:CharacterMap.Controls"
+    xmlns:controls1="using:Microsoft.UI.Xaml.Controls"
     xmlns:core="using:CharacterMap.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:CharacterMap.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:views="using:CharacterMap.Views"
-    xmlns:wct="using:Microsoft.Toolkit.Uwp.UI.Controls" xmlns:controls1="using:Microsoft.UI.Xaml.Controls"
+    xmlns:wct="using:Microsoft.Toolkit.Uwp.UI.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     DataContext="{Binding Source={StaticResource Locator}, Path=Main}"
     mc:Ignorable="d">
@@ -66,326 +67,326 @@
             IsPaneOpen="True"
             OpenPaneLength="{StaticResource SplitViewPaneWidth}">
             <SplitView.Pane>
-                <Grid x:Name="PaneRoot"  Background="{StaticResource DefaultHostBrush}">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}" />
-                            <RowDefinition Height="{StaticResource TitleRowGridHeight}" />
-                            <RowDefinition Height="*" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
+                <Grid x:Name="PaneRoot" Background="{StaticResource DefaultHostBrush}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}" />
+                        <RowDefinition Height="{StaticResource TitleRowGridHeight}" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
 
-                        <!--  Pane Header Commands  -->
-                        <Grid x:Name="PaneHeaderGrid" Grid.Row="1">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
+                    <!--  Pane Header Commands  -->
+                    <Grid x:Name="PaneHeaderGrid" Grid.Row="1">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
 
-                            <AppBarButton
-                                x:Name="OpenFontButton"
-                                x:Uid="OpenFontButton"
-                                Grid.Column="0"
-                                Width="{StaticResource TitleRowHeight}"
-                                Height="{StaticResource TitleRowHeight}"
-                                VerticalAlignment="Bottom"
-                                Click="{x:Bind OpenFont}">
-                                <Path
-                                    Height="16"
-                                    Data="M896,320L1012,320L788,768L0,768L0,128L338.5,128L466.5,0L896,0ZM64,192L64,632.5L220.5,320L832,320L832,64L493.5,64L365.5,192ZM748,704L908,384L260,384L99.5,704Z"
-                                    Fill="{ThemeResource ApplicationForegroundThemeBrush}"
-                                    Opacity="0.8"
-                                    Stretch="Uniform" />
-                            </AppBarButton>
+                        <AppBarButton
+                            x:Name="OpenFontButton"
+                            x:Uid="OpenFontButton"
+                            Grid.Column="0"
+                            Width="{StaticResource TitleRowHeight}"
+                            Height="{StaticResource TitleRowHeight}"
+                            VerticalAlignment="Bottom"
+                            Click="{x:Bind OpenFont}">
+                            <Path
+                                Height="16"
+                                Data="M896,320L1012,320L788,768L0,768L0,128L338.5,128L466.5,0L896,0ZM64,192L64,632.5L220.5,320L832,320L832,64L493.5,64L365.5,192ZM748,704L908,384L260,384L99.5,704Z"
+                                Fill="{ThemeResource ApplicationForegroundThemeBrush}"
+                                Opacity="0.8"
+                                Stretch="Uniform" />
+                        </AppBarButton>
 
-                            <Button
-                                x:Name="FontListFilter"
-                                x:Uid="FontListFilter"
-                                Grid.Column="1"
-                                Height="{StaticResource TitleRowHeight}"
-                                Margin="0,0,0,0"
-                                Padding="12 0"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                HorizontalContentAlignment="Left"
-                                VerticalContentAlignment="Stretch"
-                                Background="Transparent"
-                                Style="{StaticResource TransparentHintButton}"
-                                ToolTipService.Placement="Bottom">
+                        <Button
+                            x:Name="FontListFilter"
+                            x:Uid="FontListFilter"
+                            Grid.Column="1"
+                            Height="{StaticResource TitleRowHeight}"
+                            Margin="0,0,0,0"
+                            Padding="12 0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            HorizontalContentAlignment="Left"
+                            VerticalContentAlignment="Stretch"
+                            Background="Transparent"
+                            Style="{StaticResource TransparentHintButton}"
+                            ToolTipService.Placement="Bottom">
 
-                                <StackPanel VerticalAlignment="Center" Orientation="Vertical">
+                            <StackPanel VerticalAlignment="Center" Orientation="Vertical">
+                                <TextBlock
+                                    x:Name="GroupLabel"
+                                    FontSize="16"
+                                    FontWeight="Bold"
+                                    OpticalMarginAlignment="TrimSideBearings"
+                                    Text="{x:Bind ViewModel.FilterTitle, Mode=OneWay}"
+                                    TextLineBounds="Tight" />
+                                <Border Opacity="0.5">
                                     <TextBlock
-                                        x:Name="GroupLabel"
-                                        FontSize="16"
-                                        FontWeight="Bold"
+                                        x:Name="InlineLabelCount"
+                                        Grid.Row="0"
+                                        Margin="0 8 0 0"
                                         OpticalMarginAlignment="TrimSideBearings"
-                                        Text="{x:Bind ViewModel.FilterTitle, Mode=OneWay}"
+                                        Style="{StaticResource StatusBarTextStyle}"
+                                        Text="{x:Bind UpdateFontCountLabel(ViewModel.FontList), Mode=OneWay}"
                                         TextLineBounds="Tight" />
-                                    <Border Opacity="0.5">
-                                        <TextBlock
-                                            x:Name="InlineLabelCount"
-                                            Grid.Row="0"
-                                            Margin="0 8 0 0"
-                                            OpticalMarginAlignment="TrimSideBearings"
-                                            Style="{StaticResource StatusBarTextStyle}"
-                                            Text="{x:Bind UpdateFontCountLabel(ViewModel.FontList), Mode=OneWay}"
-                                            TextLineBounds="Tight" />
-                                    </Border>
-                                </StackPanel>
+                                </Border>
+                            </StackPanel>
 
-                                <Button.Flyout>
-                                    <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
-                                        <MenuFlyout.MenuFlyoutPresenterStyle>
-                                            <Style TargetType="MenuFlyoutPresenter">
-                                                <Setter Property="FontSize" Value="16" />
-                                                <Setter Property="CornerRadius" Value="0" />
-                                                <Setter Property="Margin" Value="0 -4 0 0" />
-                                                <Setter Property="Padding" Value="0" />
-                                                <!--<Setter Property="BorderBrush" Value="{ThemeResource SystemAccentColor}" />-->
-                                                <Setter Property="BorderThickness" Value="1" />
-                                            </Style>
-                                        </MenuFlyout.MenuFlyoutPresenterStyle>
+                            <Button.Flyout>
+                                <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
+                                    <MenuFlyout.MenuFlyoutPresenterStyle>
+                                        <Style TargetType="MenuFlyoutPresenter">
+                                            <Setter Property="FontSize" Value="16" />
+                                            <Setter Property="CornerRadius" Value="0" />
+                                            <Setter Property="Margin" Value="0 -4 0 0" />
+                                            <Setter Property="Padding" Value="0" />
+                                            <!--<Setter Property="BorderBrush" Value="{ThemeResource SystemAccentColor}" />-->
+                                            <Setter Property="BorderThickness" Value="1" />
+                                        </Style>
+                                    </MenuFlyout.MenuFlyoutPresenterStyle>
+                                    <MenuFlyoutItem
+                                        x:Uid="OptionAllFonts"
+                                        Click="Filter_Click"
+                                        FontSize="16"
+                                        Tag="0" />
+                                    <MenuFlyoutItem
+                                        x:Uid="OptionSerifFonts"
+                                        Click="Filter_Click"
+                                        FontSize="16"
+                                        Tag="4" />
+                                    <MenuFlyoutItem
+                                        x:Uid="OptionSansSerifFonts"
+                                        Click="Filter_Click"
+                                        FontSize="16"
+                                        Tag="5" />
+                                    <MenuFlyoutItem
+                                        x:Uid="OptionSymbolFonts"
+                                        Click="Filter_Click"
+                                        FontSize="16"
+                                        Tag="1" />
+                                    <MenuFlyoutSubItem x:Uid="OptionMoreFilters" FontSize="16">
                                         <MenuFlyoutItem
-                                            x:Uid="OptionAllFonts"
+                                            x:Uid="OptionColorFonts"
                                             Click="Filter_Click"
                                             FontSize="16"
-                                            Tag="0" />
+                                            Tag="10" />
                                         <MenuFlyoutItem
-                                            x:Uid="OptionSerifFonts"
+                                            x:Uid="OptionDecorativeFonts"
                                             Click="Filter_Click"
                                             FontSize="16"
-                                            Tag="4" />
+                                            Tag="8" />
                                         <MenuFlyoutItem
-                                            x:Uid="OptionSansSerifFonts"
+                                            x:Uid="OptionScriptFonts"
                                             Click="Filter_Click"
                                             FontSize="16"
-                                            Tag="5" />
+                                            Tag="9" />
                                         <MenuFlyoutItem
-                                            x:Uid="OptionSymbolFonts"
+                                            x:Uid="OptionMonospacedFonts"
                                             Click="Filter_Click"
                                             FontSize="16"
-                                            Tag="1" />
-                                        <MenuFlyoutSubItem x:Uid="OptionMoreFilters" FontSize="16">
-                                            <MenuFlyoutItem
-                                                x:Uid="OptionColorFonts"
-                                                Click="Filter_Click"
-                                                FontSize="16"
-                                                Tag="10" />
-                                            <MenuFlyoutItem
-                                                x:Uid="OptionDecorativeFonts"
-                                                Click="Filter_Click"
-                                                FontSize="16"
-                                                Tag="8" />
-                                            <MenuFlyoutItem
-                                                x:Uid="OptionScriptFonts"
-                                                Click="Filter_Click"
-                                                FontSize="16"
-                                                Tag="9" />
-                                            <MenuFlyoutItem
-                                                x:Uid="OptionMonospacedFonts"
-                                                Click="Filter_Click"
-                                                FontSize="16"
-                                                Tag="3" />
-                                            <MenuFlyoutSeparator x:Name="FontSourceSeperator" />
-                                            <MenuFlyoutItem
-                                                x:Name="CloudFontsOption"
-                                                x:Uid="OptionCloudFonts"
-                                                Click="Filter_Click"
-                                                FontSize="16"
-                                                Tag="7" />
-                                            <MenuFlyoutItem
-                                                x:Name="AppxOption"
-                                                x:Uid="OptionAppxFonts"
-                                                Click="Filter_Click"
-                                                FontSize="16"
-                                                Tag="6" />
-                                        </MenuFlyoutSubItem>
-                                        <MenuFlyoutSeparator />
+                                            Tag="3" />
+                                        <MenuFlyoutSeparator x:Name="FontSourceSeperator" />
                                         <MenuFlyoutItem
-                                            x:Uid="OptionImportedFonts"
+                                            x:Name="CloudFontsOption"
+                                            x:Uid="OptionCloudFonts"
                                             Click="Filter_Click"
                                             FontSize="16"
-                                            Tag="2" />
-                                    </MenuFlyout>
-                                </Button.Flyout>
-                            </Button>
-
-                        </Grid>
-
-                        <!--  Font List Grid  -->
-                        <Grid
-                            x:Name="FontListGrid"
-                            Grid.Row="2"
-                            Loading="FontListGrid_Loading">
-
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-
-                            <!--  User Collection Control Panel  -->
-                            <Grid
-                                x:Name="CollectionControlRow"
-                                Grid.Row="1"
-                                Visibility="{x:Bind core:Converters.IsNotNullToVis(ViewModel.SelectedCollection), Mode=OneWay, FallbackValue=Collapsed}">
-                                <Border x:Name="CollectionControlBackground" Background="{ThemeResource DefaultAcrylicBrush}" />
-                                <StackPanel
-                                    x:Name="CollectionControlItems"
-                                    Padding="0,0"
-                                    HorizontalAlignment="Center"
-                                    Orientation="Horizontal"
-                                    Spacing="12">
-                                    <AppBarButton
-                                        x:Uid="RenameCollectionButton"
-                                        Height="48"
-                                        Click="RenameFontCollection_Click"
-                                        Icon="Rename"
-                                        ToolTipService.Placement="Bottom" />
-                                    <AppBarButton
-                                        x:Uid="DeleteCollectionButton"
-                                        Height="48"
-                                        Click="DeleteCollection_Click"
-                                        Icon="Delete"
-                                        ToolTipService.Placement="Bottom" />
-                                </StackPanel>
-                            </Grid>
-
-                            <TextBlock
-                                x:Name="ImportFontHelpBlock"
-                                x:Uid="ImportFontHelpBlock"
-                                Grid.Row="2"
-                                Margin="12"
-                                FontSize="13"
-                                Opacity="0.7"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Visibility="Collapsed" />
-
-                            <SemanticZoom x:Name="FontsSemanticZoom" Grid.Row="2">
-                                <SemanticZoom.ZoomedInView>
-                                    <ListView
-                                        x:Name="LstFontFamily"
-                                        IsItemClickEnabled="False"
-                                        IsSwipeEnabled="False"
-                                        ItemTemplate="{StaticResource FontListItemTemplate}"
-                                        ItemsSource="{Binding Source={StaticResource GroupedFontList}}"
-                                        SelectedValuePath="Name"
-                                        SelectionChanged="LstFontFamily_SelectionChanged"
-                                        SelectionMode="Single"
-                                        ShowsScrollingPlaceholders="False">
-
-                                        <ListView.ItemContainerTransitions>
-                                            <TransitionCollection />
-                                        </ListView.ItemContainerTransitions>
-
-                                        <ListView.Resources>
-                                            <Style BasedOn="{StaticResource ListViewItemRevealStyle}" TargetType="ListViewItem">
-                                                <Setter Property="HorizontalAlignment" Value="Stretch" />
-                                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                                                <Setter Property="BorderThickness" Value="0 0.5 1 0.5" />
-                                                <Setter Property="BorderBrush" Value="{ThemeResource ButtonRevealBorderBrush}" />
-                                            </Style>
-                                        </ListView.Resources>
-
-                                        <ListView.GroupStyle>
-                                            <GroupStyle HeaderContainerStyle="{ThemeResource FontListHeaderItem}" HidesIfEmpty="True">
-                                                <GroupStyle.HeaderTemplate>
-                                                    <DataTemplate>
-                                                        <GridViewItem
-                                                            x:Name="Root"
-                                                            Margin="0"
-                                                            Padding="0"
-                                                            HorizontalAlignment="Stretch"
-                                                            HorizontalContentAlignment="Stretch"
-                                                            BorderBrush="{ThemeResource ButtonRevealBorderBrush}"
-                                                            BorderThickness="1"
-                                                            IsHitTestVisible="True"
-                                                            Style="{StaticResource GridViewItemRevealStyle}">
-                                                            <Grid>
-                                                                <Border
-                                                                    Margin="15,0"
-                                                                    BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
-                                                                    BorderThickness="0,0,0,1"
-                                                                    Opacity="0.2" />
-                                                                <TextBlock
-                                                                    Padding="15,8,15,10"
-                                                                    HorizontalAlignment="Stretch"
-                                                                    VerticalAlignment="Stretch"
-                                                                    FontSize="30"
-                                                                    FontWeight="SemiBold"
-                                                                    Text="{Binding Key}" />
-                                                            </Grid>
-                                                        </GridViewItem>
-                                                    </DataTemplate>
-                                                </GroupStyle.HeaderTemplate>
-                                            </GroupStyle>
-                                        </ListView.GroupStyle>
-                                    </ListView>
-                                </SemanticZoom.ZoomedInView>
-                                <SemanticZoom.ZoomedOutView>
-                                    <GridView
-                                        x:Name="ZoomGridView"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        ItemContainerStyle="{StaticResource GridViewItemRevealStyle}"
-                                        ItemsSource="{Binding CollectionGroups, Source={StaticResource GroupedFontList}}">
-                                        <GridView.ItemTemplate>
-                                            <DataTemplate>
-                                                <Border Width="64" Height="64">
-                                                    <TextBlock
-                                                        HorizontalAlignment="Center"
-                                                        VerticalAlignment="Center"
-                                                        FontSize="32"
-                                                        FontWeight="Bold"
-                                                        Opacity="{Binding Group.Count, Converter={StaticResource ZoomBackgroundConverter}}"
-                                                        Text="{Binding Group.Key}" />
-                                                </Border>
-                                            </DataTemplate>
-                                        </GridView.ItemTemplate>
-                                    </GridView>
-                                </SemanticZoom.ZoomedOutView>
-                            </SemanticZoom>
-                        </Grid>
-
-                        <Grid
-                            Grid.Row="3"
-                            Height="32"
-                            HorizontalAlignment="Right"
-                            Background="{x:Bind PaneRoot.Background, Mode=OneWay}">
-
-                            <AppBarButton
-                                x:Name="TitleHidePaneButton"
-                                x:Uid="BtnHidePane"
-                                Grid.Column="1"
-                                Width="45"
-                                VerticalAlignment="Stretch"
-                                BorderThickness="0"
-                                Click="TogglePane_Click">
-                                <FontIcon
-                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                    FontSize="18"
-                                    Glyph="&#xE127;" />
-                            </AppBarButton>
-
-                            <AppBarButton
-                                x:Name="TitleShowPaneButton"
-                                x:Uid="BtnShowPane"
-                                Grid.Column="1"
-                                Width="45"
-                                VerticalAlignment="Stretch"
-                                BorderBrush="Transparent"
-                                BorderThickness="0"
-                                Click="TogglePane_Click"
-                                Visibility="Collapsed">
-                                <FontIcon
-                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                    FontSize="18"
-                                    Glyph="&#xE126;" />
-                            </AppBarButton>
-
-                        </Grid>
+                                            Tag="7" />
+                                        <MenuFlyoutItem
+                                            x:Name="AppxOption"
+                                            x:Uid="OptionAppxFonts"
+                                            Click="Filter_Click"
+                                            FontSize="16"
+                                            Tag="6" />
+                                    </MenuFlyoutSubItem>
+                                    <MenuFlyoutSeparator />
+                                    <MenuFlyoutItem
+                                        x:Uid="OptionImportedFonts"
+                                        Click="Filter_Click"
+                                        FontSize="16"
+                                        Tag="2" />
+                                </MenuFlyout>
+                            </Button.Flyout>
+                        </Button>
 
                     </Grid>
+
+                    <!--  Font List Grid  -->
+                    <Grid
+                        x:Name="FontListGrid"
+                        Grid.Row="2"
+                        Loading="FontListGrid_Loading">
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <!--  User Collection Control Panel  -->
+                        <Grid
+                            x:Name="CollectionControlRow"
+                            Grid.Row="1"
+                            Visibility="{x:Bind core:Converters.IsNotNullToVis(ViewModel.SelectedCollection), Mode=OneWay, FallbackValue=Collapsed}">
+                            <Border x:Name="CollectionControlBackground" Background="{ThemeResource DefaultAcrylicBrush}" />
+                            <StackPanel
+                                x:Name="CollectionControlItems"
+                                Padding="0,0"
+                                HorizontalAlignment="Center"
+                                Orientation="Horizontal"
+                                Spacing="12">
+                                <AppBarButton
+                                    x:Uid="RenameCollectionButton"
+                                    Height="48"
+                                    Click="RenameFontCollection_Click"
+                                    Icon="Rename"
+                                    ToolTipService.Placement="Bottom" />
+                                <AppBarButton
+                                    x:Uid="DeleteCollectionButton"
+                                    Height="48"
+                                    Click="DeleteCollection_Click"
+                                    Icon="Delete"
+                                    ToolTipService.Placement="Bottom" />
+                            </StackPanel>
+                        </Grid>
+
+                        <TextBlock
+                            x:Name="ImportFontHelpBlock"
+                            x:Uid="ImportFontHelpBlock"
+                            Grid.Row="2"
+                            Margin="12"
+                            FontSize="13"
+                            Opacity="0.7"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Visibility="Collapsed" />
+
+                        <SemanticZoom x:Name="FontsSemanticZoom" Grid.Row="2">
+                            <SemanticZoom.ZoomedInView>
+                                <ListView
+                                    x:Name="LstFontFamily"
+                                    IsItemClickEnabled="False"
+                                    IsSwipeEnabled="False"
+                                    ItemTemplate="{StaticResource FontListItemTemplate}"
+                                    ItemsSource="{Binding Source={StaticResource GroupedFontList}}"
+                                    SelectedValuePath="Name"
+                                    SelectionChanged="LstFontFamily_SelectionChanged"
+                                    SelectionMode="Single"
+                                    ShowsScrollingPlaceholders="False">
+
+                                    <ListView.ItemContainerTransitions>
+                                        <TransitionCollection />
+                                    </ListView.ItemContainerTransitions>
+
+                                    <ListView.Resources>
+                                        <Style BasedOn="{StaticResource ListViewItemRevealStyle}" TargetType="ListViewItem">
+                                            <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                            <Setter Property="BorderThickness" Value="0 0.5 1 0.5" />
+                                            <Setter Property="BorderBrush" Value="{ThemeResource ButtonRevealBorderBrush}" />
+                                        </Style>
+                                    </ListView.Resources>
+
+                                    <ListView.GroupStyle>
+                                        <GroupStyle HeaderContainerStyle="{ThemeResource FontListHeaderItem}" HidesIfEmpty="True">
+                                            <GroupStyle.HeaderTemplate>
+                                                <DataTemplate>
+                                                    <GridViewItem
+                                                        x:Name="Root"
+                                                        Margin="0"
+                                                        Padding="0"
+                                                        HorizontalAlignment="Stretch"
+                                                        HorizontalContentAlignment="Stretch"
+                                                        BorderBrush="{ThemeResource ButtonRevealBorderBrush}"
+                                                        BorderThickness="1"
+                                                        IsHitTestVisible="True"
+                                                        Style="{StaticResource GridViewItemRevealStyle}">
+                                                        <Grid>
+                                                            <Border
+                                                                Margin="15,0"
+                                                                BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
+                                                                BorderThickness="0,0,0,1"
+                                                                Opacity="0.2" />
+                                                            <TextBlock
+                                                                Padding="15,8,15,10"
+                                                                HorizontalAlignment="Stretch"
+                                                                VerticalAlignment="Stretch"
+                                                                FontSize="30"
+                                                                FontWeight="SemiBold"
+                                                                Text="{Binding Key}" />
+                                                        </Grid>
+                                                    </GridViewItem>
+                                                </DataTemplate>
+                                            </GroupStyle.HeaderTemplate>
+                                        </GroupStyle>
+                                    </ListView.GroupStyle>
+                                </ListView>
+                            </SemanticZoom.ZoomedInView>
+                            <SemanticZoom.ZoomedOutView>
+                                <GridView
+                                    x:Name="ZoomGridView"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    ItemContainerStyle="{StaticResource GridViewItemRevealStyle}"
+                                    ItemsSource="{Binding CollectionGroups, Source={StaticResource GroupedFontList}}">
+                                    <GridView.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Width="64" Height="64">
+                                                <TextBlock
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"
+                                                    FontSize="32"
+                                                    FontWeight="Bold"
+                                                    Opacity="{Binding Group.Count, Converter={StaticResource ZoomBackgroundConverter}}"
+                                                    Text="{Binding Group.Key}" />
+                                            </Border>
+                                        </DataTemplate>
+                                    </GridView.ItemTemplate>
+                                </GridView>
+                            </SemanticZoom.ZoomedOutView>
+                        </SemanticZoom>
+                    </Grid>
+
+                    <Grid
+                        Grid.Row="3"
+                        Height="32"
+                        HorizontalAlignment="Right"
+                        Background="{x:Bind PaneRoot.Background, Mode=OneWay}">
+
+                        <AppBarButton
+                            x:Name="TitleHidePaneButton"
+                            x:Uid="BtnHidePane"
+                            Grid.Column="1"
+                            Width="45"
+                            VerticalAlignment="Stretch"
+                            BorderThickness="0"
+                            Click="TogglePane_Click">
+                            <FontIcon
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                FontSize="18"
+                                Glyph="&#xE127;" />
+                        </AppBarButton>
+
+                        <AppBarButton
+                            x:Name="TitleShowPaneButton"
+                            x:Uid="BtnShowPane"
+                            Grid.Column="1"
+                            Width="45"
+                            VerticalAlignment="Stretch"
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
+                            Click="TogglePane_Click"
+                            Visibility="Collapsed">
+                            <FontIcon
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                FontSize="18"
+                                Glyph="&#xE126;" />
+                        </AppBarButton>
+
+                    </Grid>
+
+                </Grid>
             </SplitView.Pane>
 
             <!--  FontMap Grid  -->

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -24,11 +24,6 @@
             IsSourceGrouped="True"
             Source="{Binding GroupedFontList}" />
 
-        <BackEase
-            x:Key="BackOut4"
-            Amplitude="0.4"
-            EasingMode="EaseOut" />
-
     </Page.Resources>
 
     <Grid
@@ -38,9 +33,6 @@
         DragOver="Grid_DragOver"
         Drop="Grid_Drop"
         KeyDown="LayoutRoot_KeyDown">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="{StaticResource PaneGridWidth}" />
             <ColumnDefinition Width="*" />
@@ -134,7 +126,6 @@
                                     <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
                                         <MenuFlyout.MenuFlyoutPresenterStyle>
                                             <Style TargetType="MenuFlyoutPresenter">
-                                                <Setter Property="RequestedTheme" Value="Default" />
                                                 <Setter Property="FontSize" Value="16" />
                                                 <Setter Property="CornerRadius" Value="0" />
                                                 <Setter Property="Margin" Value="0 -4 0 0" />
@@ -322,7 +313,7 @@
                                                         VerticalAlignment="Center"
                                                         FontSize="32"
                                                         FontWeight="Bold"
-                                                        Foreground="{Binding Group.Count, Converter={StaticResource ZoomBackgroundConverter}}"
+                                                        Opacity="{Binding Group.Count, Converter={StaticResource ZoomBackgroundConverter}}"
                                                         Text="{Binding Group.Key}" />
                                                 </Border>
                                             </DataTemplate>
@@ -338,7 +329,7 @@
                     <Grid
                         x:Name="PaneStatusBar"
                         Grid.Row="1"
-                        Background="{StaticResource AltHostBrush}">
+                        Background="{StaticResource StatusBarBrush}">
                         <Grid.Resources>
                             <Style BasedOn="{StaticResource StatusBarTextStyle}" TargetType="TextBlock" />
                         </Grid.Resources>

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -8,7 +8,7 @@
     xmlns:helpers="using:CharacterMap.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:views="using:CharacterMap.Views"
-    xmlns:wct="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:wct="using:Microsoft.Toolkit.Uwp.UI.Controls" xmlns:controls1="using:Microsoft.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     DataContext="{Binding Source={StaticResource Locator}, Path=Main}"
     mc:Ignorable="d">
@@ -44,18 +44,17 @@
             Grid.ColumnSpan="2"
             VerticalAlignment="Top"
             Canvas.ZIndex="1">
-            <Grid>
-
+            <StackPanel Orientation="Horizontal">
                 <ToggleButton
                     x:Uid="ToggleFullScreenModeButton"
+                    Width="45"
                     Command="{Binding CommandToggleFullScreen}"
                     Foreground="{ThemeResource AppBarItemForegroundThemeBrush}"
                     Style="{StaticResource IconToggleButtonStyle}"
                     ToolTipService.Placement="Right">
                     <FontIcon FontSize="14" Glyph="&#xE740;" />
                 </ToggleButton>
-
-            </Grid>
+            </StackPanel>
         </controls:XamlTitleBar>
 
         <!--  Main Content  -->
@@ -65,21 +64,14 @@
             Grid.ColumnSpan="3"
             DisplayMode="Inline"
             IsPaneOpen="True"
-            OpenPaneLength="{StaticResource SplitViewPaneWidth}"
-            PaneBackground="Transparent">
+            OpenPaneLength="{StaticResource SplitViewPaneWidth}">
             <SplitView.Pane>
-                <Grid x:Name="PaneRoot" Background="{StaticResource DefaultHostBrush}">
-
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition x:Name="StatusBarRow" Height="{StaticResource StatusBarGridHeight}" />
-                    </Grid.RowDefinitions>
-
-                    <Grid x:Name="PaneContentRoot">
+                <Grid x:Name="PaneRoot"  Background="{StaticResource DefaultHostBrush}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="{x:Bind TitleBar.TemplateSettings.GridHeight, Mode=OneWay}" />
                             <RowDefinition Height="{StaticResource TitleRowGridHeight}" />
                             <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
                         <!--  Pane Header Commands  -->
@@ -112,16 +104,35 @@
                                 Grid.Column="1"
                                 Height="{StaticResource TitleRowHeight}"
                                 Margin="0,0,0,0"
-                                Padding="12,6"
+                                Padding="12 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 HorizontalContentAlignment="Left"
+                                VerticalContentAlignment="Stretch"
                                 Background="Transparent"
-                                Content="{x:Bind ViewModel.FilterTitle, Mode=OneWay}"
-                                FontSize="16"
-                                FontWeight="Bold"
                                 Style="{StaticResource TransparentHintButton}"
                                 ToolTipService.Placement="Bottom">
+
+                                <StackPanel VerticalAlignment="Center" Orientation="Vertical">
+                                    <TextBlock
+                                        x:Name="GroupLabel"
+                                        FontSize="16"
+                                        FontWeight="Bold"
+                                        OpticalMarginAlignment="TrimSideBearings"
+                                        Text="{x:Bind ViewModel.FilterTitle, Mode=OneWay}"
+                                        TextLineBounds="Tight" />
+                                    <Border Opacity="0.5">
+                                        <TextBlock
+                                            x:Name="InlineLabelCount"
+                                            Grid.Row="0"
+                                            Margin="0 8 0 0"
+                                            OpticalMarginAlignment="TrimSideBearings"
+                                            Style="{StaticResource StatusBarTextStyle}"
+                                            Text="{x:Bind UpdateFontCountLabel(ViewModel.FontList), Mode=OneWay}"
+                                            TextLineBounds="Tight" />
+                                    </Border>
+                                </StackPanel>
+
                                 <Button.Flyout>
                                     <MenuFlyout Opening="MenuFlyout_Opening" Placement="BottomEdgeAlignedRight">
                                         <MenuFlyout.MenuFlyoutPresenterStyle>
@@ -131,7 +142,7 @@
                                                 <Setter Property="Margin" Value="0 -4 0 0" />
                                                 <Setter Property="Padding" Value="0" />
                                                 <!--<Setter Property="BorderBrush" Value="{ThemeResource SystemAccentColor}" />-->
-                                                <Setter Property="BorderThickness" Value="1 0 1 1" />
+                                                <Setter Property="BorderThickness" Value="1" />
                                             </Style>
                                         </MenuFlyout.MenuFlyoutPresenterStyle>
                                         <MenuFlyoutItem
@@ -209,10 +220,15 @@
 
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
 
-                            <Grid x:Name="CollectionControlRow" Visibility="{x:Bind core:Converters.IsNotNullToVis(ViewModel.SelectedCollection), Mode=OneWay, FallbackValue=Collapsed}">
+                            <!--  User Collection Control Panel  -->
+                            <Grid
+                                x:Name="CollectionControlRow"
+                                Grid.Row="1"
+                                Visibility="{x:Bind core:Converters.IsNotNullToVis(ViewModel.SelectedCollection), Mode=OneWay, FallbackValue=Collapsed}">
                                 <Border x:Name="CollectionControlBackground" Background="{ThemeResource DefaultAcrylicBrush}" />
                                 <StackPanel
                                     x:Name="CollectionControlItems"
@@ -238,14 +254,14 @@
                             <TextBlock
                                 x:Name="ImportFontHelpBlock"
                                 x:Uid="ImportFontHelpBlock"
-                                Grid.Row="1"
+                                Grid.Row="2"
                                 Margin="12"
                                 FontSize="13"
                                 Opacity="0.7"
                                 Style="{StaticResource CaptionTextBlockStyle}"
                                 Visibility="Collapsed" />
 
-                            <SemanticZoom x:Name="FontsSemanticZoom" Grid.Row="1">
+                            <SemanticZoom x:Name="FontsSemanticZoom" Grid.Row="2">
                                 <SemanticZoom.ZoomedInView>
                                     <ListView
                                         x:Name="LstFontFamily"
@@ -266,6 +282,8 @@
                                             <Style BasedOn="{StaticResource ListViewItemRevealStyle}" TargetType="ListViewItem">
                                                 <Setter Property="HorizontalAlignment" Value="Stretch" />
                                                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                                <Setter Property="BorderThickness" Value="0 0.5 1 0.5" />
+                                                <Setter Property="BorderBrush" Value="{ThemeResource ButtonRevealBorderBrush}" />
                                             </Style>
                                         </ListView.Resources>
 
@@ -279,19 +297,24 @@
                                                             Padding="0"
                                                             HorizontalAlignment="Stretch"
                                                             HorizontalContentAlignment="Stretch"
-                                                            IsHitTestVisible="True">
-                                                            <Border
-                                                                Margin="15,0"
-                                                                BorderBrush="#CCC"
-                                                                BorderThickness="0,0,0,1">
+                                                            BorderBrush="{ThemeResource ButtonRevealBorderBrush}"
+                                                            BorderThickness="1"
+                                                            IsHitTestVisible="True"
+                                                            Style="{StaticResource GridViewItemRevealStyle}">
+                                                            <Grid>
+                                                                <Border
+                                                                    Margin="15,0"
+                                                                    BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
+                                                                    BorderThickness="0,0,0,1"
+                                                                    Opacity="0.2" />
                                                                 <TextBlock
-                                                                    Padding="0,8,0,10"
+                                                                    Padding="15,8,15,10"
                                                                     HorizontalAlignment="Stretch"
                                                                     VerticalAlignment="Stretch"
                                                                     FontSize="30"
                                                                     FontWeight="SemiBold"
                                                                     Text="{Binding Key}" />
-                                                            </Border>
+                                                            </Grid>
                                                         </GridViewItem>
                                                     </DataTemplate>
                                                 </GroupStyle.HeaderTemplate>
@@ -304,6 +327,7 @@
                                         x:Name="ZoomGridView"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
+                                        ItemContainerStyle="{StaticResource GridViewItemRevealStyle}"
                                         ItemsSource="{Binding CollectionGroups, Source={StaticResource GroupedFontList}}">
                                         <GridView.ItemTemplate>
                                             <DataTemplate>
@@ -323,57 +347,45 @@
                             </SemanticZoom>
                         </Grid>
 
-                    </Grid>
+                        <Grid
+                            Grid.Row="3"
+                            Height="32"
+                            HorizontalAlignment="Right"
+                            Background="{x:Bind PaneRoot.Background, Mode=OneWay}">
 
-                    <!--  Pane Status Bar  -->
-                    <Grid
-                        x:Name="PaneStatusBar"
-                        Grid.Row="1"
-                        Background="{StaticResource StatusBarBrush}">
-                        <Grid.Resources>
-                            <Style BasedOn="{StaticResource StatusBarTextStyle}" TargetType="TextBlock" />
-                        </Grid.Resources>
+                            <AppBarButton
+                                x:Name="TitleHidePaneButton"
+                                x:Uid="BtnHidePane"
+                                Grid.Column="1"
+                                Width="45"
+                                VerticalAlignment="Stretch"
+                                BorderThickness="0"
+                                Click="TogglePane_Click">
+                                <FontIcon
+                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                    FontSize="18"
+                                    Glyph="&#xE127;" />
+                            </AppBarButton>
 
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
+                            <AppBarButton
+                                x:Name="TitleShowPaneButton"
+                                x:Uid="BtnShowPane"
+                                Grid.Column="1"
+                                Width="45"
+                                VerticalAlignment="Stretch"
+                                BorderBrush="Transparent"
+                                BorderThickness="0"
+                                Click="TogglePane_Click"
+                                Visibility="Collapsed">
+                                <FontIcon
+                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                    FontSize="18"
+                                    Glyph="&#xE126;" />
+                            </AppBarButton>
 
-                        <AppBarButton
-                            x:Name="HidePaneButton"
-                            x:Uid="BtnHidePane"
-                            Width="32"
-                            Margin="0 0 -6 0"
-                            VerticalAlignment="Stretch"
-                            Click="TogglePane_Click">
-                            <FontIcon
-                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                FontSize="16"
-                                Glyph="&#xE127;" />
-                        </AppBarButton>
-
-                        <AppBarButton
-                            x:Name="ShowPaneButton2"
-                            x:Uid="BtnShowPane"
-                            Width="32"
-                            Margin="0 0 -6 0"
-                            VerticalAlignment="Stretch"
-                            Click="TogglePane_Click"
-                            Visibility="Collapsed">
-                            <FontIcon
-                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                FontSize="16"
-                                Glyph="&#xE126;" />
-                        </AppBarButton>
-
-                        <TextBlock
-                            x:Name="FontFamilyCountLabel"
-                            Grid.Column="1"
-                            Text="{x:Bind UpdateFontCountLabel(ViewModel.FontList), Mode=OneWay}" />
+                        </Grid>
 
                     </Grid>
-
-                </Grid>
             </SplitView.Pane>
 
             <!--  FontMap Grid  -->
@@ -413,24 +425,9 @@
                                 Glyph="&#xE115;" />
                         </AppBarButton>
                     </views:FontMapView.TitleRightContent>
-                    <views:FontMapView.StatusBarLeftContent>
-                        <AppBarButton
-                            x:Name="ShowPaneButton"
-                            x:Uid="BtnShowPane"
-                            Width="32"
-                            Margin="0 0 -6 0"
-                            VerticalAlignment="Stretch"
-                            Click="TogglePane_Click"
-                            Visibility="Collapsed">
-                            <FontIcon
-                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                FontSize="16"
-                                Glyph="&#xE126;" />
-                        </AppBarButton>
-                    </views:FontMapView.StatusBarLeftContent>
                 </views:FontMapView>
-            </Grid>
 
+            </Grid>
         </SplitView>
 
         <!--  Settings  -->
@@ -522,9 +519,9 @@
                         <Setter Target="SplitView.IsPaneOpen" Value="False" />
                         <Setter Target="SplitView.DisplayMode" Value="Overlay" />
                         <Setter Target="OpenFontPaneButton.Visibility" Value="Visible" />
-                        <Setter Target="ShowPaneButton.Visibility" Value="Collapsed" />
-                        <Setter Target="ShowPaneButton2.Visibility" Value="Collapsed" />
-                        <Setter Target="HidePaneButton.Visibility" Value="Collapsed" />
+                        <Setter Target="TitleHidePaneButton.Visibility" Value="Collapsed" />
+                        <Setter Target="TitleShowPaneButton.Visibility" Value="Collapsed" />
+                        <Setter Target="PaneRoot.Background" Value="{ThemeResource SystemChromeMediumColor}" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="CollapsedViewState">
@@ -532,15 +529,17 @@
                         <Setter Target="SplitView.IsPaneOpen" Value="False" />
                         <Setter Target="SplitView.DisplayMode" Value="Overlay" />
                         <Setter Target="OpenFontPaneButton.Visibility" Value="Visible" />
-                        <Setter Target="ShowPaneButton.Visibility" Value="Visible" />
-                        <Setter Target="ShowPaneButton2.Visibility" Value="Visible" />
-                        <Setter Target="HidePaneButton.Visibility" Value="Collapsed" />
+                        <Setter Target="TitleHidePaneButton.Visibility" Value="Collapsed" />
+                        <Setter Target="TitleShowPaneButton.Visibility" Value="Visible" />
+                        <Setter Target="PaneRoot.Background" Value="{ThemeResource SystemChromeMediumColor}" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="DefaultViewState">
                     <VisualState.Setters>
                         <Setter Target="SplitView.IsPaneOpen" Value="True" />
                         <Setter Target="SplitView.DisplayMode" Value="Inline" />
+                        <Setter Target="TitleHidePaneButton.Visibility" Value="Visible" />
+                        <Setter Target="TitleShowPaneButton.Visibility" Value="Collapsed" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -549,11 +548,19 @@
                     <VisualState.Setters>
                         <Setter Target="SplitView.Opacity" Value="0" />
                         <Setter Target="SplitView.IsEnabled" Value="False" />
+                        <Setter Target="TitleHidePaneButton.IsEnabled" Value="False" />
+                        <Setter Target="TitleShowPaneButton.IsEnabled" Value="False" />
+                        <Setter Target="TitleHidePaneButton.Opacity" Value="0" />
+                        <Setter Target="TitleShowPaneButton.Opacity" Value="0" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FontsFailedState">
                     <VisualState.Setters>
                         <Setter Target="SplitView.Visibility" Value="Collapsed" />
+                        <Setter Target="TitleHidePaneButton.IsEnabled" Value="False" />
+                        <Setter Target="TitleShowPaneButton.IsEnabled" Value="False" />
+                        <Setter Target="TitleHidePaneButton.Opacity" Value="0" />
+                        <Setter Target="TitleShowPaneButton.Opacity" Value="0" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FontsLoadedState" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -103,7 +103,7 @@ namespace CharacterMap.Views
                     {
                         LstFontFamily.SelectedItem = ViewModel.SelectedFont;
                         if (ViewModel.Settings.UseSelectionAnimations)
-                            Composition.PlayEntrance(FontTitleBlock, 0, 0, 80);
+                            Composition.PlayEntrance(FontMap.FontTitleBlock, 0, 0, 80);
                     }
 
                     break;
@@ -180,8 +180,8 @@ namespace CharacterMap.Views
                             OpenFontPaneButton,
                             FontListFilter,
                             OpenFontButton,
-                            FontTitleBlock,
-                            SearchBox,
+                            FontMap.FontTitleBlock,
+                            FontMap.SearchBox,
                             BtnSettings
                         },
                         new List<UIElement>
@@ -194,9 +194,7 @@ namespace CharacterMap.Views
                         });
                 }
             }
-
         }
-
 
         private void ViewModel_FontListCreated(object sender, EventArgs e)
         {
@@ -289,14 +287,6 @@ namespace CharacterMap.Views
         {
             if (fontList != null)
                 return Localization.Get("StatusBarFontCount", fontList.Count);
-
-            return string.Empty;
-        }
-
-        private string UpdateCharacterCountLabel(FontVariant variant)
-        {
-            if (variant != null)
-                return Localization.Get("StatusBarCharacterCount", variant.Characters.Count);
 
             return string.Empty;
         }
@@ -435,33 +425,6 @@ namespace CharacterMap.Views
             }
         }
 
-        private async void PickFonts()
-        {
-            var picker = new FileOpenPicker();
-            foreach (var format in FontFinder.SupportedFormats)
-                picker.FileTypeFilter.Add(format);
-
-            picker.CommitButtonText = Localization.Get("FilePickerConfirm");
-            var files = await picker.PickMultipleFilesAsync();
-            if (files.Any())
-            {
-                ViewModel.IsLoadingFonts = true;
-                try
-                {
-                    if (await FontFinder.ImportFontsAsync(files.ToList()) is FontImportResult result
-                        && result.Imported.Count > 0)
-                    {
-                        ViewModel.RefreshFontList();
-                        ViewModel.TrySetSelectionFromImport(result);
-                    }
-                }
-                finally
-                {
-                    ViewModel.IsLoadingFonts = false;
-                }
-            }
-        }
-
         private async void OpenFont()
         {
             var picker = new FileOpenPicker();
@@ -552,6 +515,7 @@ namespace CharacterMap.Views
         public FontMapView GetFontMap() => FontMap;
 
         public GridLength GetTitleBarHeight() => TitleBar.TemplateSettings.GridHeight;
+
 
 
 

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -94,7 +94,12 @@ namespace CharacterMap.Views
                         return;
 
                     if (ViewModel.Settings.UseSelectionAnimations)
+                    {
                         Composition.PlayEntrance(LstFontFamily, 66, 100);
+                        Composition.PlayEntrance(GroupLabel, 0, 0, 80);
+                        if (InlineLabelCount.Visibility == Visibility.Visible)
+                            Composition.PlayEntrance(InlineLabelCount, 83, 0, 80);
+                    }
 
                     break;
 
@@ -103,7 +108,11 @@ namespace CharacterMap.Views
                     {
                         LstFontFamily.SelectedItem = ViewModel.SelectedFont;
                         if (ViewModel.Settings.UseSelectionAnimations)
-                            Composition.PlayEntrance(FontMap.FontTitleBlock, 0, 0, 80);
+                        {
+                            Composition.PlayEntrance(FontMap.FontTitleBlock, 0);
+                            Composition.PlayEntrance(FontMap.CharGridHeader, 83);
+                            Composition.PlayEntrance(FontMap.TxtPreviewViewBox, 83);
+                        }
                     }
 
                     break;
@@ -541,7 +550,7 @@ namespace CharacterMap.Views
 
         private void Grid_Loading(FrameworkElement sender, object args)
         {
-            Composition.SetThemeShadow(sender, 40, PaneContentRoot);
+            Composition.SetThemeShadow(sender, 40, PaneRoot);
         }
 
         private void FontListGrid_Loading(FrameworkElement sender, object args)

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml
@@ -157,7 +157,11 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Border Grid.RowSpan="2" Background="{StaticResource DefaultHostBrush}" />
+        <Border
+            x:Name="TitleBackground"
+            Grid.RowSpan="2"
+            Margin="0 0 0 -10"
+            Background="{StaticResource DefaultHostBrush}" />
 
         <Grid
             x:Name="HeaderGrid"
@@ -185,6 +189,7 @@
 
         <Grid
             x:Name="ContentPanel"
+            CornerRadius="8 8 0 0"
             Grid.Row="2"
             ColumnSpacing="24"
             Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml
@@ -148,13 +148,13 @@
 
     </UserControl.Resources>
 
-    <Grid x:Name="LayoutRoot" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid x:Name="LayoutRoot">
 
         <Grid.RowDefinitions>
             <RowDefinition Height="{x:Bind TitleBarHeight, Mode=OneWay}" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
-            <RowDefinition Height="AUto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Border Grid.RowSpan="2" Background="{StaticResource DefaultHostBrush}" />
@@ -162,8 +162,7 @@
         <Grid
             x:Name="HeaderGrid"
             Grid.Row="1"
-            Height="45"
-            Loading="HeaderGrid_Loading">
+            Height="{StaticResource TitleRowHeight}">
             <TextBlock
                 x:Uid="PrintViewTitle"
                 Margin="20 0"
@@ -175,8 +174,8 @@
             <AppBarButton
                 x:Name="BtnClose"
                 x:Uid="BtnClose"
-                Width="45"
-                Height="45"
+                Width="{StaticResource TitleRowHeight}"
+                Height="{StaticResource TitleRowHeight}"
                 HorizontalAlignment="Right"
                 Click="{x:Bind Hide}">
                 <SymbolIcon Symbol="Cancel" />
@@ -187,7 +186,9 @@
         <Grid
             x:Name="ContentPanel"
             Grid.Row="2"
-            ColumnSpacing="24">
+            ColumnSpacing="24"
+            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            Loading="ContentPanel_Loading">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="0.8*" />
                 <ColumnDefinition Width="*" />
@@ -196,6 +197,7 @@
             <!--  Requires it's own element to enable theme shadows  -->
             <Border x:Name="ContentBackground" Grid.ColumnSpan="2" />
 
+            <!--  Options Scroller  -->
             <ScrollViewer x:Name="ContentScroller">
                 <StackPanel
                     x:Name="OptionsPanel"
@@ -452,6 +454,7 @@
                 </StackPanel>
             </ScrollViewer>
 
+            <!--  Page Preview Container  -->
             <Grid
                 Grid.Column="1"
                 Margin="12"
@@ -510,18 +513,16 @@
             </Grid>
         </Grid>
 
-
         <Grid
             x:Name="BottomBar"
             Grid.Row="3"
-            Background="{ThemeResource SystemAccentColorDark2}">
+            Background="{StaticResource AltHostBrush}">
 
             <TextBlock
                 x:Name="BottomLabel"
                 Margin="12 0"
                 VerticalAlignment="Center"
                 FontSize="12"
-                Foreground="White"
                 TextLineBounds="Tight">
                 <Run Text="{x:Bind GetPageRangeLabel(ViewModel.FirstPage, ViewModel.PagesToPrint), Mode=OneWay}" />
             </TextBlock>
@@ -531,7 +532,6 @@
                 Margin="8"
                 HorizontalAlignment="Right"
                 Orientation="Horizontal"
-                RequestedTheme="Dark"
                 Spacing="8">
                 <Button
                     x:Name="BtnContinue"

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml
@@ -189,10 +189,10 @@
 
         <Grid
             x:Name="ContentPanel"
-            CornerRadius="8 8 0 0"
             Grid.Row="2"
             ColumnSpacing="24"
             Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            CornerRadius="8 8 0 0"
             Loading="ContentPanel_Loading">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="0.8*" />

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml
@@ -15,6 +15,7 @@
     d:DesignHeight="720"
     d:DesignWidth="1280"
     Background="Transparent"
+    TabFocusNavigation="Cycle"
     mc:Ignorable="d">
 
     <UserControl.Resources>
@@ -147,28 +148,29 @@
 
     </UserControl.Resources>
 
-    <Grid x:Name="LayoutRoot">
+    <Grid x:Name="LayoutRoot" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
         <Grid.RowDefinitions>
+            <RowDefinition Height="{x:Bind TitleBarHeight, Mode=OneWay}" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="AUto" />
         </Grid.RowDefinitions>
 
+        <Border Grid.RowSpan="2" Background="{StaticResource DefaultHostBrush}" />
+
         <Grid
             x:Name="HeaderGrid"
+            Grid.Row="1"
             Height="45"
-            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
-            Loading="HeaderGrid_Loading"
-            RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(Settings), Mode=OneWay}">
+            Loading="HeaderGrid_Loading">
             <TextBlock
                 x:Uid="PrintViewTitle"
                 Margin="20 0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 FontSize="22"
-                FontWeight="SemiLight"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(Settings), Mode=OneWay}" />
+                FontWeight="Bold" />
 
             <AppBarButton
                 x:Name="BtnClose"
@@ -176,8 +178,7 @@
                 Width="45"
                 Height="45"
                 HorizontalAlignment="Right"
-                Click="{x:Bind Hide}"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(Settings), Mode=OneWay}">
+                Click="{x:Bind Hide}">
                 <SymbolIcon Symbol="Cancel" />
             </AppBarButton>
 
@@ -185,7 +186,7 @@
 
         <Grid
             x:Name="ContentPanel"
-            Grid.Row="1"
+            Grid.Row="2"
             ColumnSpacing="24">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="0.8*" />
@@ -193,10 +194,7 @@
             </Grid.ColumnDefinitions>
 
             <!--  Requires it's own element to enable theme shadows  -->
-            <Border
-                x:Name="ContentBackground"
-                Grid.ColumnSpan="2"
-                Background="{StaticResource DefaultAcrylicBrush}" />
+            <Border x:Name="ContentBackground" Grid.ColumnSpan="2" />
 
             <ScrollViewer x:Name="ContentScroller">
                 <StackPanel
@@ -488,8 +486,6 @@
                         <TextBlock VerticalAlignment="Center">
                             <Run x:Uid="PrintViewOfLabel" />
                             <Run Text="{x:Bind PageCount, Mode=OneWay}" />
-                            <!--<Run Text="(of" />
-                        <Run Text="{x:Bind PageCount, Mode=OneWay}" /><Run Text=")" />-->
                         </TextBlock>
                     </StackPanel>
 
@@ -517,7 +513,7 @@
 
         <Grid
             x:Name="BottomBar"
-            Grid.Row="2"
+            Grid.Row="3"
             Background="{ThemeResource SystemAccentColorDark2}">
 
             <TextBlock

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml.cs
@@ -310,7 +310,7 @@ namespace CharacterMap.Views
 
         private void ContentPanel_Loading(FrameworkElement sender, object args)
         {
-            Composition.SetThemeShadow(ContentPanel, 40, HeaderGrid);
+            Composition.SetThemeShadow(ContentPanel, 40, TitleBackground);
         }
 
 

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml.cs
@@ -308,9 +308,9 @@ namespace CharacterMap.Views
                 item.IsSelected = false;
         }
 
-        private void HeaderGrid_Loading(FrameworkElement sender, object args)
+        private void ContentPanel_Loading(FrameworkElement sender, object args)
         {
-            Composition.SetThemeShadow(HeaderGrid, 30, ContentPanel);
+            Composition.SetThemeShadow(ContentPanel, 40, HeaderGrid);
         }
 
 

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml.cs
@@ -28,6 +28,7 @@ namespace CharacterMap.Views
     {
         Border GetPresenter();
         FontMapView GetFontMap();
+        GridLength GetTitleBarHeight();
     }
 
     public sealed partial class PrintView : ViewBase
@@ -63,6 +64,13 @@ namespace CharacterMap.Views
             private set => Set(ref _canContinue, value);
         }
 
+        private GridLength _titleBarHeight = new GridLength(32);
+        public GridLength TitleBarHeight
+        {
+            get => _titleBarHeight;
+            set => Set(ref _titleBarHeight, value);
+        }
+
         public List<PrintLayout> Layouts { get; } = new List<PrintLayout>
         {
             PrintLayout.Grid,
@@ -90,6 +98,7 @@ namespace CharacterMap.Views
         public static void Show(IPrintPresenter presenter)
         {
             var view = new PrintView(presenter);
+            view.TitleBarHeight = presenter.GetTitleBarHeight();
             presenter.GetPresenter().Child = view;
             view.Show();
         }
@@ -119,6 +128,9 @@ namespace CharacterMap.Views
             this.Visibility = Visibility.Visible;
             UpdatePreview();
 
+            // Focus the close button to ensure keyboard focus is retained inside the panel
+            BtnClose.Focus(FocusState.Programmatic);
+
             ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
         }
@@ -128,6 +140,8 @@ namespace CharacterMap.Views
             if (_presenter == null)
                 return;
 
+            this.Bindings.StopTracking();
+
             ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
 
             _presenter.GetPresenter().Child = null;
@@ -136,12 +150,17 @@ namespace CharacterMap.Views
 
             _printHelper.UnregisterForPrinting();
             _printHelper.Clear();
+
         }
 
         private void StartShowAnimation()
         {
             if (!Composition.UISettings.AnimationsEnabled)
+            {
+                this.GetElementVisual().Opacity = 1;
+                this.GetElementVisual().Properties.InsertVector3(Composition.TRANSLATION, Vector3.Zero);
                 return;
+            }
 
             List<UIElement> elements = new List<UIElement> { this };
             elements.AddRange(OptionsPanel.Children);

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -58,34 +58,28 @@
     <!--
         Background="{ThemeResource SystemChromeHighColor}"
     -->
-    <Grid>
-        <Grid.Background>
-            <AcrylicBrush
-                win1903:TintLuminosityOpacity="0.3"
-                BackgroundSource="Backdrop"
-                FallbackColor="{ThemeResource SystemAltHighColor}"
-                TintColor="{ThemeResource SystemChromeGrayColor}"
-                TintOpacity="0.6" />
-        </Grid.Background>
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
         <Grid.RowDefinitions>
+            <RowDefinition Height="{x:Bind TitleBarHeight, Mode=OneWay}" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
+        <Border Grid.RowSpan="2" Background="{StaticResource DefaultHostBrush}" />
+
         <Grid
             x:Name="HeaderGrid"
-            Height="45"
-            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
-            RequestedTheme="{x:Bind core:Converters.ChooseThemeForAccent(Settings), Mode=OneWay}">
+            Grid.Row="1"
+            Height="45">
+
             <TextBlock
                 x:Uid="SettingsHeader"
                 Margin="20 0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 FontSize="22"
-                FontWeight="SemiLight"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(Settings), Mode=OneWay}" />
+                FontWeight="Bold" />
 
             <AppBarButton
                 x:Name="BtnClose"
@@ -93,14 +87,13 @@
                 Width="45"
                 Height="45"
                 HorizontalAlignment="Right"
-                Click="{x:Bind Hide}"
-                Foreground="{x:Bind core:Converters.GetForegroundBrush(Settings), Mode=OneWay}">
+                Click="{x:Bind Hide}">
                 <SymbolIcon Symbol="Cancel" />
             </AppBarButton>
 
         </Grid>
 
-        <ScrollViewer x:Name="ContentScroller" Grid.Row="1">
+        <ScrollViewer x:Name="ContentScroller" Grid.Row="2">
             <Grid
                 x:Name="ContentPanel"
                 ColumnSpacing="16"
@@ -234,22 +227,23 @@
                         <TextBlock x:Uid="FontListDisplayHeader" Style="{StaticResource HeaderStyle}" />
                         <TextBlock x:Uid="SettingsFontListDescription" Style="{StaticResource DescriptionStyle}" />
                         <RadioButton
-                            x:Name="UseSystemFont"
-                            x:Uid="RbUseSystemFont"
-                            Checked="UseSystemFont_Checked"
-                            GroupName="FontList" />
-                        <RadioButton
                             x:Name="UseActualFont"
                             x:Uid="RbUseActualFont"
                             Checked="UseActualFont_Checked"
                             GroupName="FontList" />
+                        <RadioButton
+                            x:Name="UseSystemFont"
+                            x:Uid="RbUseSystemFont"
+                            Checked="UseSystemFont_Checked"
+                            GroupName="FontList" />
+
 
                         <ListView
                             x:Name="LstFontFamily"
                             Width="256"
                             Margin="0 12 0 0"
                             HorizontalAlignment="Left"
-                            Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
+                            Background="{StaticResource DefaultHostBrush}"
                             IsHitTestVisible="False"
                             IsItemClickEnabled="False"
                             IsSwipeEnabled="False"
@@ -315,6 +309,10 @@
                         <TextBlock x:Uid="SettingsSimpleAnimationHeader" Style="{StaticResource HeaderStyle}" />
                         <TextBlock x:Uid="SettingsSimpleAnimationDescription" Style="{StaticResource DescriptionStyle}" />
                         <ToggleSwitch IsOn="{x:Bind Settings.UseSelectionAnimations, Mode=TwoWay}" />
+
+                        <TextBlock x:Uid="SettingsTransparencyHeader" Style="{StaticResource HeaderStyle}" />
+                        <TextBlock x:Uid="SettingsTransparencyDescription" Style="{StaticResource DescriptionStyle}" />
+                        <ToggleSwitch IsOn="{x:Bind Settings.IsTransparencyEnabled, Mode=TwoWay}" />
 
                         <win1903:StackPanel>
                             <win1903:TextBlock x:Uid="SettingsShadowsHeader" Style="{StaticResource HeaderStyle}" />

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -66,7 +66,11 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Border Grid.RowSpan="2" Background="{StaticResource DefaultHostBrush}" />
+        <Border
+            x:Name="TitleBackground"
+            Grid.RowSpan="2"
+            Margin="0 0 0 -10"
+            Background="{StaticResource DefaultHostBrush}" />
 
         <Grid
             x:Name="HeaderGrid"
@@ -96,7 +100,8 @@
         <ScrollViewer
             x:Name="ContentScroller"
             Grid.Row="2"
-            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            CornerRadius="8 8 0 0">
             <Grid
                 x:Name="ContentPanel"
                 ColumnSpacing="16"
@@ -160,6 +165,7 @@
                             Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
                             BorderBrush="{ThemeResource PivotNavButtonBackgroundThemeBrush}"
                             BorderThickness="1"
+                            CornerRadius="4"
                             Orientation="Horizontal">
                             <GridViewItem>
                                 <Grid
@@ -247,6 +253,7 @@
                             Margin="0 12 0 0"
                             HorizontalAlignment="Left"
                             Background="{StaticResource DefaultHostBrush}"
+                            CornerRadius="4"
                             IsHitTestVisible="False"
                             IsItemClickEnabled="False"
                             IsSwipeEnabled="False"
@@ -309,6 +316,7 @@
                     </StackPanel>
 
                     <StackPanel Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
+
                         <TextBlock x:Uid="SettingsSimpleAnimationHeader" Style="{StaticResource HeaderStyle}" />
                         <TextBlock x:Uid="SettingsSimpleAnimationDescription" Style="{StaticResource DescriptionStyle}" />
                         <ToggleSwitch IsOn="{x:Bind Settings.UseSelectionAnimations, Mode=TwoWay}" />

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -58,7 +58,7 @@
     <!--
         Background="{ThemeResource SystemChromeHighColor}"
     -->
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
 
         <Grid.RowDefinitions>
             <RowDefinition Height="{x:Bind TitleBarHeight, Mode=OneWay}" />
@@ -71,7 +71,7 @@
         <Grid
             x:Name="HeaderGrid"
             Grid.Row="1"
-            Height="45">
+            Height="{StaticResource TitleRowHeight}">
 
             <TextBlock
                 x:Uid="SettingsHeader"
@@ -93,7 +93,10 @@
 
         </Grid>
 
-        <ScrollViewer x:Name="ContentScroller" Grid.Row="2">
+        <ScrollViewer
+            x:Name="ContentScroller"
+            Grid.Row="2"
+            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
             <Grid
                 x:Name="ContentPanel"
                 ColumnSpacing="16"

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -419,7 +419,7 @@
                     <StackPanel x:Name="DeveloperPanel" Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
                         <TextBlock x:Uid="SettingsDevToolsGroupHeader" Style="{StaticResource SubheaderTextBlockStyle}" />
 
-                        <StackPanel Visibility="Collapsed">
+                        <StackPanel>
                             <TextBlock x:Uid="SettingsDevToolsDescription" Style="{StaticResource HeaderStyle}" />
                             <TextBlock x:Uid="SettingsDevToolsDescription" Style="{StaticResource DescriptionStyle}" />
                             <ToggleSwitch IsOn="{x:Bind Settings.ShowDevUtils, Mode=TwoWay}" />

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -151,7 +151,7 @@ namespace CharacterMap.Views
 
         private void View_Loading(FrameworkElement sender, object args)
         {
-            Composition.SetThemeShadow(ContentScroller, 40, HeaderGrid);
+            Composition.SetThemeShadow(ContentScroller, 40, TitleBackground);
 
             // Set the settings that can't be set with bindings
             switch (Settings.UserRequestedTheme)

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -84,6 +84,9 @@ namespace CharacterMap.Views
 
         public void Show(FontVariant variant, InstalledFont font)
         {
+            if (IsOpen)
+                return;
+
             StartShowAnimation();
             this.Visibility = Visibility.Visible;
 
@@ -148,10 +151,9 @@ namespace CharacterMap.Views
 
         private void View_Loading(FrameworkElement sender, object args)
         {
-            Composition.SetThemeShadow(HeaderGrid, 40, ContentScroller);
+            Composition.SetThemeShadow(ContentScroller, 40, HeaderGrid);
 
             // Set the settings that can't be set with bindings
-
             switch (Settings.UserRequestedTheme)
             {
                 case ElementTheme.Default:

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml.cs
@@ -43,6 +43,13 @@ namespace CharacterMap.Views
 
         public bool IsOpen { get; private set; }
 
+        private GridLength _titleBarHeight = new GridLength(32);
+        public GridLength TitleBarHeight
+        {
+            get => _titleBarHeight;
+            set => Set(ref _titleBarHeight, value);
+        }
+
         public List<GlyphAnnotation> Annotations { get; } = new List<GlyphAnnotation>
         {
             GlyphAnnotation.None,
@@ -216,6 +223,7 @@ namespace CharacterMap.Views
 
         public void SelectedLanguageToString(object selected) => 
             Settings.AppLanguage = selected is SupportedLanguage s ? s.LanguageID : "en-US";
+
 
 
 


### PR DESCRIPTION
![Screenshot 5](https://user-images.githubusercontent.com/2319473/78188484-356d5580-7468-11ea-8350-5d9e5f6450de.png)

So not sure if anyone actually wants this, but I did it for fun and it turned out to look quite nice, so throwing it out there. It does look better in person than screenshots! 

An attempt at merging Character Map with fluent design directions. No real layout changes involved, mostly brush changes with some small additional animation.

Support in the in-app settings to disable transparency if it causes any performance issues, though I haven't seen any on my 1.3Ghz Atom tablet from 4 years ago.

As ever, I still need to do a bit more testing and localisation before marking as ready, but open to feedback or complete rejection in the meantime 😅

### Light Theme
![Screenshot 1](https://user-images.githubusercontent.com/2319473/78187958-508b9580-7467-11ea-8960-826a655ac7e8.png)

### Dark Theme
![Screenshot 2](https://user-images.githubusercontent.com/2319473/78187960-51242c00-7467-11ea-8007-2bc4154523dc.png)

### Light Theme (no transparency)
![Screenshot 3](https://user-images.githubusercontent.com/2319473/78187963-51bcc280-7467-11ea-8456-c232ec851137.png)

### Dark Theme (no transparency)
![Screenshot 4](https://user-images.githubusercontent.com/2319473/78187966-52555900-7467-11ea-9c42-8ed90ad5c71e.png)
