### PR TITLE
Font Export & System Font Set notifications

### DIFF
--- a/CharacterMap/CharacterMap.CX/CharacterMap.CX.vcxproj
+++ b/CharacterMap/CharacterMap.CX/CharacterMap.CX.vcxproj
@@ -274,6 +274,7 @@
     <ClInclude Include="DWriteFontSet.h" />
     <ClInclude Include="DWriteFontSource.h" />
     <ClInclude Include="DWriteProperties.h" />
+    <ClInclude Include="FontFileData.h" />
     <ClInclude Include="GlyphImageFormat.h" />
     <ClInclude Include="GridViewHelper.h" />
     <ClInclude Include="PathData.h" />

--- a/CharacterMap/CharacterMap.CX/CharacterMap.CX.vcxproj.filters
+++ b/CharacterMap/CharacterMap.CX/CharacterMap.CX.vcxproj.filters
@@ -26,6 +26,7 @@
     <ClInclude Include="DWriteFontSet.h" />
     <ClInclude Include="PathData.h" />
     <ClInclude Include="GridViewHelper.h" />
+    <ClInclude Include="FontFileData.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/CharacterMap/CharacterMap.CX/FontFileData.h
+++ b/CharacterMap/CharacterMap.CX/FontFileData.h
@@ -1,0 +1,42 @@
+#pragma once
+
+using namespace Platform;
+using namespace Windows::Storage::Streams;
+using namespace Windows::Foundation::Collections;
+
+namespace CharacterMapCX
+{
+	public ref class FontFileData sealed
+	{
+	public:
+
+		property IBuffer^ Buffer
+		{
+			IBuffer^ get() { return m_buffer; }
+		}
+
+		property String^ FileName
+		{
+			String^ get() { return m_name;; }
+		}
+
+		virtual ~FontFileData()
+		{
+			m_buffer = nullptr;
+			m_name = nullptr;
+		}
+
+	internal:
+		FontFileData(IBuffer^ buffer, String^ name)
+		{
+			m_buffer = buffer;
+			m_name = name;
+		}
+
+	private:
+		inline FontFileData() { }
+
+		IBuffer^ m_buffer = nullptr;
+		String^ m_name = nullptr;
+	};
+}

--- a/CharacterMap/CharacterMap.CX/Interop.cpp
+++ b/CharacterMap/CharacterMap.CX/Interop.cpp
@@ -7,12 +7,16 @@
 #include "SVGGeometrySink.h"
 #include "PathData.h"
 #include "Windows.h"
+#include <concurrent_vector.h>
 
 using namespace Microsoft::WRL;
 using namespace CharacterMapCX;
+using namespace Windows::Storage;
 using namespace Windows::Storage::Streams;
 using namespace Platform::Collections;
 using namespace Windows::Foundation::Numerics;
+using namespace concurrency;
+
 
 Interop::Interop(CanvasDevice^ device)
 {
@@ -35,15 +39,46 @@ Interop::Interop(CanvasDevice^ device)
 		&m_d2dContext);
 }
 
+IAsyncAction^ Interop::ListenForFontSetExpirationAsync()
+{
+	return create_async([this]
+		{
+			if (m_systemFontSet != nullptr)
+			{
+				auto handle = m_systemFontSet->GetExpirationEvent();
+				WaitForSingleObject(handle, INFINITE);
+
+				m_isFontSetStale = true;
+				FontSetInvalidated(this, nullptr);
+			}
+		});
+}
+
 DWriteFontSet^ Interop::GetSystemFonts()
 {
-	ComPtr<IDWriteFontSet2> fontSet;
-	ThrowIfFailed(m_dwriteFactory->GetSystemFontSet(true, &fontSet));
+	if (m_isFontSetStale)
+	{
+		m_systemFontSet = nullptr;
+		m_appFontSet = nullptr;
+	}
 
-	ComPtr<IDWriteFontSet3> fontSet3;
-	ThrowIfFailed(fontSet.As(&fontSet3));
+	if (m_systemFontSet == nullptr || m_appFontSet == nullptr)
+	{
+		ComPtr<IDWriteFontSet2> fontSet;
+		ThrowIfFailed(m_dwriteFactory->GetSystemFontSet(true, &fontSet));
 
-	return GetFonts(fontSet3);
+		ComPtr<IDWriteFontSet3> fontSet3;
+		ThrowIfFailed(fontSet.As(&fontSet3));
+		m_systemFontSet = fontSet3;
+		m_appFontSet = GetFonts(fontSet3);
+		m_isFontSetStale = false;
+
+		// We listen for the expiration event on a background thread
+		// with an infinite thread block, so don't await this.
+		ListenForFontSetExpirationAsync();
+	}
+
+	return m_appFontSet;
 }
 
 DWriteFontSet^ Interop::GetFonts(Uri^ uri)
@@ -379,4 +414,58 @@ bool Interop::HasValidFonts(Uri^ uri)
 	bool valid = fontset->Fonts->Size > 0;
 	delete fontset;
 	return valid;
+}
+
+IAsyncOperation<bool>^ Interop::WriteToFileAsync(CanvasFontFace^ fontFace, StorageFile^ storageFile)
+{
+	return create_async([fontFace, storageFile]
+		{
+			// 1. Acquire the underlying FontLoader used to create the CanvasFontFace
+			ComPtr<IDWriteFontFaceReference> fontFaceRef = GetWrappedResource<IDWriteFontFaceReference>(fontFace);
+
+			ComPtr<IDWriteFontFile> file;
+			if (fontFaceRef->GetFontFile(&file) != S_OK)
+				return task_from_result(false);
+
+			ComPtr<IDWriteFontFileLoader> loader;
+			if (file->GetLoader(&loader) != S_OK)
+				return task_from_result(false);
+
+			ComPtr<IDWriteLocalFontFileLoader> localLoader;
+			if (loader->QueryInterface<IDWriteLocalFontFileLoader>(&localLoader) == S_OK)
+			{
+				// 2. Get the font stream from the loader
+				ComPtr<IDWriteFontFileStream> fileStream;
+
+				const void* refKey = nullptr;
+				uint32 size = 0;
+				if (file->GetReferenceKey(&refKey, &size) == S_OK)
+				{
+					localLoader->CreateStreamFromKey(refKey, size, &fileStream);
+
+					void* context;
+					const void* fragment;
+
+					// 3. Read the source file into memory
+					fileStream->ReadFileFragment(&fragment, 0, fontFaceRef->GetFileSize(), &context);
+					auto b = (byte*)fragment;
+
+					// 4. Write the memory to file.
+					return create_task(storageFile->OpenAsync(FileAccessMode::ReadWrite)).then([storageFile, b, fontFaceRef](IRandomAccessStream^ stream)
+						{
+							stream->Size = 0;
+							DataWriter^ w = ref new DataWriter(stream->GetOutputStreamAt(0));
+							w->WriteBytes(Platform::ArrayReference<BYTE>(b, fontFaceRef->GetFileSize()));
+							
+							return create_task(w->StoreAsync()).then([](bool result)
+								{
+									return task_from_result(result);
+								}, task_continuation_context::use_arbitrary());
+
+						}, task_continuation_context::use_arbitrary());
+				}
+			}
+
+			return task_from_result(false);
+		});
 }

--- a/CharacterMap/CharacterMap.CX/Interop.h
+++ b/CharacterMap/CharacterMap.CX/Interop.h
@@ -11,6 +11,7 @@
 #include "DWriteFontFace.h"
 #include "DWriteFontSet.h"
 #include "PathData.h"
+#include "FontFileData.h"
 
 using namespace Microsoft::Graphics::Canvas;
 using namespace Microsoft::Graphics::Canvas::Text;
@@ -40,6 +41,7 @@ namespace CharacterMapCX
 		IVectorView<PathData^>^ GetPathDatas(CanvasFontFace^ fontFace, const Platform::Array<UINT16>^ glyphIndicies);
 		Platform::String^ GetPathData(CanvasFontFace^ fontFace, UINT16 glyphIndicie);
 		PathData^ GetPathData(CanvasGeometry^ geometry);
+		FontFileData^ GetFileBuffer(CanvasFontFace^ fontFace);
 
 		DWriteFontSet^ GetSystemFonts();
 		DWriteFontSet^ GetFonts(Uri^ uri);

--- a/CharacterMap/CharacterMap.CX/Interop.h
+++ b/CharacterMap/CharacterMap.CX/Interop.h
@@ -12,7 +12,6 @@
 #include "DWriteFontSet.h"
 #include "PathData.h"
 
-
 using namespace Microsoft::Graphics::Canvas;
 using namespace Microsoft::Graphics::Canvas::Text;
 using namespace Microsoft::Graphics::Canvas::Geometry;
@@ -33,6 +32,8 @@ namespace CharacterMapCX
 
         Interop(CanvasDevice^ device);
 		bool HasValidFonts(Uri^ uri);
+		
+		IAsyncOperation<bool>^ WriteToFileAsync(CanvasFontFace^ fontFace, Windows::Storage::StorageFile^ storageFile);
 		IBuffer^ GetImageDataBuffer(CanvasFontFace^ fontFace, UINT32 pixelsPerEm, UINT unicodeIndex, UINT imageType);
 		CanvasTextLayoutAnalysis^ AnalyzeFontLayout(CanvasTextLayout^ layout, CanvasFontFace^ fontFace);
 		CanvasTextLayoutAnalysis^ AnalyzeCharacterLayout(CanvasTextLayout^ layout);
@@ -48,6 +49,13 @@ namespace CharacterMapCX
 		__inline DWriteProperties^ GetDWriteProperties(ComPtr<IDWriteFontSet3> fontSet, UINT index, ComPtr<IDWriteFontFaceReference1> faceRef, int ls, wchar_t* locale);
 		__inline String^ GetLocaleString(ComPtr<IDWriteLocalizedStrings> strings, int ls, wchar_t* locale);
 		__inline DWriteProperties^ GetDWriteProperties(CanvasFontSet^ fontSet, UINT index);
+
+		IAsyncAction^ ListenForFontSetExpirationAsync();
+
+
+		bool m_isFontSetStale = true;
+		ComPtr<IDWriteFontSet3> m_systemFontSet;
+		DWriteFontSet^ m_appFontSet;
 
 		ComPtr<IDWriteFactory7> m_dwriteFactory;
 		ComPtr<ID2D1Factory5> m_d2dFactory;

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Core\AppSettings.cs" />
     <Compile Include="Core\ExceptionHandlingSynchronizationContext.cs" />
     <Compile Include="Helpers\CompositionExtensions.cs" />
+    <Compile Include="Helpers\Extensions.cs" />
     <Compile Include="Helpers\InAppNotificationHelper.cs" />
     <Compile Include="Helpers\PrintHelper.cs" />
     <Compile Include="Helpers\Unicode.cs" />

--- a/CharacterMap/CharacterMap/Helpers/Extensions.cs
+++ b/CharacterMap/CharacterMap/Helpers/Extensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Input;
+
+namespace CharacterMap.Helpers
+{
+    public static class Extensions
+    {
+        public static T AddKeyboardAccelerator<T>(this T u, VirtualKey key, VirtualKeyModifiers modifiers) where T : UIElement
+        {
+            u.KeyboardAccelerators.Add(new KeyboardAccelerator { Key = key, Modifiers = modifiers });
+            return u;
+        }
+    }
+}

--- a/CharacterMap/CharacterMap/Helpers/InAppNotificationHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/InAppNotificationHelper.cs
@@ -32,6 +32,14 @@ namespace CharacterMap.Helpers
                 var content = ResourceHelper.InflateDataTemplate("ExportNotificationTemplate", result);
                 ShowNotification(presenter, content, 5000);
             }
+            if (msg.Data is ExportFontFileResult fontExportResult)
+            {
+                if (!fontExportResult.Success)
+                    return;
+
+                var content = ResourceHelper.InflateDataTemplate("ExportFontNotificationTemplate", fontExportResult);
+                ShowNotification(presenter, content, 5000);
+            }
             else if (msg.Data is AddToCollectionResult added)
             {
                 if (!added.Success)

--- a/CharacterMap/CharacterMap/Helpers/ResourceHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/ResourceHelper.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.ApplicationModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
@@ -70,6 +71,11 @@ namespace CharacterMap.Helpers
 
         public static ElementTheme GetEffectiveTheme()
         {
+#if DEBUG
+            if (DesignMode.DesignMode2Enabled)
+                return ElementTheme.Default;
+#endif
+
             return AppSettings.UserRequestedTheme switch
             {
                 ElementTheme.Default => App.Current.RequestedTheme == ApplicationTheme.Dark ? ElementTheme.Dark : ElementTheme.Light,

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -472,8 +472,8 @@
           <target state="new">Open File</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="new">Open Folder</target>
+          <source>Show in Folder</source>
+          <target state="new">Show in Folder</target>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -972,6 +972,18 @@ Please consider posting details about this error to GitHub so we can help you fi
         <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
           <source>Collection Name</source>
           <target state="new">Collection Name</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -985,6 +985,22 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>{0} exported</source>
           <target state="new">{0} exported</target>
         </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -1001,6 +1001,10 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -472,8 +472,8 @@
           <target state="new">Open File</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="new">Open Folder</target>
+          <source>Show in Folder</source>
+          <target state="new">Show in Folder</target>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -972,6 +972,18 @@ Please consider posting details about this error to GitHub so we can help you fi
         <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
           <source>Collection Name</source>
           <target state="new">Collection Name</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -985,6 +985,22 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>{0} exported</source>
           <target state="new">{0} exported</target>
         </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -1001,6 +1001,10 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -472,8 +472,8 @@
           <target state="new">Open File</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="new">Open Folder</target>
+          <source>Show in Folder</source>
+          <target state="new">Show in Folder</target>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -972,6 +972,18 @@ Please consider posting details about this error to GitHub so we can help you fi
         <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
           <source>Collection Name</source>
           <target state="new">Collection Name</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -985,6 +985,22 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>{0} exported</source>
           <target state="new">{0} exported</target>
         </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -1001,6 +1001,10 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.it-IT.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.it-IT.xlf
@@ -475,8 +475,9 @@
           <target state="translated">Apri file</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="translated">Apri cartella</target>
+          <source>Show in Folder</source>
+          <target state="needs-review-translation">Apri cartella</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -971,6 +972,34 @@ Ti consigliamo di pubblicare i dettagli di questo errore su GitHub in modo che p
         <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
           <source>was added to</source>
           <target state="translated">è stato aggiunto a</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.it-IT.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.it-IT.xlf
@@ -1001,6 +1001,10 @@ Ti consigliamo di pubblicare i dettagli di questo errore su GitHub in modo che p
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -472,8 +472,8 @@
           <target state="new">Open File</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="new">Open Folder</target>
+          <source>Show in Folder</source>
+          <target state="new">Show in Folder</target>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -972,6 +972,18 @@ Please consider posting details about this error to GitHub so we can help you fi
         <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
           <source>Collection Name</source>
           <target state="new">Collection Name</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -985,6 +985,22 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>{0} exported</source>
           <target state="new">{0} exported</target>
         </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -1001,6 +1001,10 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -472,8 +472,8 @@
           <target state="new">Open File</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="new">Open Folder</target>
+          <source>Show in Folder</source>
+          <target state="new">Show in Folder</target>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -972,6 +972,18 @@ Please consider posting details about this error to GitHub so we can help you fi
         <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
           <source>Collection Name</source>
           <target state="new">Collection Name</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -985,6 +985,22 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>{0} exported</source>
           <target state="new">{0} exported</target>
         </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -1001,6 +1001,10 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -474,8 +474,9 @@
           <target state="translated">เปิดฟอนต์</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="translated">เปิดโฟล์เดอร์</target>
+          <source>Show in Folder</source>
+          <target state="needs-review-translation">เปิดโฟล์เดอร์</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -975,6 +976,18 @@ Please consider posting details about this error to GitHub so we can help you fi
         <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
           <source>Collection Name</source>
           <target state="new">Collection Name</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -1005,6 +1005,10 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -989,6 +989,22 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>{0} exported</source>
           <target state="new">{0} exported</target>
         </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -474,8 +474,9 @@
           <target state="translated">打开文件</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="translated">打开文件夹</target>
+          <source>Show in Folder</source>
+          <target state="needs-review-translation">打开文件夹</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -975,6 +976,18 @@ Please consider posting details about this error to GitHub so we can help you fi
         <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
           <source>Collection Name</source>
           <target state="new">Collection Name</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -1005,6 +1005,10 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -989,6 +989,22 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>{0} exported</source>
           <target state="new">{0} exported</target>
         </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -987,6 +987,22 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>{0} exported</source>
           <target state="new">{0} exported</target>
         </trans-unit>
+        <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Export Fonts</source>
+          <target state="new">Export Fonts</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
+          <source>To Folder</source>
+          <target state="new">To Folder</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="new">Export</target>
+        </trans-unit>
+        <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
+          <source>As Zip Archive</source>
+          <target state="new">As Zip Archive</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -474,8 +474,8 @@
           <target state="new">Open File</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
-          <source>Open Folder</source>
-          <target state="new">Open Folder</target>
+          <source>Show in Folder</source>
+          <target state="new">Show in Folder</target>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane</source>
@@ -974,6 +974,18 @@ Please consider posting details about this error to GitHub so we can help you fi
         <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
           <source>Collection Name</source>
           <target state="new">Collection Name</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
+          <source>Font File</source>
+          <target state="new">Font File</target>
+        </trans-unit>
+        <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
+          <source>Save Font File As</source>
+          <target state="new">Save Font File As</target>
+        </trans-unit>
+        <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
+          <source>{0} exported</source>
+          <target state="new">{0} exported</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -1003,6 +1003,10 @@ Please consider posting details about this error to GitHub so we can help you fi
           <source>As Zip Archive</source>
           <target state="new">As Zip Archive</target>
         </trans-unit>
+        <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
+          <source>Font listings are out of date. Click to reload.</source>
+          <target state="new">Font listings are out of date. Click to reload.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -858,4 +858,7 @@ Please consider posting details about this error to GitHub so we can help you fi
   <data name="CollectionExportZip.Text" xml:space="preserve">
     <value>As Zip Archive</value>
   </data>
+  <data name="SystemFontsExpiredMessage.Text" xml:space="preserve">
+    <value>Font listings are out of date. Click to reload.</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -469,7 +469,7 @@
     <value>Open File</value>
   </data>
   <data name="BtnOpenFolder.Content" xml:space="preserve">
-    <value>Open Folder</value>
+    <value>Show in Folder</value>
   </data>
   <data name="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Hide font pane</value>
@@ -834,7 +834,16 @@ Please consider posting details about this error to GitHub so we can help you fi
   <data name="NotificationFontRemovedBody.Text" xml:space="preserve">
     <value>was removed from</value>
   </data>
-   <data name="NotificationFontAddedBody.Text" xml:space="preserve">
+  <data name="NotificationFontAddedBody.Text" xml:space="preserve">
     <value>was added to</value>
+  </data>
+  <data name="ExportFontFile.Text" xml:space="preserve">
+    <value>Font File</value>
+  </data>
+  <data name="ExportFontFileLabel.Text" xml:space="preserve">
+    <value>Save Font File As</value>
+  </data>
+  <data name="FontExportedMessage" xml:space="preserve">
+    <value>{0} exported</value>
   </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -846,4 +846,16 @@ Please consider posting details about this error to GitHub so we can help you fi
   <data name="FontExportedMessage" xml:space="preserve">
     <value>{0} exported</value>
   </data>
+  <data name="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Export Fonts</value>
+  </data>
+  <data name="CollectionExportFolder.Text" xml:space="preserve">
+    <value>To Folder</value>
+  </data>
+  <data name="CollectionExportHeader.Text" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="CollectionExportZip.Text" xml:space="preserve">
+    <value>As Zip Archive</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml
+++ b/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml
@@ -98,6 +98,29 @@
         </Grid>
     </DataTemplate>
 
+    <DataTemplate x:Key="ExportFontNotificationTemplate" x:DataType="core:ExportFontFileResult">
+        <Grid ColumnSpacing="12" HorizontalAlignment="Stretch">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock
+                VerticalAlignment="Center"
+                FontSize="16"
+                IsColorFontEnabled="True"
+                Text="{x:Bind GetMessage()}"
+                TextWrapping="Wrap" />
+
+            <Button
+                x:Uid="BtnOpenFolder"
+                Grid.Column="1"
+                Click="OpenFolderButton_Click"
+                Style="{StaticResource ButtonRevealStyle}" />
+
+        </Grid>
+    </DataTemplate>
+
     <DataTemplate x:Key="AddedToCollectionNotificationTemplate" x:DataType="services:AddToCollectionResult">
         <Grid ColumnSpacing="12" HorizontalAlignment="Stretch">
             <Grid.ColumnDefinitions>

--- a/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml.cs
+++ b/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml.cs
@@ -38,11 +38,20 @@ namespace CharacterMap.Styles
             if (sender is Button b && b.DataContext is ExportResult result)
             {
                 _ = Launcher.LaunchFolderPathAsync(
-                    Path.GetDirectoryName(result.File.Path), 
-                    new FolderLauncherOptions
-                    {
-                        ItemsToSelect = { result.File }
-                    });
+                        Path.GetDirectoryName(result.File.Path), 
+                        new FolderLauncherOptions
+                        {
+                            ItemsToSelect = { result.File }
+                        });
+            }
+            else if (sender is Button bb && bb.DataContext is ExportFontFileResult fresult)
+            {
+                _ = Launcher.LaunchFolderPathAsync(
+                        Path.GetDirectoryName(fresult.File.Path),
+                        new FolderLauncherOptions
+                        {
+                            ItemsToSelect = { fresult.File }
+                        });
             }
         }
 
@@ -89,6 +98,8 @@ namespace CharacterMap.Styles
                 FlyoutHelper.CreateMenu(
                     menu,
                     font,
+                    null,
+                    null,
                     false);
             }
         }

--- a/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml.cs
+++ b/CharacterMap/CharacterMap/Styles/ItemTemplates.xaml.cs
@@ -46,12 +46,20 @@ namespace CharacterMap.Styles
             }
             else if (sender is Button bb && bb.DataContext is ExportFontFileResult fresult)
             {
-                _ = Launcher.LaunchFolderPathAsync(
+                if (fresult.File != null)
+                {
+                    _ = Launcher.LaunchFolderPathAsync(
                         Path.GetDirectoryName(fresult.File.Path),
                         new FolderLauncherOptions
                         {
                             ItemsToSelect = { fresult.File }
                         });
+                }
+                else if (fresult.Folder != null)
+                {
+                    _ = Launcher.LaunchFolderAsync(fresult.Folder);
+                }
+                
             }
         }
 

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -99,6 +99,13 @@ namespace CharacterMap.ViewModels
             set => Set(ref _isFontSetExpired, value);
         }
 
+        private bool _isCollectionExportEnabled = true;
+        public bool IsCollectionExportEnabled
+        {
+            get => _isCollectionExportEnabled;
+            set => Set(ref _isCollectionExportEnabled, value);
+        }
+
         private List<InstalledFont> _fontList;
         public List<InstalledFont> FontList
         {
@@ -379,6 +386,34 @@ namespace CharacterMap.ViewModels
                  * We'll get em next time the app launches! */
                 MessengerInstance.Send(
                     new AppNotificationMessage(true, Localization.Get("FontsClearedOnNextLaunchNotice"), 6000));
+            }
+        }
+
+        internal async void ExportAsZip()
+        {
+            IsCollectionExportEnabled = false;
+
+            try
+            {
+                await ExportManager.ExportCollectionAsZipAsync(FontList, SelectedCollection);
+            }
+            finally
+            {
+                IsCollectionExportEnabled = true;
+            }
+        }
+
+        internal async void ExportAsFolder()
+        {
+            IsCollectionExportEnabled = false;
+
+            try
+            {
+                await ExportManager.ExportCollectionToFolderAsync(FontList, SelectedCollection);
+            }
+            finally
+            {
+                IsCollectionExportEnabled = true;
             }
         }
     }

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -596,11 +596,13 @@
                         Loaded="{x:Bind helpers:Composition.SetStandardReposition}">
                         <TextBlock
                             FontSize="12"
+                            IsTextSelectionEnabled="True"
                             Text="{x:Bind ViewModel.GetCharName(ViewModel.SelectedChar), Mode=OneWay}"
                             TextWrapping="Wrap" />
                         <TextBlock
                             FontSize="12"
                             Foreground="{ThemeResource TextControlPlaceholderForeground}"
+                            IsTextSelectionEnabled="True"
                             Text="{x:Bind ViewModel.GetCharDescription(ViewModel.SelectedChar), Mode=OneWay}"
                             TextWrapping="Wrap" />
                     </StackPanel>
@@ -980,10 +982,14 @@
             x:DeferLoadStrategy="Lazy"
             Grid.RowSpan="10"
             Grid.ColumnSpan="10"
+            d:IsHidden="True"
             Canvas.ZIndex="100" />
 
         <!--  Off-screen printer render container  -->
-        <Canvas x:Name="PrintCanvas" Margin="-10000, -10000, 0, 0" />
+        <Canvas
+            x:Name="PrintCanvas"
+            Margin="-10000, -10000, 0, 0"
+            d:IsHidden="True" />
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LoadingStates">

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -30,6 +30,7 @@ using System.ComponentModel;
 using Windows.UI.Core;
 using CharacterMap.Annotations;
 using CharacterMap.Controls;
+using CharacterMapCX;
 
 namespace CharacterMap.Views
 {
@@ -251,6 +252,27 @@ namespace CharacterMap.Views
             });
         }
 
+        private void LayoutRoot_KeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            var ctrlState = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control);
+            if ((ctrlState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down)
+            {
+                switch (e.Key)
+                {
+                    case VirtualKey.C:
+                        TryCopy();
+                        break;
+                    case VirtualKey.P:
+                        Messenger.Default.Send(new PrintRequestedMessage());
+                        break;
+                    case VirtualKey.S:
+                        if (ViewModel.SelectedVariant is FontVariant v && ViewModel.SelectedVariantAnalysis is CanvasTextLayoutAnalysis a)
+                            ExportManager.RequestExportFontFile(v, a);
+                        break;
+                }
+            }
+        }
+
         private void UpdateCharacterFit()
         {
             if (ViewModel.Settings.FitCharacter)
@@ -279,23 +301,6 @@ namespace CharacterMap.Views
                   this,
                   ViewModel.Settings.UseInstantSearch ? nameof(InstantSearchState) : nameof(ManualSearchState),
                   true);
-            }
-        }
-
-        private void LayoutRoot_KeyDown(object sender, KeyRoutedEventArgs e)
-        {
-            var ctrlState = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control);
-            if ((ctrlState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down)
-            {
-                switch (e.Key)
-                {
-                    case VirtualKey.C:
-                        TryCopy();
-                        break;
-                    case VirtualKey.P:
-                        Messenger.Default.Send(new PrintRequestedMessage());
-                        break;
-                }
             }
         }
 
@@ -512,6 +517,8 @@ namespace CharacterMap.Views
                 FlyoutHelper.CreateMenu(
                     menu,
                     font,
+                    ViewModel.SelectedVariant,
+                    ViewModel.SelectedVariantAnalysis,
                     IsStandalone,
                     true);
             }

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -91,11 +91,11 @@
                             Height="{StaticResource TitleRowHeight}"
                             VerticalAlignment="Bottom"
                             Click="{x:Bind OpenFont}">
+
                             <Path
                                 Height="16"
                                 Data="M896,320L1012,320L788,768L0,768L0,128L338.5,128L466.5,0L896,0ZM64,192L64,632.5L220.5,320L832,320L832,64L493.5,64L365.5,192ZM748,704L908,384L260,384L99.5,704Z"
                                 Fill="{ThemeResource ApplicationForegroundThemeBrush}"
-                                Opacity="0.8"
                                 Stretch="Uniform" />
                         </AppBarButton>
 
@@ -249,6 +249,36 @@
                                     Click="DeleteCollection_Click"
                                     Icon="Delete"
                                     ToolTipService.Placement="Bottom" />
+                                <AppBarButton
+                                    x:Uid="CollectionExportButton"
+                                    Height="48"
+                                    IsEnabled="{x:Bind ViewModel.IsCollectionExportEnabled, Mode=OneWay}">
+                                    <AppBarButton.Flyout>
+                                        <MenuFlyout Placement="Bottom">
+                                            <MenuFlyoutItem x:Uid="CollectionExportHeader" Style="{StaticResource MenuFlyoutItemReadOnlyHeaderStyle}" />
+                                            <MenuFlyoutItem x:Uid="CollectionExportFolder" Click="{x:Bind ViewModel.ExportAsFolder}" />
+                                            <MenuFlyoutItem x:Uid="CollectionExportZip" Click="{x:Bind ViewModel.ExportAsZip}" />
+                                        </MenuFlyout>
+                                    </AppBarButton.Flyout>
+                                    <Grid>
+                                        <ProgressRing
+                                            Width="20"
+                                            Height="20"
+                                            MinWidth="20"
+                                            MinHeight="20"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            IsActive="{x:Bind core:Converters.False(ViewModel.IsCollectionExportEnabled), Mode=OneWay}"
+                                            Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.IsCollectionExportEnabled), Mode=OneWay}" />
+                                        <Path
+                                            Height="16"
+                                            Data="F1 M 38.613281 -43.886719 L 47.167969 -52.500000 L 0.000000 -52.500000 L 0.000000 -60.000000 L 47.167969 -60.000000 L 38.613281 -68.613281 L 43.886719 -73.886719 L 61.523438 -56.250000 L 43.886719 -38.613281 Z M 62.167969 -112.500000 L 120.000000 -112.500000 L 120.000000 -22.500000 L 0.000000 -22.500000 L 0.000000 -45.000000 L 7.500000 -45.000000 L 7.500000 -30.000000 L 112.500000 -30.000000 L 112.500000 -75.000000 L 62.167969 -75.000000 L 47.167969 -90.000000 L 7.500000 -90.000000 L 7.500000 -67.500000 L 0.000000 -67.500000 L 0.000000 -97.500000 L 47.167969 -97.500000 Z M 112.500000 -82.500000 L 112.500000 -105.000000 L 65.332031 -105.000000 L 54.023438 -93.750000 L 65.332031 -82.500000 Z "
+                                            Fill="{ThemeResource ButtonForegroundThemeBrush}"
+                                            Stretch="Uniform"
+                                            Visibility="{x:Bind ViewModel.IsCollectionExportEnabled, Mode=OneWay}" />
+                                    </Grid>
+
+                                </AppBarButton>
                             </StackPanel>
                         </Grid>
 
@@ -259,7 +289,10 @@
                             Visibility="{x:Bind ViewModel.IsFontSetExpired, Mode=OneWay, FallbackValue=Collapsed}">
                             <Border Background="{StaticResource SystemControlAccentDark1AcrylicElementAccentDark1Brush}" />
 
-                            <Grid ColumnSpacing="12" Margin="12 4 4 4" RequestedTheme="Dark">
+                            <Grid
+                                ColumnSpacing="12"
+                                Margin="12 4 4 4"
+                                RequestedTheme="Dark">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
@@ -274,8 +307,8 @@
 
                                 <AppBarButton
                                     Grid.Column="1"
-                                    VerticalAlignment="Center"
                                     Height="50"
+                                    VerticalAlignment="Center"
                                     Click="{x:Bind ViewModel.ReloadFontSet}"
                                     Icon="Refresh"
                                     ToolTipService.Placement="Bottom" />

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -228,7 +228,7 @@
                         <!--  User Collection Control Panel  -->
                         <Grid
                             x:Name="CollectionControlRow"
-                            Grid.Row="1"
+                            Grid.Row="0"
                             Visibility="{x:Bind core:Converters.IsNotNullToVis(ViewModel.SelectedCollection), Mode=OneWay, FallbackValue=Collapsed}">
                             <Border x:Name="CollectionControlBackground" Background="{ThemeResource DefaultAcrylicBrush}" />
                             <StackPanel
@@ -252,10 +252,44 @@
                             </StackPanel>
                         </Grid>
 
+                        <!--  Font List Refresh Grid  -->
+                        <Grid
+                            x:Name="CollectionRefreshRow"
+                            Grid.Row="1"
+                            Visibility="{x:Bind ViewModel.IsFontSetExpired, Mode=OneWay, FallbackValue=Collapsed}">
+                            <Border Background="{StaticResource SystemControlAccentDark1AcrylicElementAccentDark1Brush}" />
+
+                            <Grid ColumnSpacing="12" Margin="12 4 4 4" RequestedTheme="Dark">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock
+                                    Margin="0 -2 0 0"
+                                    VerticalAlignment="Center"
+                                    FontSize="13.333"
+                                    Text="Font listings are out of date. Click to reload."
+                                    TextWrapping="Wrap" />
+
+                                <AppBarButton
+                                    Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Height="50"
+                                    Click="{x:Bind ViewModel.ReloadFontSet}"
+                                    Icon="Refresh"
+                                    ToolTipService.Placement="Bottom" />
+
+                            </Grid>
+
+
+
+                        </Grid>
+
                         <TextBlock
                             x:Name="ImportFontHelpBlock"
                             x:Uid="ImportFontHelpBlock"
-                            Grid.Row="2"
+                            Grid.Row="1"
                             Margin="12"
                             FontSize="13"
                             Opacity="0.7"
@@ -348,6 +382,7 @@
                         </SemanticZoom>
                     </Grid>
 
+                    <!--  Pane Footer  -->
                     <Grid
                         Grid.Row="3"
                         Height="32"

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -299,10 +299,10 @@
                                 </Grid.ColumnDefinitions>
 
                                 <TextBlock
+                                    x:Uid="SystemFontsExpiredMessage"
                                     Margin="0 -2 0 0"
                                     VerticalAlignment="Center"
                                     FontSize="13.333"
-                                    Text="Font listings are out of date. Click to reload."
                                     TextWrapping="Wrap" />
 
                                 <AppBarButton

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -585,5 +585,6 @@ namespace CharacterMap.Views
 
             sender.SetHideAnimation(v.Compositor.CreateAnimationGroup(ani, op));
         }
+
     }
 }

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -26,7 +26,7 @@ using CharacterMap.Models;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Windows.UI.ViewManagement;
 using Windows.UI.Core.AnimationMetrics;
-
+using CharacterMapCX;
 
 namespace CharacterMap.Views
 {
@@ -248,6 +248,10 @@ namespace CharacterMap.Views
                     case VirtualKey.C:
                         FontMap.TryCopy();
                         break;
+                    case VirtualKey.S:
+                        if (FontMap.ViewModel.SelectedVariant is FontVariant v && FontMap.ViewModel.SelectedVariantAnalysis is CanvasTextLayoutAnalysis a)
+                            ExportManager.RequestExportFontFile(v, a);
+                            break;
                     case VirtualKey.N:
                         if (ViewModel.SelectedFont is InstalledFont fnt)
                             _ = FontMapView.CreateNewViewForFontAsync(fnt);


### PR DESCRIPTION
## New features:

- Ability to save / export nearly all font files (system & imported) to files from Character Map view, by clicking the More / "..." button, and choose "Save Font File As"
![image](https://user-images.githubusercontent.com/2319473/79577494-b3fb0180-80bc-11ea-8af0-3a35400d5156.png)

- Notification banner is now presented to reload the font list whenever a change is made to the system font collection (like a user uninstalls or installs a font to Windows outside the app)
![image](https://user-images.githubusercontent.com/2319473/79577684-fb818d80-80bc-11ea-94ce-1b5894456611.png)

- You can now export all the fonts inside a collection to either a folder, or to a zip file.
![image](https://user-images.githubusercontent.com/2319473/79577429-9f1e6e00-80bc-11ea-9a2a-37c58d5958c3.png)


Also added a little placeholder for #98 , in that you can direct copy the unicode from the UI for now.
![image](https://user-images.githubusercontent.com/2319473/79576725-a4c78400-80bb-11ea-8a62-acb3ccb65143.png)
